### PR TITLE
Use ConfigureAwait(false) in non-test code

### DIFF
--- a/src/xunit.analyzers/AssertThrowsShouldNotBeUsedForAsyncThrowsCheckFixer.cs
+++ b/src/xunit.analyzers/AssertThrowsShouldNotBeUsedForAsyncThrowsCheckFixer.cs
@@ -46,7 +46,7 @@ namespace Xunit.Analyzers
             var memberAccess = (MemberAccessExpressionSyntax)invocation.Expression;
 
             var modifiers = GetModifiersWithAsyncKeywordAdded(method);
-            var returnType = await GetReturnType(method, invocation, document, editor, cancellationToken);
+            var returnType = await GetReturnType(method, invocation, document, editor, cancellationToken).ConfigureAwait(false);
             var asyncThrowsInvocation = GetAsyncThrowsInvocation(invocation, replacementMethod, memberAccess);
 
             editor.ReplaceNode(method,

--- a/src/xunit.analyzers/ClassDataAttributeMustPointAtValidClassFixer.cs
+++ b/src/xunit.analyzers/ClassDataAttributeMustPointAtValidClassFixer.cs
@@ -62,7 +62,7 @@ namespace Xunit.Analyzers
                     if (!(ctor.IsImplicitlyDeclared && typeSymbol.IsAbstract))
                     {
                         var ctorSyntaxRef = ctor.DeclaringSyntaxReferences.FirstOrDefault();
-                        editor.SetAccessibility(await ctorSyntaxRef.GetSyntaxAsync(ct), Accessibility.Public);
+                        editor.SetAccessibility(await ctorSyntaxRef.GetSyntaxAsync(ct).ConfigureAwait(false), Accessibility.Public);
                     }
                 }
 
@@ -72,7 +72,7 @@ namespace Xunit.Analyzers
                     editor.AddInterfaceType(classDeclaration, generator.TypeExpression(iEnumerableOfObjectArray));
                 }
 
-            }, cancellationToken);
+            }, cancellationToken).ConfigureAwait(false);
             return symbolEditor.ChangedSolution;
         }
     }

--- a/src/xunit.analyzers/CodeActions/Actions.cs
+++ b/src/xunit.analyzers/CodeActions/Actions.cs
@@ -32,8 +32,8 @@ namespace Xunit.Analyzers.CodeActions
                 var newMods = DeclarationModifiers.From(memberSymbol).WithIsStatic(isStatic);
                 if (memberSymbol is IPropertySymbol propertySymbol && propertySymbol.IsReadOnly)
                 {
-                    // Looks like there's a bug in Roslym where SetModifiers will apply the 'readonly'
-                    // keyword to a property that only has a getter, which produces illegal syntax.
+                    // Looks like there's a bug in Roslyn where SetModifiers applies the 'readonly'
+                    // keyword to a get-only property, producing illegal syntax.
                     newMods = newMods.WithIsReadOnly(false);
                 }
                 docEditor.SetModifiers(syntaxNode, newMods);

--- a/src/xunit.analyzers/FixProviders/ChangeMemberTypeFix.cs
+++ b/src/xunit.analyzers/FixProviders/ChangeMemberTypeFix.cs
@@ -19,7 +19,7 @@ namespace Xunit.Analyzers.FixProviders
 
         public override async Task RegisterCodeFixesAsync(CodeFixContext context, ISymbol member)
         {
-            var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken);
+            var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
             var type = TypeSymbolFactory.IEnumerableOfObjectArray(semanticModel.Compilation);
 
             context.RegisterCodeFix(

--- a/src/xunit.analyzers/FixProviders/MemberFixBase.cs
+++ b/src/xunit.analyzers/FixProviders/MemberFixBase.cs
@@ -34,7 +34,7 @@ namespace Xunit.Analyzers.FixProviders
             if (member.Locations.FirstOrDefault()?.IsInMetadata ?? true)
                 return;
 
-            await RegisterCodeFixesAsync(context, member);
+            await RegisterCodeFixesAsync(context, member).ConfigureAwait(false);
         }
 
         public abstract Task RegisterCodeFixesAsync(CodeFixContext context, ISymbol member);


### PR DESCRIPTION
There are a couple of places in the codebase where it seems `ConfigureAwait(false)` should be used but it's not being used, I did a search with `grep` for all of them and fixed them.