### PR TITLE
Upgrade to Roslyn 1.2.2, enable concurrent execution in all analyzers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 xUnit.net is a free, open source, community-focused unit testing tool for the .NET Framework. Written by the original inventor of NUnit v2, xUnit.net is the latest technology for unit testing C#, F#, VB.NET and other .NET languages. xUnit.net works with ReSharper, CodeRush, TestDriven.NET and Xamarin. It is part of the [.NET Foundation](https://www.dotnetfoundation.org/), and operates under their [code of conduct](https://www.dotnetfoundation.org/code-of-conduct). It is licensed under [Apache 2](https://opensource.org/licenses/Apache-2.0) (an OSI approved license).
 
-This project contains source code analysis and cleanup rules for xUnit.net. It supports xUnit.net v2.0+ and Visual Studio 2015+.
+This project contains source code analysis and cleanup rules for xUnit.net. It supports xUnit.net v2.0+ and Visual Studio 2015 Update 2 and above.
 
 To start using the analyzers in your test project, simply add a reference to the [xunit.analyzers NuGet package](https://www.nuget.org/packages/xunit.analyzers/).
 

--- a/src/xunit.analyzers/AssertCollectionContainsShouldNotUseBoolCheck.cs
+++ b/src/xunit.analyzers/AssertCollectionContainsShouldNotUseBoolCheck.cs
@@ -63,7 +63,7 @@ namespace Xunit.Analyzers
         {
             var methodSymbol = symbolInfo.Symbol;
             var containingType = methodSymbol.ContainingType;
-            var genericCollectionType = GetICollectionType(containingType, context.SemanticModel.Compilation);
+            var genericCollectionType = GetICollectionType(containingType, context.Compilation);
             if (genericCollectionType == null)
                 return false;
 

--- a/src/xunit.analyzers/AssertEqualShouldNotBeUsedForCollectionSizeCheck.cs
+++ b/src/xunit.analyzers/AssertEqualShouldNotBeUsedForCollectionSizeCheck.cs
@@ -73,7 +73,7 @@ namespace Xunit.Analyzers
 
         private static bool IsCollectionCountProperty(SyntaxNodeAnalysisContext context, SymbolInfo symbolInfo)
         {
-            var collectionCountSymbol = context.SemanticModel.Compilation
+            var collectionCountSymbol = context.Compilation
                 .GetTypeByMetadataName(typeof(ICollection).FullName)
                 .GetMembers(nameof(ICollection.Count))
                 .Single();
@@ -87,14 +87,14 @@ namespace Xunit.Analyzers
             if (symbolInfo.Symbol.ContainingType.TypeArguments.IsEmpty)
                 return false;
 
-            var genericCollectionCountSymbol = context.SemanticModel.Compilation
+            var genericCollectionCountSymbol = context.Compilation
                 .GetSpecialType(SpecialType.System_Collections_Generic_ICollection_T)
                 .Construct(symbolInfo.Symbol.ContainingType.TypeArguments.ToArray())
                 .GetMembers(nameof(ICollection<int>.Count))
                 .Single();
 
             var genericCollectionSymbolImplementation = symbolInfo.Symbol.ContainingType.FindImplementationForInterfaceMember(genericCollectionCountSymbol);
-            return genericCollectionSymbolImplementation != null && genericCollectionSymbolImplementation.Equals(symbolInfo.Symbol);
+            return genericCollectionSymbolImplementation?.Equals(symbolInfo.Symbol) ?? false;
         }
     }
 }

--- a/src/xunit.analyzers/AssertThrowsShouldNotBeUsedForAsyncThrowsCheck.cs
+++ b/src/xunit.analyzers/AssertThrowsShouldNotBeUsedForAsyncThrowsCheck.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -65,10 +64,10 @@ namespace Xunit.Analyzers
 
         private static bool ThrowExpressionReturnsTask(SymbolInfo symbol, SyntaxNodeAnalysisContext context)
         {
-            if (symbol.Symbol == null || symbol.Symbol.Kind != SymbolKind.Method)
+            if (symbol.Symbol?.Kind != SymbolKind.Method)
                 return false;
 
-            var taskType = context.SemanticModel.Compilation.GetTypeByMetadataName(typeof(Task).FullName);
+            var taskType = context.Compilation.GetTypeByMetadataName(Constants.Types.SystemThreadingTasksTask);
             return taskType.IsAssignableFrom(((IMethodSymbol)symbol.Symbol).ReturnType);
         }
     }

