### PR TITLE
Add analyzer to ensure all parameters are used within a Theory method

### DIFF
--- a/src/xunit.analyzers/Descriptors.cs
+++ b/src/xunit.analyzers/Descriptors.cs
@@ -148,7 +148,10 @@ namespace Xunit.Analyzers
             Categories.Usage, DiagnosticSeverity.Warning, isEnabledByDefault: true,
             description: "Theory should have all InlineData elements unique. Remove redundant attribute(s) from the theory method.");
 
-        // Placeholder for rule X1026
+        internal static DiagnosticDescriptor X1026_TheoryMethodMustUseAllParameters { get; } = new DiagnosticDescriptor("xUnit1026",
+            "Theory methods should use all of their parameters",
+            "Theory method '{0}' on test class '{1}' does not use parameter '{2}'.",
+            Categories.Usage, DiagnosticSeverity.Warning, isEnabledByDefault: true);
 
         // Placeholder for rule X1027
 
@@ -161,7 +164,7 @@ namespace Xunit.Analyzers
         // Placeholder for rule X1031
 
         // Placeholder for rule X1032
-        
+
         internal static DiagnosticDescriptor X2000_AssertEqualLiteralValueShouldBeFirst { get; } = new DiagnosticDescriptor("xUnit2000",
             "Expected value should be first",
             "The literal or constant value {0} should be the first argument in the call to '{1}' in method '{2}' on type '{3}'.",

--- a/src/xunit.analyzers/FixProviders/RemoveMethodParameterFix.cs
+++ b/src/xunit.analyzers/FixProviders/RemoveMethodParameterFix.cs
@@ -16,7 +16,8 @@ namespace Xunit.Analyzers.FixProviders
 
         public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
             Descriptors.X1022_TheoryMethodCannotHaveParameterArray.Id,
-            Descriptors.X1023_TheoryMethodCannotHaveDefaultParameter.Id);
+            Descriptors.X1023_TheoryMethodCannotHaveDefaultParameter.Id,
+            Descriptors.X1026_TheoryMethodMustUseAllParameters.Id);
 
         public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/xunit.analyzers/TheoryMethodMustUseAllParameters.cs
+++ b/src/xunit.analyzers/TheoryMethodMustUseAllParameters.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Xunit.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class TheoryMethodMustUseAllParameters : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+           ImmutableArray.Create(Descriptors.X1026_TheoryMethodMustUseAllParameters);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterCompilationStartAction(compilationStartContext =>
+            {
+                var theoryType = compilationStartContext.Compilation.GetTypeByMetadataName(Constants.Types.XunitTheoryAttribute);
+                if (theoryType == null)
+                    return;
+
+                compilationStartContext.RegisterSyntaxNodeAction(syntaxNodeContext =>
+                {
+                    var methodSyntax = (MethodDeclarationSyntax)syntaxNodeContext.Node;
+                    var methodSymbol = syntaxNodeContext.SemanticModel.GetDeclaredSymbol(methodSyntax);
+
+                    var attributes = methodSymbol.GetAttributes();
+                    if (!attributes.ContainsAttributeType(theoryType))
+                        return;
+
+                    AnalyzeTheoryParameters(syntaxNodeContext, methodSyntax, methodSymbol);
+                },
+                SyntaxKind.MethodDeclaration);
+            });
+        }
+
+        private static void AnalyzeTheoryParameters(SyntaxNodeAnalysisContext context, MethodDeclarationSyntax methodSyntax, IMethodSymbol methodSymbol)
+        {
+            var flowAnalysis = context.SemanticModel.AnalyzeDataFlow(methodSyntax.Body);
+            var usedParameters = new HashSet<ISymbol>(flowAnalysis.ReadInside);
+
+            for (int i = 0; i < methodSymbol.Parameters.Length; i++)
+            {
+                var parameterSymbol = methodSymbol.Parameters[i];
+                if (!usedParameters.Contains(parameterSymbol))
+                {
+                    var parameterSyntax = methodSyntax.ParameterList.Parameters[i];
+
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        Descriptors.X1026_TheoryMethodMustUseAllParameters,
+                        parameterSyntax.Identifier.GetLocation(),
+                        methodSymbol.Name,
+                        methodSymbol.ContainingType.Name,
+                        parameterSymbol.Name));
+                }
+            }
+        }
+    }
+}

--- a/test/xunit.analyzers.tests/CodeAnalyzerHelper.cs
+++ b/test/xunit.analyzers.tests/CodeAnalyzerHelper.cs
@@ -72,7 +72,12 @@ namespace Xunit.Analyzers
             }
 
             var project = solution.GetProject(projectId);
