### PR TITLE
Add ability to view code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,3 +253,9 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# OpenCover results file
+results.xml
+
+# ReportGenerator output folder
+/reports/

--- a/build.ps1
+++ b/build.ps1
@@ -103,7 +103,7 @@ function __target__setversion() {
 
 function __target__test() {
     _build_step "Running unit tests"
-        _xunit_console ("test\xunit.analyzers.tests\bin\" + $configuration + "\net452\xunit.analyzers.tests.dll -xml artifacts\test\TestResults.xml -diagnostics")
+        _xunit_console ("test\xunit.analyzers.tests\bin\" + $configuration + "\netcoreapp1.1\xunit.analyzers.tests.dll -xml artifacts\test\TestResults.xml -diagnostics")
 }
 
 # Dispatch

--- a/src/xunit.analyzers.vsix/xunit.analyzers.vsix.csproj
+++ b/src/xunit.analyzers.vsix/xunit.analyzers.vsix.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -15,7 +16,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>xunit.analyzers.vsix</RootNamespace>
     <AssemblyName>xunit.analyzers.vsix</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>

--- a/src/xunit.analyzers/xunit.analyzers.csproj
+++ b/src/xunit.analyzers/xunit.analyzers.csproj
@@ -11,13 +11,16 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
     <RootNamespace>Xunit.Analyzers</RootNamespace>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
+    <!--
+    This is needed to 1) make debugging the VSIX possible and 2) work around https://github.com/OpenCover/opencover/issues/601.
+    -->
     <DebugType>full</DebugType>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/xunit.analyzers.tests/AssertStringEqualityCheckShouldNotUseBoolCheckTest.cs
+++ b/test/xunit.analyzers.tests/AssertStringEqualityCheckShouldNotUseBoolCheckTest.cs
@@ -21,8 +21,8 @@ namespace Xunit.Analyzers
             {
                 StringComparison.CurrentCulture,
                 StringComparison.CurrentCultureIgnoreCase,
-                StringComparison.InvariantCulture,
-                StringComparison.InvariantCultureIgnoreCase
+                (StringComparison)2, // InvariantCulture not exposed in .NET Core
+                (StringComparison)3 // InvariantCultureIgnoreCase not exposed in .NET Core
             };
 
         public static TheoryData<StringComparison> AllStringComparisons = new TheoryData<StringComparison>
@@ -31,8 +31,8 @@ namespace Xunit.Analyzers
                 StringComparison.OrdinalIgnoreCase,
                 StringComparison.CurrentCulture,
                 StringComparison.CurrentCultureIgnoreCase,
-                StringComparison.InvariantCulture,
-                StringComparison.InvariantCultureIgnoreCase
+                (StringComparison)2, // InvariantCulture not exposed in .NET Core
+                (StringComparison)3 // InvariantCultureIgnoreCase not exposed in .NET Core
             };
 
         private static void AssertHasDiagnostic(IEnumerable<Diagnostic> diagnostics, string method)

--- a/test/xunit.analyzers.tests/TheoryMethodMustUseAllParametersTests.cs
+++ b/test/xunit.analyzers.tests/TheoryMethodMustUseAllParametersTests.cs
@@ -93,7 +93,7 @@ class TestClass
     [Theory]
     void TestMethod(int foo, int bar, int baz)
     {
-        Console.WriteLine(bar);
+        TestMethod(bar, bar, bar);
         baz = 3;
     }
 }");
@@ -115,7 +115,7 @@ class TestClass
     [Theory]
     void TestMethod(int unused)
     {
-        Console.WriteLine(unused);
+        TestMethod(unused);
     }
 }");
         }

