### PR TITLE
Refactoring: Split Extensions into two and move it to Utilities

### DIFF
--- a/src/xunit.analyzers/SymbolExtensions.cs
+++ b/src/xunit.analyzers/SymbolExtensions.cs
@@ -1,0 +1,47 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Xunit.Analyzers
+{
+    internal static class SymbolExtensions
+    {
+        internal static bool ContainsAttributeType(this ImmutableArray<AttributeData> attributes, INamedTypeSymbol attributeType, bool exactMatch = false)
+        {
+            return attributes.Any(a => attributeType.IsAssignableFrom(a.AttributeClass, exactMatch));
+        }
+
+        internal static ImmutableArray<ISymbol> GetInheritedAndOwnMembers(this ITypeSymbol symbol, string name = null)
+        {
+            var builder = ImmutableArray.CreateBuilder<ISymbol>();
+            while (symbol != null)
+            {
+                builder.AddRange(name == null ? symbol.GetMembers() : symbol.GetMembers(name));
+                symbol = symbol.BaseType;
+            }
+            return builder.ToImmutable();
+        }
+
+        internal static bool IsAssignableFrom(this ITypeSymbol targetType, ITypeSymbol sourceType, bool exactMatch = false)
+        {
+            if (targetType != null)
+            {
+                while (sourceType != null)
+                {
+                    if (sourceType.Equals(targetType))
+                        return true;
+
+                    if (exactMatch)
+                        return false;
+
+                    if (targetType.TypeKind == TypeKind.Interface)
+                        return sourceType.AllInterfaces.Any(i => i.Equals(targetType));
+
+                    sourceType = sourceType.BaseType;
+                }
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
The methods in the `Extensions` class seem really random. Apart from them being related to types from Roslyn, they don't really have a coherent theme-- some methods are related to syntax, others to symbols. I split `Extensions` into two new classes, `SyntaxExtensions` and `SymbolExtensions`, and put them in the `Utilities` subdirectory.

/cc @marcind, @ErikSchierboom 