-            project = project.WithCompilationOptions(((CSharpCompilationOptions)project.CompilationOptions).WithOutputKind(OutputKind.DynamicallyLinkedLibrary).WithWarningLevel(2));
+            var compilationOptions = ((CSharpCompilationOptions)project.CompilationOptions)
+                .WithAllowUnsafe(true)
+                .WithOutputKind(OutputKind.DynamicallyLinkedLibrary)
+                .WithWarningLevel(2);
+            project = project.WithCompilationOptions(compilationOptions);
+
             var compilation = await project.GetCompilationAsync();
             var compilationDiagnostics = compilation.GetDiagnostics();
             if (!ignoreCompilationErrors && compilationDiagnostics.Any())

--- a/test/xunit.analyzers.tests/TheoryMethodMustUseAllParametersTests.cs
+++ b/test/xunit.analyzers.tests/TheoryMethodMustUseAllParametersTests.cs
@@ -1,0 +1,123 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Xunit.Analyzers
+{
+    public class TheoryMethodMustUseAllParametersTests
+    {
+        private static DiagnosticAnalyzer Analyzer { get; } = new TheoryMethodMustUseAllParameters();
+
+        private static void CheckDiagnostics(IEnumerable<Diagnostic> diagnostics, params (string method, string type, string parameter)[] messageArgs)
+        {
+            var diagnosticArray = diagnostics.ToArray();
+            Assert.Equal(messageArgs.Length, diagnosticArray.Length);
+
+            for (int i = 0; i < messageArgs.Length; i++)
+            {
+                var (method, type, parameter) = messageArgs[i];
+                string message = $"Theory method '{method}' on test class '{type}' does not use parameter '{parameter}'.";
+
+                var diagnostic = diagnosticArray[i];
+                Assert.Equal(message, diagnostic.GetMessage());
+                Assert.Equal("xUnit1026", diagnostic.Id);
+                Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+            }
+        }
+
+        [Fact]
+        public async void FindsError_ParameterNotReferenced()
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(Analyzer, @"
+using Xunit;
+
+class TestClass
+{
+    [Theory]
+    void TestMethod(int unused) { }
+}");
+
+            CheckDiagnostics(diagnostics,
+                (method: "TestMethod", type: "TestClass", parameter: "unused"));
+        }
+
+        [Fact]
+        public async void FindsError_ParameterUnread()
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(Analyzer, @"
+using System;
+using Xunit;
+
+class TestClass
+{
+    [Theory]
+    void TestMethod(int unused)
+    {
+        unused = 3;
+        int.TryParse(""123"", out unused);
+    }
+}");
+
+            CheckDiagnostics(diagnostics,
+                (method: "TestMethod", type: "TestClass", parameter: "unused"));
+        }
+
+        [Fact]
+        public async void FindsError_MultipleUnreadParameters()
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(Analyzer, @"
+using Xunit;
+
+class TestClass
+{
+    [Theory]
+    void TestMethod(int foo, int bar, int baz) { }
+}");
+
+            CheckDiagnostics(diagnostics,
+                (method: "TestMethod", type: "TestClass", parameter: "foo"),
+                (method: "TestMethod", type: "TestClass", parameter: "bar"),
+                (method: "TestMethod", type: "TestClass", parameter: "baz"));
+        }
+
+        [Fact]
+        public async void FindsError_SomeUnreadParameters()
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(Analyzer, @"
+using System;
+using Xunit;
+
+class TestClass
+{
+    [Theory]
+    void TestMethod(int foo, int bar, int baz)
+    {
+        Console.WriteLine(bar);
+        baz = 3;
+    }
+}");
+
+            CheckDiagnostics(diagnostics,
+                (method: "TestMethod", type: "TestClass", parameter: "foo"),
+                (method: "TestMethod", type: "TestClass", parameter: "baz"));
+        }
+
+        [Fact]
+        public async void DoesNotFindError_ParameterRead()
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(Analyzer, @"
+using System;
+using Xunit;
+
+class TestClass
+{
+    [Theory]
+    void TestMethod(int unused)
+    {
+        Console.WriteLine(unused);
+    }
+}");
+        }
+    }
+}

--- a/test/xunit.analyzers.tests/xunit.analyzers.tests.csproj
+++ b/test/xunit.analyzers.tests/xunit.analyzers.tests.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.1.0" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
     <PackageReference Include="xunit.assert" Version="2.2.0" />
     <PackageReference Include="xunit.core" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />


### PR DESCRIPTION
This fixes https://github.com/xunit/xunit/issues/1373 by adding an analyzer to warn on unused Theory parameters, along with tests for the new analyzer. It uses [`SemanticModel.AnalyzeDataFlow`](https://joshvarty.wordpress.com/2015/02/05/learn-roslyn-now-part-8-data-flow-analysis/) on the theory method and checks if parameters are in `ReadInside` to determine if they are used.

/cc @hughbe, @marcind 