--- a/test/xunit.analyzers.tests/TupleMemberDataAttribute.cs
+++ b/test/xunit.analyzers.tests/TupleMemberDataAttribute.cs
@@ -30,7 +30,7 @@ namespace Xunit.Analyzers
 
         static Func<object, object[]> GetConverter(object item)
         {
-            if (!item.GetType().IsGenericType || !TupleOpenGenericTypes.Contains(item.GetType().GetGenericTypeDefinition()))
+            if (!item.GetType().GetTypeInfo().IsGenericType || !TupleOpenGenericTypes.Contains(item.GetType().GetGenericTypeDefinition()))
             {
                 return null;
             }

--- a/test/xunit.analyzers.tests/xunit.analyzers.tests.csproj
+++ b/test/xunit.analyzers.tests/xunit.analyzers.tests.csproj
@@ -2,12 +2,19 @@
 
   <PropertyGroup>
     <RootNamespace>Xunit.Analyzers</RootNamespace>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <PackageTargetFallback>portable-net45+win8+wp8+wpa81</PackageTargetFallback>
+    <!-- This is needed to work around https://github.com/OpenCover/opencover/issues/601. -->
+    <DebugType>full</DebugType>
   </PropertyGroup>
 
+  <!-- Please keep the OpenCover and ReportGenerator versions in sync with those in view-coverage.cmd. -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />
+    <PackageReference Include="OpenCover" Version="4.6.519" />
+    <PackageReference Include="ReportGenerator" Version="2.5.10" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
     <PackageReference Include="xunit.assert" Version="2.2.0" />
     <PackageReference Include="xunit.core" Version="2.2.0" />

--- a/view-coverage.cmd
+++ b/view-coverage.cmd
@@ -1,0 +1,32 @@
+@if not defined _echo @echo off
+setlocal EnableDelayedExpansion
+
+:: Please keep the OpenCover and ReportGenerator versions in sync with those in xunit.analyzers.tests.csproj.
+
+set PackageRoot="%USERPROFILE%\.nuget\packages"
+set OpenCoverVersion=4.6.519
+set OpenCoverPath="%PackageRoot%\OpenCover\%OpenCoverVersion%\tools\OpenCover.Console.exe"
+set DotNetPath="%PROGRAMFILES%\dotnet\dotnet.exe"
+
+set ReportGeneratorVersion=2.5.10
+set ReportGeneratorPath="%PackageRoot%\ReportGenerator\%ReportGeneratorVersion%\tools\ReportGenerator.exe"
+set ReportDirectory="%~dp0reports"
+
+pushd "%~dp0test"
+
+for /d %%d in (*.tests) do (
+    pushd "%%d"
+
+    %OpenCoverPath% -target:%DotNetPath% -targetargs:"test" -register:user -filter:"+[*]*" -oldStyle
+
+    set TestAssembly="%%d"
+    set TargetDirectory="%ReportDirectory:"=%\!TestAssembly:~1,-1!"
+    set ReportFile="!TargetDirectory:~1,-1!\index.htm"
+
+    %ReportGeneratorPath% -reports:results.xml -targetdir:!TargetDirectory!
+    start !ReportFile:~1,-1!
+
+    popd
+)
+
+popd


### PR DESCRIPTION
This PR adds the ability for users to generate and view code coverage reports for `xunit.analyzers`, using OpenCover and ReportGenerator. It's as easy as navigating to the repo root in a command prompt and typing `view-coverage`. The script will call `dotnet test` with OpenCover generating `results.xml`, then generate a report in `<repo root>/reports/xunit.analyzers.tests/` and open it in the browser.

For an infrastructure PR, this contains a lot of code changes. Let me explain why:

- OpenCover mysteriously says everything is 0% coverage when `xunit.analyzers.tests` targets `net452`. So I had to change it to target `netcoreapp1.1` in order for the coverage to work.
  - This necessitated upgrading the version of `Microsoft.CodeAnalysis.CSharp` `xunit.analyzers.tests` used, so I upgraded it to the latest version both there and in `xunit.analyzers`.
    - This required changing `xunit.analyzers` to target `netstandard1.3`, in turn requiring `xunit.analyzers.vsix` to target `net46`.
  - Upgrading to netcoreapp1.1 also made some things not compile (e.g. needed extra `GetTypeInfo()` calls). It also screwed with the references in `CodeAnalyzerHelper`, causing all the tests to fail since `typeof(object).Assembly.Location` is no longer mscorlib.dll but System.Private.CoreLib.ni.dll. I had to rewrite most of the logic there.