### PR TITLE
Warn when users call IsType with an interface/abstract class

### DIFF
--- a/src/xunit.analyzers/AssertIsTypeShouldNotBeUsedForAbstractType.cs
+++ b/src/xunit.analyzers/AssertIsTypeShouldNotBeUsedForAbstractType.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Xunit.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class AssertIsTypeShouldNotBeUsedForAbstractType : AssertUsageAnalyzerBase
+    {
+        private const string AbstractClass = "abstract class";
+        private const string Interface = "interface";
+
+        private static HashSet<string> IsTypeMethods { get; } = new HashSet<string>(new[] { "IsType", "IsNotType" });
+
+        public AssertIsTypeShouldNotBeUsedForAbstractType() :
+            base(Descriptors.X2018_AssertIsTypeShouldNotBeUsedForAbstractType, IsTypeMethods)
+        {
+        }
+
+        protected override void Analyze(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocation, IMethodSymbol method)
+        {
+            var genericName = invocation.GetSimpleName() as GenericNameSyntax;
+            if (genericName == null)
+                return;
+
+            var typeSyntax = genericName.TypeArgumentList.Arguments[0];
+            var typeInfo = context.SemanticModel.GetTypeInfo(typeSyntax);
+            var typeKind = GetAbstractTypeKind(typeInfo.Type);
+            if (typeKind == null)
+                return;
+            
+            var typeName = SymbolDisplay.ToDisplayString(typeInfo.Type);
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                Descriptors.X2018_AssertIsTypeShouldNotBeUsedForAbstractType,
+                invocation.GetLocation(),
+                typeKind,
+                typeName));
+        }
+
+        private static string GetAbstractTypeKind(ITypeSymbol typeSymbol)
+        {
+            switch (typeSymbol.TypeKind)
+            {
+                case TypeKind.Class:
+                    if (typeSymbol.IsAbstract)
+                    {
+                        return AbstractClass;
+                    }
+                    break;
+                case TypeKind.Interface:
+                    return Interface;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/xunit.analyzers/AssertIsTypeShouldNotBeUsedForAbstractTypeFixer.cs
+++ b/src/xunit.analyzers/AssertIsTypeShouldNotBeUsedForAbstractTypeFixer.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace Xunit.Analyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+    public class AssertIsTypeShouldNotBeUsedForAbstractTypeFixer : CodeFixProvider
+    {
+        private const string Title = "Use Assert." + IsAssignableFrom;
+
+        private const string IsAssignableFrom = "IsAssignableFrom";
+
+        private const string IsType = "IsType";
+
+        public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(Descriptors.X2018_AssertIsTypeShouldNotBeUsedForAbstractType.Id);
+
+        public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var invocation = root.FindNode(context.Span).FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            var methodName = invocation.GetSimpleName()?.Identifier.Text;
+            if (methodName == IsType)
+            {
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        Title,
+                        createChangedDocument: ct => UseIsAssignableFromAsync(context.Document, invocation, ct),
+                        equivalenceKey: Title),
+                    context.Diagnostics);
+            }
+        }
+
+        private static async Task<Document> UseIsAssignableFromAsync(Document document, InvocationExpressionSyntax invocation, CancellationToken cancellationToken)
+        {
+            var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+            var simpleName = invocation.GetSimpleName();
+            editor.ReplaceNode(simpleName, simpleName.WithIdentifier(SyntaxFactory.Identifier(IsAssignableFrom)));
+            return editor.GetChangedDocument();
+        }
+    }
+}

--- a/src/xunit.analyzers/Descriptors.cs
+++ b/src/xunit.analyzers/Descriptors.cs
@@ -262,7 +262,10 @@ namespace Xunit.Analyzers
             "Do not use Contains() to check if a value exists in a collection.",
             Categories.Assertions, DiagnosticSeverity.Warning, isEnabledByDefault: true);
 
-        // Placeholder for rule X2018
+        internal static DiagnosticDescriptor X2018_AssertIsTypeShouldNotBeUsedForAbstractType { get; } = new DiagnosticDescriptor("xUnit2018",
+            "Do not compare an object's exact type to an abstract class or interface",
+            "Do not compare an object's exact type to the {0} '{1}'.",
+            Categories.Assertions, DiagnosticSeverity.Warning, isEnabledByDefault: true);
 
         // Placeholder for rule X2019
 

--- a/src/xunit.analyzers/Extensions.cs
+++ b/src/xunit.analyzers/Extensions.cs
@@ -39,6 +39,19 @@ namespace Xunit.Analyzers
             return builder.ToImmutable();
         }
 
