### PR TITLE
Check whether first argument is an `int` in `AssertEqualShouldNotBeUsedForCollectionSizeCheck`

### DIFF
--- a/src/xunit.analyzers/AssertEqualShouldNotBeUsedForCollectionSizeCheck.cs
+++ b/src/xunit.analyzers/AssertEqualShouldNotBeUsedForCollectionSizeCheck.cs
@@ -35,8 +35,18 @@ namespace Xunit.Analyzers
                 return;
 
             var size = context.SemanticModel.GetConstantValue(invocation.ArgumentList.Arguments[0].Expression, context.CancellationToken);
+            if (!size.HasValue)
+            {
+                return;
+            }
 
-            if (!size.HasValue || (int)size.Value < 0 || (int)size.Value > 1 || (int)size.Value == 1 && method.Name != "Equal")
+            // Make sure the first parameter really is an int before checking it's value. Could for example be a char.
+            if (typeof(int) != size.Value.GetType())
+            {
+                return;
+            }
+
+            if ((int)size.Value < 0 || (int)size.Value > 1 || (int)size.Value == 1 && method.Name != "Equal")
                 return;
 
             var expression =

--- a/src/xunit.analyzers/AssertEqualShouldNotBeUsedForCollectionSizeCheck.cs
+++ b/src/xunit.analyzers/AssertEqualShouldNotBeUsedForCollectionSizeCheck.cs
@@ -40,7 +40,7 @@ namespace Xunit.Analyzers
                 return;
             }
 
-            // Make sure the first parameter really is an int before checking it's value. Could for example be a char.
+            // Make sure the first parameter really is an int before checking its value. Could for example be a char.
             if (typeof(int) != size.Value.GetType())
             {
                 return;

--- a/test/xunit.analyzers.tests/AssertEqualShouldNotBeUsedForCollectionSizeCheckTests.cs
+++ b/test/xunit.analyzers.tests/AssertEqualShouldNotBeUsedForCollectionSizeCheckTests.cs
@@ -181,5 +181,16 @@ class TestClass
 
             Assert.Empty(diagnostics);
         }
+
+        [Fact]
+        public async void DoesNotCrash_ForNonIntArguments()
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
+                @"class TestClass { void TestMethod() {
+            Xunit.Assert.Equal('b', new int[0].Length);
+        } }");
+
+            Assert.Empty(diagnostics);
+        }
     }
 }


### PR DESCRIPTION
- xunit/xunit#1502