### PR TITLE
Add analyzer to rewrite collection size checks that use Assert.Equal/NotEqual

### DIFF
--- a/src/xunit.analyzers/AssertEqualShouldNotBeUsedForCollectionSizeCheck.cs
+++ b/src/xunit.analyzers/AssertEqualShouldNotBeUsedForCollectionSizeCheck.cs
@@ -1,0 +1,99 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Xunit.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class AssertEqualShouldNotBeUsedForCollectionSizeCheck : AssertUsageAnalyzerBase
+    {
+        internal static string MethodName = "MethodName";
+        internal static string SizeValue = "SizeValue";
+
+        private static readonly HashSet<string> EqualMethods = new HashSet<string>(new[] { "Equal", "NotEqual" });
+
+        private static readonly HashSet<string> SizeMethods = new HashSet<string>
+        {
+            "System.Array.Length",
+            "System.Collections.Generic.IEnumerable<TSource>.Count<TSource>()"
+        };
+
+        public AssertEqualShouldNotBeUsedForCollectionSizeCheck() :
+            base(Descriptors.X2013_AssertEqualShouldNotBeUsedForCollectionSizeCheck, EqualMethods)
+        {
+        }
+
+        protected override void Analyze(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocation, IMethodSymbol method)
+        {
+            if (method.Parameters.Length != 2 || 
+                !method.Parameters[0].Type.SpecialType.Equals(SpecialType.System_Int32) ||
+                !method.Parameters[1].Type.SpecialType.Equals(SpecialType.System_Int32))
+                return;
+
+            var size = context.SemanticModel.GetConstantValue(invocation.ArgumentList.Arguments[0].Expression, context.CancellationToken);
+            
+            if (!size.HasValue || (int)size.Value < 0 || (int)size.Value > 1 || (int)size.Value == 1 && method.Name != "Equal")
+                return;
+
+            var expression =
+                (ExpressionSyntax)(invocation.ArgumentList.Arguments[1].Expression as InvocationExpressionSyntax) ??
+                (ExpressionSyntax)(invocation.ArgumentList.Arguments[1].Expression as MemberAccessExpressionSyntax);
+
+            if (expression == null)
+                return;
+
+            var symbolInfo = context.SemanticModel.GetSymbolInfo(expression, context.CancellationToken);
+
+            if (!IsWellKnownSizeMethod(symbolInfo) && 
+                !IsCollectionCountProperty(context, symbolInfo) &&
+                !IsGenericCountProperty(context, symbolInfo))
+                return;
+
+            var builder = ImmutableDictionary.CreateBuilder<string, string>();
+            builder[MethodName] = method.Name;
+            builder[SizeValue] = size.Value.ToString();
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                Descriptors.X2013_AssertEqualShouldNotBeUsedForCollectionSizeCheck,
+                invocation.GetLocation(),
+                builder.ToImmutable(),
+                SymbolDisplay.ToDisplayString(method, SymbolDisplayFormat.CSharpShortErrorMessageFormat.WithParameterOptions(SymbolDisplayParameterOptions.None).WithGenericsOptions(SymbolDisplayGenericsOptions.None))));
+        }
+
+        private static bool IsWellKnownSizeMethod(SymbolInfo symbolInfo)
+        {
+            return SizeMethods.Contains(SymbolDisplay.ToDisplayString(symbolInfo.Symbol.OriginalDefinition));
+        }
+
+        private static bool IsCollectionCountProperty(SyntaxNodeAnalysisContext context, SymbolInfo symbolInfo)
+        {
+            var collectionCountSymbol = context.SemanticModel.Compilation
+                .GetTypeByMetadataName(typeof(ICollection).FullName)
+                .GetMembers(nameof(ICollection.Count))
+                .Single();
+
+            var collectionSymbolImplementation = symbolInfo.Symbol.ContainingType.FindImplementationForInterfaceMember(collectionCountSymbol);
+            return collectionSymbolImplementation != null && collectionSymbolImplementation.Equals(symbolInfo.Symbol);
+        }
+
+        private static bool IsGenericCountProperty(SyntaxNodeAnalysisContext context, SymbolInfo symbolInfo)
+        {
+            if (symbolInfo.Symbol.ContainingType.TypeArguments.IsEmpty)
+                return false;
+
+            var genericCollectionCountSymbol = context.SemanticModel.Compilation
+                .GetSpecialType(SpecialType.System_Collections_Generic_ICollection_T)
+                .Construct(symbolInfo.Symbol.ContainingType.TypeArguments.ToArray())
+                .GetMembers(nameof(ICollection<int>.Count))
+                .Single();
+
+            var genericCollectionSymbolImplementation = symbolInfo.Symbol.ContainingType.FindImplementationForInterfaceMember(genericCollectionCountSymbol);
+            return genericCollectionSymbolImplementation != null && genericCollectionSymbolImplementation.Equals(symbolInfo.Symbol);
+        }
+    }
+}

