### PR TITLE
Fix nullref on expression-bodied test methods in xUnit1026

### DIFF
--- a/src/xunit.analyzers/TheoryMethodMustUseAllParameters.cs
+++ b/src/xunit.analyzers/TheoryMethodMustUseAllParameters.cs
@@ -38,7 +38,11 @@ namespace Xunit.Analyzers
 
         private static void AnalyzeTheoryParameters(SyntaxNodeAnalysisContext context, MethodDeclarationSyntax methodSyntax, IMethodSymbol methodSymbol)
         {
-            var flowAnalysis = context.SemanticModel.AnalyzeDataFlow(methodSyntax.Body);
+            var methodBody = (SyntaxNode)methodSyntax.Body ?? methodSyntax.ExpressionBody?.Expression;
+            if (methodBody == null)
+                return;
+
+            var flowAnalysis = context.SemanticModel.AnalyzeDataFlow(methodBody);
             var usedParameters = new HashSet<ISymbol>(flowAnalysis.ReadInside);
 
             for (var i = 0; i < methodSymbol.Parameters.Length; i++)

--- a/test/xunit.analyzers.tests/TheoryMethodMustUseAllParametersTests.cs
+++ b/test/xunit.analyzers.tests/TheoryMethodMustUseAllParametersTests.cs
@@ -27,7 +27,7 @@ namespace Xunit.Analyzers
         }
 
         [Fact]
-        public async void FindsError_ParameterNotReferenced()
+        public async void FindsWarning_ParameterNotReferenced()
         {
             var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(Analyzer, @"
 using Xunit;
@@ -43,7 +43,7 @@ class TestClass
         }
 
         [Fact]
-        public async void FindsError_ParameterUnread()
+        public async void FindsWarning_ParameterUnread()
         {
             var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(Analyzer, @"
 using System;
@@ -64,7 +64,7 @@ class TestClass
         }
 
         [Fact]
-        public async void FindsError_MultipleUnreadParameters()
+        public async void FindsWarning_MultipleUnreadParameters()
         {
             var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(Analyzer, @"
 using Xunit;
@@ -82,7 +82,7 @@ class TestClass
         }
 
         [Fact]
-        public async void FindsError_SomeUnreadParameters()
+        public async void FindsWarning_SomeUnreadParameters()
         {
             var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(Analyzer, @"
 using System;
@@ -104,7 +104,23 @@ class TestClass
         }
 
         [Fact]
-        public async void DoesNotFindError_ParameterRead()
+        public async void FindsWarning_ExpressionBodiedMethod()
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(Analyzer, @"
+using Xunit;
+
+class TestClass
+{
+    [Theory]
+    void TestMethod(int unused) => Assert.Equal(5, 2 + 2);
+}");
+
+            CheckDiagnostics(diagnostics,
+                (method: "TestMethod", type: "TestClass", parameter: "unused"));
+        }
+
+        [Fact]
+        public async void DoesNotFindWarning_ParameterRead()
         {
             var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(Analyzer, @"
 using System;
@@ -113,11 +129,28 @@ using Xunit;
 class TestClass
 {
     [Theory]
-    void TestMethod(int unused)
+    void TestMethod(int used)
     {
-        Console.WriteLine(unused);
+        Console.WriteLine(used);
     }
 }");
+
+            CheckDiagnostics(diagnostics);
+        }
+
+        [Fact]
+        public async void DoesNotFindWarning_ExpressionBodiedMethod()
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(Analyzer, @"
+using Xunit;
+
+class TestClass
+{
+    [Theory]
+    void TestMethod(int used) => Assert.Equal(used, 2 + 2);
+}");
+
+            CheckDiagnostics(diagnostics);
         }
     }
 }

--- a/test/xunit.analyzers.tests/TheoryMethodMustUseAllParametersTests.cs
+++ b/test/xunit.analyzers.tests/TheoryMethodMustUseAllParametersTests.cs
@@ -152,5 +152,20 @@ class TestClass
 
             CheckDiagnostics(diagnostics);
         }
+
+        [Fact]
+        public async void DoesNotCrash_MethodWithoutBody()
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(Analyzer, @"
+using Xunit;
+
+class TestClass
+{
+    [Theory]
+    extern void TestMethod(int foo);
+}");
+
+            CheckDiagnostics(diagnostics);
+        }
     }
 }


### PR DESCRIPTION
Fixes xunit/xunit#1409 and adds regression tests. `MethodDeclarationSyntax.Body` is null when the method is expression-bodied.

/cc @marcind 