### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ xUnit.net is a free, open source, community-focused unit testing tool for the .N
 
 This project contains source code analysis and cleanup rules for xUnit.net. It supports xUnit.net v2.0+ and Visual Studio 2015+.
 
-To start using the analyzers in your test project, simply add a reference to the [xunit.analyzer NuGet package](https://www.nuget.org/packages/xunit.analyzers/).
+To start using the analyzers in your test project, simply add a reference to the [xunit.analyzers NuGet package](https://www.nuget.org/packages/xunit.analyzers/).
 
 To open an issue for this project, please visit the [core xUnit.net project issue tracker](https://github.com/xunit/xunit/issues).
 


### PR DESCRIPTION
People will try to do `Install-Package xunit.analyzer` and waste time figuring out why it doesn't work, so here's to prevent that.