--- a/src/xunit.analyzers/AssertEqualShouldNotBeUsedForCollectionSizeCheckFixer.cs
+++ b/src/xunit.analyzers/AssertEqualShouldNotBeUsedForCollectionSizeCheckFixer.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace Xunit.Analyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+    public class AssertEqualShouldNotBeUsedForCollectionSizeCheckFixer : CodeFixProvider
+    {
+        const string TitleTemplate = "Use Assert.{0}";
+
+        public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(Descriptors.X2013_AssertEqualShouldNotBeUsedForCollectionSizeCheck.Id);
+
+        public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var invocation = root.FindNode(context.Span).FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            var methodName = context.Diagnostics.First().Properties[AssertEqualShouldNotBeUsedForCollectionSizeCheck.MethodName];
+            var sizeValue = context.Diagnostics.First().Properties[AssertEqualShouldNotBeUsedForCollectionSizeCheck.SizeValue];
+            var replacement = GetReplacementMethodName(methodName, sizeValue);
+            
+            var title = string.Format(TitleTemplate, replacement);
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title,
+                    createChangedDocument: ct => UseCollectionSizeAssertionAsync(context.Document, invocation, replacement, ct),
+                    equivalenceKey: title),
+                context.Diagnostics);
+        }
+
+        private static string GetReplacementMethodName(string methodName, string literalValue)
+        {
+            if (literalValue == "1")
+                return "Single";
+            
+            return methodName == "Equal" ? "Empty" : "NotEmpty";
+        }
+
+        private static async Task<Document> UseCollectionSizeAssertionAsync(Document document, InvocationExpressionSyntax invocation, string replacementMethod, CancellationToken cancellationToken)
+        {
+            var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+            var memberAccess = (MemberAccessExpressionSyntax)invocation.Expression;
+            var expression = GetExpressionSyntax(invocation);
+
+            editor.ReplaceNode(invocation,
+                invocation.WithArgumentList(invocation.ArgumentList.WithArguments(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Argument(expression))))
+                    .WithExpression(memberAccess.WithName(SyntaxFactory.IdentifierName(replacementMethod))));
+            return editor.GetChangedDocument();
+        }
+
+        private static ExpressionSyntax GetExpressionSyntax(InvocationExpressionSyntax invocation)
+        {
+            var sizeInvocation = invocation.ArgumentList.Arguments[1].Expression as InvocationExpressionSyntax;
+            if (sizeInvocation != null)
+                return ((MemberAccessExpressionSyntax)sizeInvocation.Expression).Expression;
+
+            var sizeMemberAccess = invocation.ArgumentList.Arguments[1].Expression as MemberAccessExpressionSyntax;
+            return sizeMemberAccess?.Expression;
+        }
+    }
+}

--- a/src/xunit.analyzers/Descriptors.cs
+++ b/src/xunit.analyzers/Descriptors.cs
@@ -214,5 +214,10 @@ namespace Xunit.Analyzers
             "Do not use Enumerable.Any() to check if a value exists in a collection",
             "Do not use Enumerable.Any() to check if a value exists in a collection.",
             Categories.Assertions, DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+        internal static DiagnosticDescriptor X2013_AssertEqualShouldNotBeUsedForCollectionSizeCheck { get; } = new DiagnosticDescriptor("xUnit2013",
+            "Do not use equality check to check for collection size.",
+            "Do not use {0} to check for collection size.",
+            Categories.Assertions, DiagnosticSeverity.Warning, isEnabledByDefault: true);
     }
 }

