### PR TITLE
Fixes false positives with public methods which are not allowed

### DIFF
--- a/src/xunit.analyzers.vsix/source.extension.vsixmanifest
+++ b/src/xunit.analyzers.vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="xunit.analyzers..d09124d1-9c5e-40de-b1de-35120196c3e0" Version="1.0.1" Language="en-US" Publisher="Marcin Dobosz"/>
+    <Identity Id="xunit.analyzers..d09124d1-9c5e-40de-b1de-35120196c3e0" Version="1.0" Language="en-US" Publisher="Marcin Dobosz"/>
     <DisplayName>xunit.analyzers</DisplayName>
     <Description xml:space="preserve">Code Analyzers for projects using xUnit.net that help find and fix frequent issues when writing tests.</Description>
   </Metadata>

--- a/src/xunit.analyzers.vsix/source.extension.vsixmanifest
+++ b/src/xunit.analyzers.vsix/source.extension.vsixmanifest
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="xunit.analyzers..d09124d1-9c5e-40de-b1de-35120196c3e0" Version="1.0.1" Language="en-US" Publisher="Marcin Dobosz"/>
-        <DisplayName>xunit.analyzers</DisplayName>
-        <Description xml:space="preserve">Code Analyzers for projects using xUnit.net that help find and fix frequent issues when writing tests.</Description>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.Community" />
-    </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    </Dependencies>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="xunit.analyzers" Path="|xunit.analyzers|"/>
-        <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="xunit.analyzers" Path="|xunit.analyzers|"/>
-    </Assets>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.26208.0,16.0)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
+  <Metadata>
+    <Identity Id="xunit.analyzers..d09124d1-9c5e-40de-b1de-35120196c3e0" Version="1.0.1" Language="en-US" Publisher="Marcin Dobosz"/>
+    <DisplayName>xunit.analyzers</DisplayName>
+    <Description xml:space="preserve">Code Analyzers for projects using xUnit.net that help find and fix frequent issues when writing tests.</Description>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.Community" />
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+  </Dependencies>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="xunit.analyzers" Path="|xunit.analyzers|"/>
+    <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="xunit.analyzers" Path="|xunit.analyzers|"/>
+  </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.26208.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/xunit.analyzers.vsix/source.extension.vsixmanifest
+++ b/src/xunit.analyzers.vsix/source.extension.vsixmanifest
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="xunit.analyzers..d09124d1-9c5e-40de-b1de-35120196c3e0" Version="1.0" Language="en-US" Publisher="Marcin Dobosz"/>
-    <DisplayName>xunit.analyzers</DisplayName>
-    <Description xml:space="preserve">Code Analyzers for projects using xUnit.net that help find and fix frequent issues when writing tests.</Description>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.Community" />
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-  </Dependencies>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="xunit.analyzers" Path="|xunit.analyzers|"/>
-    <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="xunit.analyzers" Path="|xunit.analyzers|"/>
-  </Assets>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.26208.0,16.0)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
+    <Metadata>
+        <Identity Id="xunit.analyzers..d09124d1-9c5e-40de-b1de-35120196c3e0" Version="1.0.1" Language="en-US" Publisher="Marcin Dobosz"/>
+        <DisplayName>xunit.analyzers</DisplayName>
+        <Description xml:space="preserve">Code Analyzers for projects using xUnit.net that help find and fix frequent issues when writing tests.</Description>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.Community" />
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    </Dependencies>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="xunit.analyzers" Path="|xunit.analyzers|"/>
+        <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="xunit.analyzers" Path="|xunit.analyzers|"/>
+    </Assets>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.26208.0,16.0)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
 </PackageManifest>

--- a/src/xunit.analyzers/PublicMethodShouldBeMarkedAsTest.cs
+++ b/src/xunit.analyzers/PublicMethodShouldBeMarkedAsTest.cs
@@ -26,7 +26,8 @@ namespace Xunit.Analyzers
                 var type = (INamedTypeSymbol)symbolContext.Symbol;
 
                 if (type.TypeKind != TypeKind.Class ||
-                    type.DeclaredAccessibility != Accessibility.Public)
+                    type.DeclaredAccessibility != Accessibility.Public ||
+                    type.IsAbstract)
                     return;
 
                 var methodsToIgnore = interfacesToIgnore.Where(i => i != null && type.AllInterfaces.Contains(i))
@@ -42,7 +43,7 @@ namespace Xunit.Analyzers
                     symbolContext.CancellationToken.ThrowIfCancellationRequested();
 
                     var method = (IMethodSymbol)member;
