### PR TITLE
[WIP] Documentation for rules

### DIFF
--- a/docs/RULE_TEMPLATE.md
+++ b/docs/RULE_TEMPLATE.md
@@ -1,0 +1,51 @@
+## xUnit0000
+
+<table>
+<tr>
+  <td>Name</td>
+  <td>Rule name</td>
+</tr>
+<tr>
+  <td>ID</td>
+  <td>xUnit0000</td>
+</tr>
+<tr>
+  <td>Category</td>
+  <td>Diagnostic category</td>
+</tr>
+<tr>
+  <td>Severity</td>
+  <td>Hidden, Info, Warning, or Error</td>
+</tr>
+</table>
+
+## Cause
+
+A concise-as-possible description of when this rule is violated. If there's a lot to explain, begin with "A violation of this rule occurs when..." [example 1](xUnit1000.md#cause), [example 2](xUnit2004.md#cause)
+
+## Reason for rule
+
+Explain why the user should care if (s)he violates the rule. [example](xUnit1000.md#reason-for-rule)
+
+## Examples
+
+### Violates
+
+Example(s) of code that violates the rule. [example](xUnit1000.md#violates)
+
+### Does not violate
+
+Example(s) of code that does not violate the rule. [example](xUnit1000.md#does-not-violate)
+
+## How to fix violations
+
+To fix a violation of this rule, [describe how to fix a violation]. [example](xUnit1000.md#how-to-fix-violations)
+
+## How to suppress violations
+
+**If the severity of your analyzer isn't _Warning_, delete this section.**
+
+```csharp
+#pragma warning disable xUnit0000 // <Rule name>
+#pragma warning restore xUnit0000 // <Rule name>
+```

--- a/docs/xUnit1000.md
+++ b/docs/xUnit1000.md
@@ -1,0 +1,58 @@
+## xUnit1000
+
+<table>
+<tr>
+  <td>Name</td>
+  <td>TestClassMustBePublic</td>
+</tr>
+<tr>
+  <td>ID</td>
+  <td>xUnit1000</td>
+</tr>
+<tr>
+  <td>Category</td>
+  <td>Usage</td>
+</tr>
+<tr>
+  <td>Severity</td>
+  <td>Error</td>
+</tr>
+</table>
+
+## Cause
+
+A class containing test methods is not public.
+
+## Reason for rule
+
+xUnit will not run the test methods in a class if the class is not public.
+
+## Examples
+
+### Violates
+
+```csharp
+class TestClass
+{
+    [Fact]
+    public void TestMethod()
+    {
+    }
+}
+```
+
+### Does not violate
+
+```csharp
+public class TestClass
+{
+    [Fact]
+    public void TestMethod()
+    {
+    }
+}
+```
+
+## How to fix violations
+
+To fix a violation of this rule, make the test class public.

--- a/docs/xUnit2001.md
+++ b/docs/xUnit2001.md
@@ -1,0 +1,50 @@
+## xUnit2001
+
+<table>
+<tr>
+  <td>Name</td>
+  <td>AssertEqualsShouldNotBeUsed</td>
+</tr>
+<tr>
+  <td>ID</td>
+  <td>xUnit2001</td>
+</tr>
+<tr>
+  <td>Category</td>
+  <td>Assertions</td>
+</tr>
+<tr>
+  <td>Severity</td>
+  <td>Hidden</td>
+</tr>
+</table>
+
+## Cause
+
+`Assert.Equals` or `Assert.ReferenceEquals` is used.
+
+## Reason for rule
+
+`Assert.Equals` does not assert that two objects are equal; it exists only to hide the static `Equals` method inherited from `object`. It's a similar story for `Assert.ReferenceEquals`.
+
+## Examples
+
+### Violates
+
+```csharp
+var o = new object();
+Assert.Equals(o, o);
+Assert.ReferenceEquals(o, o);
+```
+
+### Does not violate
+
+```csharp
+var o = new object();
+Assert.Equal(o, o);
+Assert.Same(o, o);
+```
+
+## How to fix violations
+
+To fix a violation of this rule, use `Assert.Equal` instead of `Equals` and `Assert.Same` instead of `ReferenceEquals`.

--- a/docs/xUnit2004.md
+++ b/docs/xUnit2004.md
@@ -1,0 +1,66 @@
+## xUnit2004
+
+<table>
+<tr>
+  <td>Name</td>
+  <td>AssertEqualShouldNotBeUsedForBoolLiteralCheck</td>
+</tr>
+<tr>
+  <td>ID</td>
+  <td>xUnit2004</td>
+</tr>
+<tr>
+  <td>Category</td>
+  <td>Assertions</td>
+</tr>
+<tr>
+  <td>Severity</td>
+  <td>Warning</td>
+</tr>
+</table>
+
+## Cause
+
+A violation of this rule occurs when:
+
+- `Assert.Equal`, `Assert.NotEqual`, `Assert.StrictEqual`, or `Assert.NotStrictEqual` is used
+- The expected value is a `true` or `false` literal
+
+## Reason for rule
+
+It's more readable to use `Assert.True` or `Assert.False` instead.
+
+## Examples
+
+### Violates
+
+```csharp
+Assert.Equal(true, 2 + 2 == 4);
+Assert.Equal(false, 2 + 2 == 5);
+```
+
+### Does not violate
+
+```csharp
+Assert.True(2 + 2 == 4);
+Assert.False(2 + 2 == 5);
+```
+
+## How to fix violations
+
+### For `Equal` and `StrictEqual`
+
+- `Assert.{Strict}Equal(true, b)` => `Assert.True(b)`
+- `Assert.{Strict}Equal(false, b)` => `Assert.False(b)`
+
+### For `NotEqual` and `NotStrictEqual`
+
+- `Assert.Not{Strict}Equal(true, b)` => `Assert.False(b)`
+- `Assert.Not{Strict}Equal(false, b)` => `Assert.True(b)`
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable xUnit2004 // AssertEqualShouldNotBeUsedForBoolLiteralCheck
+#pragma warning restore xUnit2004 // AssertEqualShouldNotBeUsedForBoolLiteralCheck
+```


### PR DESCRIPTION
This PR begins the process of adding documentation for each rule. The docs are based off the StyleCopAnalyzers documentation here: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/tree/master/documentation, where each rule gets its own markdown file named after its ID. I'd like to get everyone's feedback before proceeding with further documentation, especially on the rule template.

Contributes to https://github.com/xunit/xunit/issues/1262

/cc @marcind, @ErikSchierboom 