--- a/test/xunit.analyzers.tests/AssertEqualShouldNotBeUsedForCollectionSizeCheckTests.cs
+++ b/test/xunit.analyzers.tests/AssertEqualShouldNotBeUsedForCollectionSizeCheckTests.cs
@@ -1,0 +1,120 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Xunit.Analyzers
+{
+    public class AssertEqualShouldNotBeUsedForCollectionSizeCheckTests
+    {
+        private readonly DiagnosticAnalyzer analyzer = new AssertEqualShouldNotBeUsedForCollectionSizeCheck();
+
+        public static TheoryData<string> Collections { get; } = new TheoryData<string>
+        {
+            "new int[0].Length",
+            "new System.Collections.ArrayList().Count",
+            "new System.Collections.Generic.List<int>().Count",
+            "new System.Collections.Generic.HashSet<int>().Count",
+            "new System.Collections.ObjectModel.Collection<int>().Count()",
+            "System.Linq.Enumerable.Empty<int>().Count()",
+        };
+
+        public static TheoryData<string, int> CollectionsWithUnsupportedSize { get; } = new TheoryData<string, int>
+        {
+            { "new int[0].Length", -1 },
+            { "new System.Collections.ArrayList().Count", -2 },
+            { "new System.Collections.Generic.List<int>().Count", 2 },
+            { "new System.Collections.Generic.HashSet<int>().Count", 3 },
+            { "new System.Collections.ObjectModel.Collection<int>().Count()", 13 },
+            { "System.Linq.Enumerable.Empty<int>().Count()", 354 }
+        };
+
+        [Theory]
+        [MemberData(nameof(Collections))]
+        public async void FindsWarningForEmptyCollectionSizeCheck(string collection)
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
+                @"using System.Linq;
+class TestClass { void TestMethod() { 
+    Xunit.Assert.Equal(0, " + collection + @");
+} }");
+
+            Assert.Collection(diagnostics, d =>
+            {
+                Assert.Equal("Do not use Assert.Equal() to check for collection size.", d.GetMessage());
+                Assert.Equal("xUnit2013", d.Id);
+                Assert.Equal(DiagnosticSeverity.Warning, d.Severity);
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(Collections))]
+        public async void FindsWarningForNonEmptyCollectionSizeCheck(string collection)
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
+                @"using System.Linq;
+        class TestClass { void TestMethod() { 
+            Xunit.Assert.NotEqual(0, " + collection + @");
+        } }");
+
+            Assert.Collection(diagnostics, d =>
+            {
+                Assert.Equal("Do not use Assert.NotEqual() to check for collection size.", d.GetMessage());
+                Assert.Equal("xUnit2013", d.Id);
+                Assert.Equal(DiagnosticSeverity.Warning, d.Severity);
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(Collections))]
+        public async void FindsWarningForSingleItemCollectionSizeCheck(string collection)
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
+                @"using System.Linq;
+        class TestClass { void TestMethod() { 
+            Xunit.Assert.Equal(1, " + collection + @");
+        } }");
+
+            Assert.Collection(diagnostics, d =>
+            {
+                Assert.Equal("Do not use Assert.Equal() to check for collection size.", d.GetMessage());
+                Assert.Equal("xUnit2013", d.Id);
+                Assert.Equal(DiagnosticSeverity.Warning, d.Severity);
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(Collections))]
+        public async void DoesNotFindWarningForNonSingleItemCollectionSizeCheck(string collection)
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
+                @"using System.Linq;
+        class TestClass { void TestMethod() { 
+            Xunit.Assert.NotEqual(1, " + collection + @");
+        } }");
+            Assert.Empty(diagnostics);
+        }
+
+        [Theory]
+        [MemberData(nameof(CollectionsWithUnsupportedSize))]
+        public async void DoesNotFindWarningForUnsupportedCollectionSizeCheck(string collection, int size)
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
+                @"using System.Linq;
+        class TestClass { void TestMethod() { 
+            Xunit.Assert.Equal(" + size + ", " + collection + @");
+        } }");
+            Assert.Empty(diagnostics);
+        }
+
+        [Theory]
+        [MemberData(nameof(CollectionsWithUnsupportedSize))]
+        public async void DoesNotFindWarningForUnsupportedNonEqualCollectionSizeCheck(string collection, int size)
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
+                @"using System.Linq;
+        class TestClass { void TestMethod() { 
+            Xunit.Assert.NotEqual(" + size + ", " + collection + @");
+        } }");
+            Assert.Empty(diagnostics);
+        }
+    }
+}


### PR DESCRIPTION
Refs: https://github.com/xunit/xunit/issues/1252

Note that the xUnit analyzer ID is 2013 as 2012 is already taken in https://github.com/xunit/xunit.analyzers/pull/59/files