### PR TITLE
Fix NRE caused by checking zero-sized arrays in InlineData attributes

### DIFF
--- a/src/xunit.analyzers/InlineDataMustMatchTheoryParameters.cs
+++ b/src/xunit.analyzers/InlineDataMustMatchTheoryParameters.cs
@@ -11,6 +11,8 @@ namespace Xunit.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class InlineDataMustMatchTheoryParameters : DiagnosticAnalyzer
     {
+        private static readonly IList<ExpressionSyntax> EmptyExpressionList = new ExpressionSyntax[0];
+
         internal static readonly string ParameterIndex = "ParameterIndex";
         internal static readonly string ParameterName = "ParameterName";
         internal static readonly string ParameterArrayStyle = "ParameterArrayStyle";
@@ -198,7 +200,7 @@ namespace Xunit.Analyzers
             }
         }
 
-        static List<ExpressionSyntax> GetParameterExpressionsFromArrayArgument(AttributeSyntax attribute)
+        static IList<ExpressionSyntax> GetParameterExpressionsFromArrayArgument(AttributeSyntax attribute)
         {
             if (attribute.ArgumentList.Arguments.Count != 1)
                 return null;
@@ -216,6 +218,12 @@ namespace Xunit.Analyzers
                 default:
                     return null;
             }
+
+            if (initializer == null)
+            {
+                return EmptyExpressionList;
+            }
+
             return initializer.Expressions.ToList();
         }
 

--- a/test/xunit.analyzers.tests/CodeAnalyzerHelper.cs
+++ b/test/xunit.analyzers.tests/CodeAnalyzerHelper.cs
@@ -78,8 +78,17 @@ namespace Xunit.Analyzers
                 Diagnostic error = compilationDiagnostics.First();
                 throw new InvalidOperationException($"Compilation has errors. First error: {error.Id} {error.WarningLevel} {error.GetMessage()}");
             }
-            var results = await compilation.WithOptions(((CSharpCompilationOptions)compilation.Options).WithWarningLevel(4)).WithAnalyzers(ImmutableArray.Create(analyzer)).GetAnalyzerDiagnosticsAsync();
-            return results;
+
+            var compilationWithAnalyzers = compilation
+                .WithOptions(((CSharpCompilationOptions)compilation.Options)
+                .WithWarningLevel(4))
+                .WithAnalyzers(ImmutableArray.Create(analyzer));
+
+            var allDiagnostics = await compilationWithAnalyzers.GetAllDiagnosticsAsync();
+
+            Assert.DoesNotContain(allDiagnostics, d => d.Id == "AD0001");
+
+            return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
         }
     }
 }

--- a/test/xunit.analyzers.tests/InlineDataMustMatchTheoryParametersTests.cs
+++ b/test/xunit.analyzers.tests/InlineDataMustMatchTheoryParametersTests.cs
@@ -154,6 +154,18 @@ namespace Xunit.Analyzers
 
                     Assert.Empty(diagnostics);
                 }
+
+                [Fact]
+                public async void DoesNotFindError_EmptyArray()
+                {
+                    var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
+                        "public class TestClass {" +
+                        "   [Xunit.Theory, Xunit.InlineData(new byte[0])]" +
+                        "   public void TestMethod(byte[] input) { }" +
+                        "}");
+
+                    Assert.Empty(diagnostics);
+                }
             }
 
             public class ForAttributeWithTooFewArguments : Analyzer


### PR DESCRIPTION
This fixes a bug in InlineDataMustMatchTheoryParameters which caused a NRE when checking 
```c#
[InlineData(new byte[0])]
```

The tests didn't catch this because `CompilationWithAnalyzers.GetAnalyzerDiagnosticsAsync` does not include `AD0001` which is produced when the analyzer fails (i.e. with NullReferenceException). I've changed the test helper to call `GetAllDiagnosticsAsync` instead.

cc @marcind 