### PR TITLE
Run the built analyzers on the test project

### DIFF
--- a/test/xunit.analyzers.tests/TestClassMustBePublicTests.cs
+++ b/test/xunit.analyzers.tests/TestClassMustBePublicTests.cs
@@ -5,7 +5,7 @@ namespace Xunit.Analyzers
 {
     public class TestClassMustBePublicTests
     {
-        private static IEnumerable<object[]> CreateFactsInNonPublicClassCases()
+        public static IEnumerable<object[]> CreateFactsInNonPublicClassCases()
         {
             foreach (var factAttribute in new[] {"Xunit.Fact", "Xunit.Theory"})
             {
@@ -31,9 +31,9 @@ namespace Xunit.Analyzers
             string classAccessModifier)
         {
             var source =   @"
-" + classAccessModifier + @" class TestClass 
-{ 
-    [" + factRelatedAttribute + @"] public void TestMethod() { } 
+" + classAccessModifier + @" class TestClass
+{
+    [" + factRelatedAttribute + @"] public void TestMethod() { }
 }";
 
             var expected = Verify.Diagnostic().WithSpan(2, 8 + classAccessModifier.Length, 2, 17 + classAccessModifier.Length);

--- a/test/xunit.analyzers.tests/xunit.analyzers.tests.csproj
+++ b/test/xunit.analyzers.tests/xunit.analyzers.tests.csproj
@@ -5,6 +5,8 @@
     <NoWarn>NU1701</NoWarn>
     <RootNamespace>Xunit.Analyzers</RootNamespace>
     <TargetFrameworks>netcoreapp2.2;net472</TargetFrameworks>
+    <TargetFramework>net452</TargetFramework>
+    <AnalyzersOutputPath>..\..\src\xunit.analyzers\bin\$(Configuration)\netstandard1.1\xunit.analyzers.dll</AnalyzersOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,6 +29,10 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\xunit.analyzers\xunit.analyzers.csproj" />
     <ProjectReference Include="..\..\src\xunit.analyzers.fixes\xunit.analyzers.fixes.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Analyzer Include="$(AnalyzersOutputPath)" />
   </ItemGroup>
 
 </Project>

--- a/test/xunit.analyzers.tests/xunit.analyzers.tests.csproj
+++ b/test/xunit.analyzers.tests/xunit.analyzers.tests.csproj
@@ -5,7 +5,6 @@
     <NoWarn>NU1701</NoWarn>
     <RootNamespace>Xunit.Analyzers</RootNamespace>
     <TargetFrameworks>netcoreapp2.2;net472</TargetFrameworks>
-    <TargetFramework>net452</TargetFramework>
     <AnalyzersOutputPath>..\..\src\xunit.analyzers\bin\$(Configuration)\netstandard1.1\xunit.analyzers.dll</AnalyzersOutputPath>
   </PropertyGroup>
 
@@ -30,7 +29,7 @@
     <ProjectReference Include="..\..\src\xunit.analyzers\xunit.analyzers.csproj" />
     <ProjectReference Include="..\..\src\xunit.analyzers.fixes\xunit.analyzers.fixes.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Analyzer Include="$(AnalyzersOutputPath)" />
   </ItemGroup>


### PR DESCRIPTION
I ran into an issue during my earlier PR where I forgot to make the test class `public`. This stumped me for a while, so when I realized what the issue was I was surprised because I assumed they were already enabled for the tests here.

This PR causes the freshly-built analyzers to be used against their own test project, so it's easier to find/fix bugs since we'll actually be using them.