### PR TITLE
xUnit1025 bug fix: issues with default parameters producing nulls for tes…

### DIFF
--- a/src/xunit.analyzers/InlineDataShouldBeUniqueWithinTheory.cs
+++ b/src/xunit.analyzers/InlineDataShouldBeUniqueWithinTheory.cs
@@ -153,7 +153,7 @@ namespace Xunit.Analyzers
                                         return false;
                                     break;
                                 case IParameterSymbol yMethodParamDefault:
-                                    if (!xArgPrimitive.Value.Equals(yMethodParamDefault.ExplicitDefaultValue))
+                                    if (xArgPrimitive.Value != yMethodParamDefault.ExplicitDefaultValue)
                                         return false;
                                     break;
                                 default:
@@ -164,11 +164,11 @@ namespace Xunit.Analyzers
                             switch (y)
                             {
                                 case TypedConstant yArgPrimitive when yArgPrimitive.Kind != TypedConstantKind.Array:
-                                    if (!xMethodParamDefault.ExplicitDefaultValue.Equals(yArgPrimitive.Value))
+                                    if (xMethodParamDefault.ExplicitDefaultValue != yArgPrimitive.Value)
                                         return false;
                                     break;
                                 case IParameterSymbol yMethodParamDefault:
-                                    if (!xMethodParamDefault.ExplicitDefaultValue.Equals(yMethodParamDefault.ExplicitDefaultValue))
+                                    if (xMethodParamDefault.ExplicitDefaultValue != yMethodParamDefault.ExplicitDefaultValue)
                                         return false;
                                     break;
                                 default:

--- a/src/xunit.analyzers/InlineDataShouldBeUniqueWithinTheoryFixer.cs
+++ b/src/xunit.analyzers/InlineDataShouldBeUniqueWithinTheoryFixer.cs
@@ -14,6 +14,8 @@ namespace Xunit.Analyzers
     [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
     public class InlineDataShouldBeUniqueWithinTheoryFixer : CodeFixProvider
     {
+        private const string Title = "Remove InlineData duplicate";
+
         public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
             Descriptors.X1025_InlineDataShouldBeUniqueWithinTheory.Id
         );
@@ -32,8 +34,9 @@ namespace Xunit.Analyzers
             Debug.Assert(attributeDuplicate != null);
 
             var codeAction = CodeAction.Create(
-                "Remove InlineData duplicate",
-                ct => RemoveInlineDataDuplicate(context.Document, attributeDuplicate, ct));
+                Title,
+                ct => RemoveInlineDataDuplicate(context.Document, attributeDuplicate, ct),
+                equivalenceKey: Title);
 
             context.RegisterCodeFix(codeAction, context.Diagnostics);
         }

--- a/test/xunit.analyzers.tests/InlineDataShouldBeUniqueWithinTheoryTests.cs
+++ b/test/xunit.analyzers.tests/InlineDataShouldBeUniqueWithinTheoryTests.cs
@@ -280,6 +280,46 @@ namespace Xunit.Analyzers
                     Assert.Collection(diagnostics, VerifyDiagnostic);
                 }
 
+                [Theory]
+                [InlineData("", "")]
+                [InlineData("", ", null")]
+                [InlineData(", null", "")]
+                [InlineData(", null", ", null")]
+                public async void FindsError_WhenDuplicateContainsDefaultOfStruct(string firstDefaultOverride, 
+                    string secondDefaultOverride)
+                {
+                    var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
+                        "public class TestClass" +
+                        "{" +
+                        "   [Xunit.Theory]" +
+                        $"   [Xunit.InlineData(1 {firstDefaultOverride})]" +
+                        $"   [Xunit.InlineData(1 {secondDefaultOverride})]" +
+                        "   public void TestMethod(int x, System.DateTime date = default(System.DateTime)) { }" +
+                        "}");
+
+                    Assert.Collection(diagnostics, VerifyDiagnostic);
+                }
+
+                [Theory]
+                [InlineData("", "")]
+                [InlineData("", ", null")]
+                [InlineData(", null", "")]
+                [InlineData(", null", ", null")]
+                public async void FindsError_WhenDuplicateContainsDefaultOfString(string firstDefaultOverride,
+                    string secondDefaultOverride)
+                {
+                    var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
+                        "public class TestClass" +
+                        "{" +
+                        "   [Xunit.Theory]" +
+                        $"   [Xunit.InlineData(1 {firstDefaultOverride})]" +
+                        $"   [Xunit.InlineData(1 {secondDefaultOverride})]" +
+                        "   public void TestMethod(int x, string y = null) { }" +
+                        "}");
+
+                    Assert.Collection(diagnostics, VerifyDiagnostic);
+                }
+
                 [Fact]
                 public async void FindsError_WhenInlineDataDuplicateAndOriginalAreItemsOfDistinctAttributesLists()
                 {


### PR DESCRIPTION
…t method arguments.

Mere != operator is enough when it comes to default values and values that can be provided with attribute parameter values. It also handles nulls well which solves the bug under question.
It also addresses warning RS1010 - explicit equivalence key of the fixer has been provided.

Fixes https://github.com/xunit/xunit/issues/1327