+        internal static SimpleNameSyntax GetSimpleName(this InvocationExpressionSyntax invocation)
+        {
+            switch (invocation.Expression)
+            {
+                case MemberAccessExpressionSyntax memberAccess:
+                    return memberAccess.Name;
+                case SimpleNameSyntax simpleName:
+                    return simpleName;
+            }
+
+            return null;
+        }
+
         internal static bool IsAssignableFrom(this ITypeSymbol targetType, ITypeSymbol sourceType, bool exactMatch = false)
         {
             if (targetType != null)

--- a/src/xunit.analyzers/xunit.analyzers.csproj
+++ b/src/xunit.analyzers/xunit.analyzers.csproj
@@ -12,6 +12,7 @@
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
     <RootNamespace>Xunit.Analyzers</RootNamespace>
     <TargetFramework>netstandard1.1</TargetFramework>
+    <DebugType>full</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/xunit.analyzers.tests/AssertIsTypeShouldNotBeUsedForAbstractTypeTests.cs
+++ b/test/xunit.analyzers.tests/AssertIsTypeShouldNotBeUsedForAbstractTypeTests.cs
@@ -1,0 +1,117 @@
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Xunit.Analyzers
+{
+    public class AssertIsTypeShouldNotBeUsedForAbstractTypeTests
+    {
+        private static DiagnosticAnalyzer Analyzer { get; } = new AssertIsTypeShouldNotBeUsedForAbstractType();
+
+        public static TheoryData<string> Methods { get; } = new TheoryData<string> { "IsType", "IsNotType" };
+
+        private static void AssertHasDiagnostic(IEnumerable<Diagnostic> diagnostics, string typeKind, string type)
+        {
+            Assert.Collection(diagnostics, d =>
+            {
+                Assert.Equal($"Do not compare an object's exact type to the {typeKind} '{type}'.", d.GetMessage());
+                Assert.Equal("xUnit2018", d.Id);
+                Assert.Equal(DiagnosticSeverity.Warning, d.Severity);
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(Methods))]
+        public async void FindsError_Interface(string method)
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(Analyzer, @"
+using System;
+using Xunit;
+
+class TestClass
+{
+    void TestMethod()
+    {
+        Assert." + method + @"<IDisposable>(new object());
+    }
+}");
+
+            AssertHasDiagnostic(diagnostics, "interface", "System.IDisposable");
+        }
+
+        [Theory]
+        [MemberData(nameof(Methods))]
+        public async void FindsError_AbstractClass(string method)
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(Analyzer, @"
+using System.IO;
+using Xunit;
+
+class TestClass
+{
+    void TestMethod()
+    {
+        Assert." + method + @"<Stream>(new object());
+    }
+}");
+
+            AssertHasDiagnostic(diagnostics, "abstract class", "System.IO.Stream");
+        }
+
+        [Theory]
+        [MemberData(nameof(Methods))]
+        public async void FindsError_UsingStatic(string method)
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(Analyzer, @"
+using System;
+using static Xunit.Assert;
+
+class TestClass
+{
+    void TestMethod()
+    {
+        " + method + @"<IDisposable>(new object());
+    }
+}");
+
+            AssertHasDiagnostic(diagnostics, "interface", "System.IDisposable");
+        }
+
+        [Theory]
+        [MemberData(nameof(Methods))]
+        public async void DoesNotFindError_NonAbstractClass(string method)
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(Analyzer, @"
+using Xunit;
+
+class TestClass
+{
+    void TestMethod()
+    {
+        Assert." + method + @"<string>(new object());
+    }
+}");
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Theory]
+        [InlineData("IsAssignableFrom")]
+        public async void DoesNotFindError_OtherMethods(string method)
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(Analyzer, @"
+using System;
+using Xunit;
+
+class TestClass
+{
+    void TestMethod()
+    {
+        Assert." + method + @"<IDisposable>(new object());
+    }
+}");
+
+            Assert.Empty(diagnostics);
+        }
+    }
+}


### PR DESCRIPTION
`IsType` verifies that an object is exactly of a given type, which isn't possible for interfaces/abstract classes. I've written an analyzer that detects usages of `Is{Not}Type` with such types and issues a warning.

This PR also contains a code fix that changes `IsType` -> `IsAssignableFrom` (there's no `IsNotAssignableFrom`, so nothing to do for `IsNotType`). I haven't been able to test out the code fix, though, since none of the code fixes seem to work when debugging the VSIX. (**edit:** managed to get around those issues and test out the code fix providers in VS.)

/cc @marcind