-                    if (method.MethodKind != MethodKind.Ordinary)
+                    if (method.MethodKind != MethodKind.Ordinary || method.IsStatic || method.IsAbstract)
                         continue;
 
                     var isTestMethod = method.GetAttributes().ContainsAttributeType(xunitContext.FactAttributeType);

--- a/src/xunit.analyzers/PublicMethodShouldBeMarkedAsTest.cs
+++ b/src/xunit.analyzers/PublicMethodShouldBeMarkedAsTest.cs
@@ -43,6 +43,10 @@ namespace Xunit.Analyzers
                     symbolContext.CancellationToken.ThrowIfCancellationRequested();
 
                     var method = (IMethodSymbol)member;
+                    // Check for method.IsAbstract and earlier for type.IsAbstract is done
+                    // twice to enable better diagnostics during code editing. It is useful with
+                    // incomplete code for abstract types - missing abstract keyword  on type
+                    // or on abstract method
                     if (method.MethodKind != MethodKind.Ordinary || method.IsAbstract)
                         continue;
 

--- a/src/xunit.analyzers/PublicMethodShouldBeMarkedAsTest.cs
+++ b/src/xunit.analyzers/PublicMethodShouldBeMarkedAsTest.cs
@@ -43,7 +43,7 @@ namespace Xunit.Analyzers
                     symbolContext.CancellationToken.ThrowIfCancellationRequested();
 
                     var method = (IMethodSymbol)member;
-                    if (method.MethodKind != MethodKind.Ordinary || method.IsStatic || method.IsAbstract)
+                    if (method.MethodKind != MethodKind.Ordinary || method.IsAbstract)
                         continue;
 
                     var isTestMethod = method.GetAttributes().ContainsAttributeType(xunitContext.FactAttributeType);

--- a/test/xunit.analyzers.tests/PublicMethodShouldBeMarkedAsTestTests.cs
+++ b/test/xunit.analyzers.tests/PublicMethodShouldBeMarkedAsTestTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Xunit.Analyzers
@@ -38,24 +39,11 @@ namespace Xunit.Analyzers
         }
 
         [Fact]
-        public async void DoesNotFindErrorForPublicStaticMethod()
-        {
-            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
-@"public class TestClass {
-    [Xunit.Fact] public void TestMethod() { }
-    public static void ItIsNotTest() { }
-}");
-
-            Assert.Empty(diagnostics);
-        }
-
-        [Fact]
         public async void DoesNotFindErrorForPublicAbstractMethod()
         {
             var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
 @"public abstract class TestClass {
     [Xunit.Fact] public void TestMethod() { }
-    public static void ItIsNotTest() { }
     public abstract void AbstractTestError();
 }");
 

--- a/test/xunit.analyzers.tests/PublicMethodShouldBeMarkedAsTestTests.cs
+++ b/test/xunit.analyzers.tests/PublicMethodShouldBeMarkedAsTestTests.cs
@@ -38,6 +38,31 @@ namespace Xunit.Analyzers
         }
 
         [Fact]
+        public async void DoesNotFindErrorForPublicStaticMethod()
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
+@"public class TestClass {
+    [Xunit.Fact] public void TestMethod() { }
+    public static void ItIsNotTest() { }
+}");
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async void DoesNotFindErrorForPublicAbstractMethod()
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
+@"public abstract class TestClass {
+    [Xunit.Fact] public void TestMethod() { }
+    public static void ItIsNotTest() { }
+    public abstract void AbstractTestError();
+}");
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
         public async void DoesNotFindErrorForIDisposableDisposeMethodOverrideFromParentClass()
         {
             var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,

--- a/test/xunit.analyzers.tests/PublicMethodShouldBeMarkedAsTestTests.cs
+++ b/test/xunit.analyzers.tests/PublicMethodShouldBeMarkedAsTestTests.cs
@@ -44,9 +44,20 @@ namespace Xunit.Analyzers
             var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
 @"public abstract class TestClass {
     [Xunit.Fact] public void TestMethod() { }
-    public abstract void AbstractTestError();
+    public abstract void AbstractMethod();
 }");
 
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async void DoesNotFindErrorForPublicAbstractMethodMarkedWithFact()
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
+@"public abstract class TestClass {
+    [Xunit.Fact] public void TestMethod() { }
+    [Xunit.Fact] public abstract void AbstractMethod();
+}");
             Assert.Empty(diagnostics);
         }
 


### PR DESCRIPTION
 as test methods in xunit: "public static" and "public abstract"

PublicMethodShouldBeMarkedAsTest greedily issues warning for 'public static' and 'public abstract'
methods although they can not be used as a test method in xunit framework. Introduced code changes
verify if public method is abstract or is static and if detected skip further checks.

Fixes https://github.com/xunit/xunit/issues/1466