--- a/src/xunit.analyzers/AssertUsageAnalyzerBase.cs
+++ b/src/xunit.analyzers/AssertUsageAnalyzerBase.cs
@@ -22,6 +22,8 @@ namespace Xunit.Analyzers
 
         public sealed override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterCompilationStartAction(compilationContext =>
             {
                 var assertType = compilationContext.Compilation.GetTypeByMetadataName(Constants.Types.XunitAssert);

--- a/src/xunit.analyzers/ClassDataAttributeMustPointAtValidClass.cs
+++ b/src/xunit.analyzers/ClassDataAttributeMustPointAtValidClass.cs
@@ -15,6 +15,8 @@ namespace Xunit.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterCompilationStartAction(compilationContext =>
             {
                 var compilation = compilationContext.Compilation;

--- a/src/xunit.analyzers/DataAttributeShouldBeUsedOnATheory.cs
+++ b/src/xunit.analyzers/DataAttributeShouldBeUsedOnATheory.cs
@@ -13,6 +13,8 @@ namespace Xunit.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var factType = compilationStartContext.Compilation.GetTypeByMetadataName(Constants.Types.XunitFactAttribute);

--- a/src/xunit.analyzers/FactMethodMustNotHaveParameters.cs
+++ b/src/xunit.analyzers/FactMethodMustNotHaveParameters.cs
@@ -14,6 +14,8 @@ namespace Xunit.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var factType = compilationStartContext.Compilation.GetTypeByMetadataName(Constants.Types.XunitFactAttribute);

--- a/src/xunit.analyzers/FactMethodShouldNotHaveTestData.cs
+++ b/src/xunit.analyzers/FactMethodShouldNotHaveTestData.cs
@@ -13,6 +13,8 @@ namespace Xunit.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var factType = compilationStartContext.Compilation.GetTypeByMetadataName(Constants.Types.XunitFactAttribute);

--- a/src/xunit.analyzers/InlineDataMustMatchTheoryParameters.cs
+++ b/src/xunit.analyzers/InlineDataMustMatchTheoryParameters.cs
@@ -27,6 +27,8 @@ namespace Xunit.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var compilation = compilationStartContext.Compilation;

--- a/src/xunit.analyzers/InlineDataShouldBeUniqueWithinTheory.cs
+++ b/src/xunit.analyzers/InlineDataShouldBeUniqueWithinTheory.cs
@@ -16,6 +16,8 @@ namespace Xunit.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var compilationTypes = new CompilationTypes(compilationStartContext.Compilation);

--- a/src/xunit.analyzers/MemberDataShouldReferenceValidMember.cs
+++ b/src/xunit.analyzers/MemberDataShouldReferenceValidMember.cs
@@ -25,6 +25,8 @@ namespace Xunit.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var compilation = compilationStartContext.Compilation;

--- a/src/xunit.analyzers/PublicMethodShouldBeMarkedAsTest.cs
+++ b/src/xunit.analyzers/PublicMethodShouldBeMarkedAsTest.cs
@@ -14,6 +14,8 @@ namespace Xunit.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var factType = compilationStartContext.Compilation.GetTypeByMetadataName(Constants.Types.XunitFactAttribute);

--- a/src/xunit.analyzers/TestClassMustBePublic.cs
+++ b/src/xunit.analyzers/TestClassMustBePublic.cs
@@ -15,6 +15,8 @@ namespace Xunit.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var factType = compilationStartContext.Compilation.GetTypeByMetadataName(Constants.Types.XunitFactAttribute);

--- a/src/xunit.analyzers/TestMethodCannotHaveOverloads.cs
+++ b/src/xunit.analyzers/TestMethodCannotHaveOverloads.cs
@@ -16,6 +16,8 @@ namespace Xunit.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var factType = compilationStartContext.Compilation.GetTypeByMetadataName(Constants.Types.XunitFactAttribute);

--- a/src/xunit.analyzers/TestMethodMustNotHaveMultipleFactAttributes.cs
+++ b/src/xunit.analyzers/TestMethodMustNotHaveMultipleFactAttributes.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 namespace Xunit.Analyzers
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -13,6 +14,8 @@ namespace Xunit.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var factType = compilationStartContext.Compilation.GetTypeByMetadataName(Constants.Types.XunitFactAttribute);
@@ -33,6 +36,7 @@ namespace Xunit.Analyzers
                             count++;
                         }
                     }
+
                     if (count > 1)
                     {
                         symbolContext.ReportDiagnostic(Diagnostic.Create(

--- a/src/xunit.analyzers/TestMethodShouldNotBeSkipped.cs
+++ b/src/xunit.analyzers/TestMethodShouldNotBeSkipped.cs
@@ -15,6 +15,8 @@ namespace Xunit.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var factType = compilationStartContext.Compilation.GetTypeByMetadataName(Constants.Types.XunitFactAttribute);

--- a/src/xunit.analyzers/TheoryMethodCannotHaveDefaultParameter.cs
+++ b/src/xunit.analyzers/TheoryMethodCannotHaveDefaultParameter.cs
@@ -26,6 +26,8 @@ namespace Xunit.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var compilation = compilationStartContext.Compilation;

--- a/src/xunit.analyzers/TheoryMethodCannotHaveParamsArray.cs
+++ b/src/xunit.analyzers/TheoryMethodCannotHaveParamsArray.cs
@@ -26,6 +26,8 @@ namespace Xunit.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var compilation = compilationStartContext.Compilation;

--- a/src/xunit.analyzers/TheoryMethodMustHaveTestData.cs
+++ b/src/xunit.analyzers/TheoryMethodMustHaveTestData.cs
@@ -13,6 +13,8 @@ namespace Xunit.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var theoryType = compilationStartContext.Compilation.GetTypeByMetadataName(Constants.Types.XunitTheoryAttribute);

--- a/src/xunit.analyzers/TheoryMethodMustUseAllParameters.cs
+++ b/src/xunit.analyzers/TheoryMethodMustUseAllParameters.cs
@@ -15,6 +15,8 @@ namespace Xunit.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var theoryType = compilationStartContext.Compilation.GetTypeByMetadataName(Constants.Types.XunitTheoryAttribute);

--- a/src/xunit.analyzers/TheoryMethodShouldHaveParameters.cs
+++ b/src/xunit.analyzers/TheoryMethodShouldHaveParameters.cs
@@ -13,6 +13,8 @@ namespace Xunit.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterCompilationStartAction(compilationStartContext =>
             {
                 var theoryType = compilationStartContext.Compilation.GetTypeByMetadataName(Constants.Types.XunitTheoryAttribute);

--- a/src/xunit.analyzers/Utilities/TypeHierarchyComparer.cs
+++ b/src/xunit.analyzers/Utilities/TypeHierarchyComparer.cs
@@ -12,9 +12,9 @@ namespace Xunit.Analyzers.Utilities
 
         public int Compare(ITypeSymbol x, ITypeSymbol y)
         {
-            if (x == null || x.TypeKind != TypeKind.Class)
+            if (x?.TypeKind != TypeKind.Class)
                 throw new ArgumentException("The argument must be a class", nameof(x));
-            if (y == null || x.TypeKind != TypeKind.Class)
+            if (y?.TypeKind != TypeKind.Class)
                 throw new ArgumentException("The argument must be a class", nameof(y));
 
             if (x.Equals(y)) return 0;

--- a/src/xunit.analyzers/xunit.analyzers.csproj
+++ b/src/xunit.analyzers/xunit.analyzers.csproj
@@ -16,13 +16,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="1.2.0-beta2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.2.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <Analyzer Include="$(NuGetPackageRoot)microsoft.codeanalysis.analyzers\1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
-    <Analyzer Include="$(NuGetPackageRoot)microsoft.codeanalysis.analyzers\1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+    <Analyzer Include="$(NuGetPackageRoot)microsoft.codeanalysis.analyzers\1.2.0-beta2\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="$(NuGetPackageRoot)microsoft.codeanalysis.analyzers\1.2.0-beta2\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
 
 </Project>

--- a/test/xunit.analyzers.tests/xunit.analyzers.tests.csproj
+++ b/test/xunit.analyzers.tests/xunit.analyzers.tests.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.1.0" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
     <PackageReference Include="xunit.assert" Version="2.2.0" />


### PR DESCRIPTION
Fixes xunit/xunit#1403.

Changes:

- Upgrade M.CA.CS.W to 1.2.2, M.C.A to 1.2.0-beta2
- Enable concurrent execution in all analyzers
- `SyntaxNodeAnalysisContext.Compilation` is now available, which is shorthand for `context.SemanticModel?.Compilation`.
- Other minor tweaks

/cc @marcind