### PR TITLE
Add some missing rule documentations

### DIFF
--- a/docs/_rules/xUnit2000.md
+++ b/docs/_rules/xUnit2000.md
@@ -5,37 +5,47 @@ category: Assertions
 severity: Warning
 ---
 
-# This is a documentation stub
-
-Please submit a PR with updates to the [appropriate file]({{ site.github.repository_url }}/tree/master/docs/{{ page.relative_path }}) or create an [issue](https://github.com/xunit/xunit/issues) if you see this.
-
 ## Cause
 
-A concise-as-possible description of when this rule is violated. If there's a lot to explain, begin with "A violation of this rule occurs when..."
+A violation of this rule occurs when the first argument to an assert is not the expected value.
 
 ## Reason for rule
 
-Explain why the user should care about the violation.
+The expected value in an assert should always be the first argument. This will ensure that generated messages explaining the test failure will correctly match the situation.
 
 ## How to fix violations
 
-To fix a violation of this rule, [describe how to fix a violation].
+To fix a violation of this rule, swap the arguments in the assert, so that the expected value is the first.
 
 ## Examples
 
 ### Violates
 
-Example(s) of code that violates the rule.
+```csharp
+[Fact]
+public void AdditionExample()
+{
+    var result = 2 + 3;
+
+    Assert.Equal(result, 5);
+}
+```
 
 ### Does not violate
 
-Example(s) of code that does not violate the rule.
+```csharp
+[Fact]
+public void AdditionExample()
+{
+    var result = 2 + 3;
+
+    Assert.Equal(5, result);
+}
+```
 
 ## How to suppress violations
 
-**If the severity of your analyzer isn't _Warning_, delete this section.**
-
 ```csharp
-#pragma warning disable xUnit0000 // <Rule name>
-#pragma warning restore xUnit0000 // <Rule name>
+#pragma warning disable xUnit2000 // Expected value should be first
+#pragma warning restore xUnit2000 // Expected value should be first
 ```

--- a/docs/_rules/xUnit2000.md
+++ b/docs/_rules/xUnit2000.md
@@ -7,15 +7,15 @@ severity: Warning
 
 ## Cause
 
-A violation of this rule occurs when the first argument to an assert is not the expected value.
+A violation of this rule occurs when the first argument to `Assert.Equal`, `AssertNotEqual`, `Assert.StrictEqual`, or `Assert.NotStrictEqual` is not the expected value.
 
 ## Reason for rule
 
-The expected value in an assert should always be the first argument. This will ensure that generated messages explaining the test failure will correctly match the situation.
+The expected value in equality assertions should always be the first argument. This will ensure that generated messages explaining the test failure will correctly match the situation.
 
 ## How to fix violations
 
-To fix a violation of this rule, swap the arguments in the assert, so that the expected value is the first.
+To fix a violation of this rule, swap the arguments in the assertion, so that the expected value is the first.
 
 ## Examples
 

--- a/docs/_rules/xUnit2002.md
+++ b/docs/_rules/xUnit2002.md
@@ -7,17 +7,15 @@ severity: Warning
 
 ## Cause
 
-A violation of this rule occurs when attempting to use `Assert.Null` or `Assert.NotNull` on a value type.
+A violation of this rule occurs when `Assert.Null` or `Assert.NotNull` are used on a value type.
 
 ## Reason for rule
 
-Value types, by definition, cannot be `null`. As such, it does not make sense to compare them to `null`.
+Value types cannot be `null`. As such, it does not make sense to compare them to `null`.
 
 ## How to fix violations
 
-To fix a violation of this rule, just remove the assert.
-
-Violations of this rule may also be a sign that the value was not actually be supposed to be a value type but a reference type.
+To fix a violation of this rule, either remove the assertion or change the object’s type to a reference type.
 
 ## Examples
 

--- a/docs/_rules/xUnit2002.md
+++ b/docs/_rules/xUnit2002.md
@@ -5,37 +5,50 @@ category: Assertions
 severity: Warning
 ---
 
-# This is a documentation stub
-
-Please submit a PR with updates to the [appropriate file]({{ site.github.repository_url }}/tree/master/docs/{{ page.relative_path }}) or create an [issue](https://github.com/xunit/xunit/issues) if you see this.
-
 ## Cause
 
-A concise-as-possible description of when this rule is violated. If there's a lot to explain, begin with "A violation of this rule occurs when..."
+A violation of this rule occurs when attempting to use `Assert.Null` or `Assert.NotNull` on a value type.
 
 ## Reason for rule
 
-Explain why the user should care about the violation.
+Value types, by definition, cannot be `null`. As such, it does not make sense to compare them to `null`.
 
 ## How to fix violations
 
-To fix a violation of this rule, [describe how to fix a violation].
+To fix a violation of this rule, just remove the assert.
+
+Violations of this rule may also be a sign that the value was not actually be supposed to be a value type but a reference type.
 
 ## Examples
 
 ### Violates
 
-Example(s) of code that violates the rule.
+```csharp
+[Fact]
+public void ExampleTest()
+{
+    int result = GetSomeValue();
+
+    Assert.Null(result);
+    Assert.True(result > 4);
+}
+```
 
 ### Does not violate
 
-Example(s) of code that does not violate the rule.
+```csharp
+[Fact]
+public void ExampleTest()
+{
+    int result = GetSomeValue();
+
+    Assert.True(result > 4);
+}
+```
 
 ## How to suppress violations
 
-**If the severity of your analyzer isn't _Warning_, delete this section.**
-
 ```csharp
-#pragma warning disable xUnit0000 // <Rule name>
-#pragma warning restore xUnit0000 // <Rule name>
+#pragma warning disable xUnit2002 // Do not use null check on value type
+#pragma warning restore xUnit2002 // Do not use null check on value type
 ```

--- a/docs/_rules/xUnit2003.md
+++ b/docs/_rules/xUnit2003.md
@@ -5,37 +5,47 @@ category: Assertions
 severity: Warning
 ---
 
-# This is a documentation stub
-
-Please submit a PR with updates to the [appropriate file]({{ site.github.repository_url }}/tree/master/docs/{{ page.relative_path }}) or create an [issue](https://github.com/xunit/xunit/issues) if you see this.
-
 ## Cause
 
-A concise-as-possible description of when this rule is violated. If there's a lot to explain, begin with "A violation of this rule occurs when..."
+A violation of this rule occurs when using equality asserts like `Assert.Equal()` or `Assert.NotEqual` with `null`.
 
 ## Reason for rule
 
-Explain why the user should care about the violation.
+`Assert.Null` and `Assert.NotNull` are preferred when checking against `null`.
 
 ## How to fix violations
 
-To fix a violation of this rule, [describe how to fix a violation].
+To fix a violation of this rule, replace the offending asserts by `Assert.Null` or `Assert.NotNull`.
 
 ## Examples
 
 ### Violates
 
-Example(s) of code that violates the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    string result = GetSomeValue();
+
+    Assert.NotEqual(null, result);
+}
+```
 
 ### Does not violate
 
-Example(s) of code that does not violate the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    string result = GetSomeValue();
+
+    Assert.NotNull(result);
+}
+```
 
 ## How to suppress violations
 
-**If the severity of your analyzer isn't _Warning_, delete this section.**
-
 ```csharp
-#pragma warning disable xUnit0000 // <Rule name>
-#pragma warning restore xUnit0000 // <Rule name>
+#pragma warning disable xUnit2003 // Do not use equality check to test for null value
+#pragma warning restore xUnit2003 // Do not use equality check to test for null value
 ```

--- a/docs/_rules/xUnit2003.md
+++ b/docs/_rules/xUnit2003.md
@@ -7,15 +7,15 @@ severity: Warning
 
 ## Cause
 
-A violation of this rule occurs when using equality asserts like `Assert.Equal()` or `Assert.NotEqual` with `null`.
+A violation of this rule occurs when `Assert.Equal`, `AssertNotEqual`, `Assert.StrictEqual`, or `Assert.NotStrictEqual` are used with `null`.
 
 ## Reason for rule
 
-`Assert.Null` and `Assert.NotNull` are preferred when checking against `null`.
+`Assert.Null` and `Assert.NotNull` should be used when checking against `null`.
 
 ## How to fix violations
 
-To fix a violation of this rule, replace the offending asserts by `Assert.Null` or `Assert.NotNull`.
+To fix a violation of this rule, replace the offending asserts with `Assert.Null` or `Assert.NotNull`.
 
 ## Examples
 
@@ -28,6 +28,7 @@ public void ExampleMethod()
     string result = GetSomeValue();
 
     Assert.NotEqual(null, result);
+    Assert.Equal(null, result);
 }
 ```
 
@@ -40,6 +41,7 @@ public void ExampleMethod()
     string result = GetSomeValue();
 
     Assert.NotNull(result);
+    Assert.Null(result);
 }
 ```
 

--- a/docs/_rules/xUnit2005.md
+++ b/docs/_rules/xUnit2005.md
@@ -5,37 +5,47 @@ category: Assertions
 severity: Warning
 ---
 
-# This is a documentation stub
-
-Please submit a PR with updates to the [appropriate file]({{ site.github.repository_url }}/tree/master/docs/{{ page.relative_path }}) or create an [issue](https://github.com/xunit/xunit/issues) if you see this.
-
 ## Cause
 
-A concise-as-possible description of when this rule is violated. If there's a lot to explain, begin with "A violation of this rule occurs when..."
+A violation of this rule occurs when comparing two value type objects using `Assert.Same` or `Assert.NotSame`.
 
 ## Reason for rule
 
-Explain why the user should care about the violation.
+`Assert.Same` and `Assert.NotSame` will use [`Object.ReferenceEquals`](https://msdn.microsoft.com/en-us/library/system.object.referenceequals.aspx) for the comparison. This check will always fail for value types since the compared value type objects will be boxed before they are being passed to the method which will always create two unequal references. As such, comparing value types based on their identity does not make any sense.
 
 ## How to fix violations
 
-To fix a violation of this rule, [describe how to fix a violation].
+To fix a violation of this rule, use `Assert.Equal` or `Assert.NotEqual` instead.
 
 ## Examples
 
 ### Violates
 
-Example(s) of code that violates the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    DateTime result = GetDateResult();
+
+    Assert.Same(new DateTime(2017, 01, 01), result);
+}
+```
 
 ### Does not violate
 
-Example(s) of code that does not violate the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    DateTime result = GetDateResult();
+
+    Assert.Equal(new DateTime(2017, 01, 01), result);
+}
+```
 
 ## How to suppress violations
 
-**If the severity of your analyzer isn't _Warning_, delete this section.**
-
 ```csharp
-#pragma warning disable xUnit0000 // <Rule name>
-#pragma warning restore xUnit0000 // <Rule name>
+#pragma warning disable xUnit2005 // Do not use identity check on value type
+#pragma warning restore xUnit2005 // Do not use identity check on value type
 ```

--- a/docs/_rules/xUnit2005.md
+++ b/docs/_rules/xUnit2005.md
@@ -7,11 +7,11 @@ severity: Warning
 
 ## Cause
 
-A violation of this rule occurs when comparing two value type objects using `Assert.Same` or `Assert.NotSame`.
+A violation of this rule occurs when two value type objects are compared using `Assert.Same` or `Assert.NotSame`.
 
 ## Reason for rule
 
-`Assert.Same` and `Assert.NotSame` will use [`Object.ReferenceEquals`](https://msdn.microsoft.com/en-us/library/system.object.referenceequals.aspx) for the comparison. This check will always fail for value types since the compared value type objects will be boxed before they are being passed to the method which will always create two unequal references. As such, comparing value types based on their identity does not make any sense.
+`Assert.Same` and `Assert.NotSame` both use [`Object.ReferenceEquals`](https://msdn.microsoft.com/en-us/library/system.object.referenceequals.aspx) to compare objects. This always fails for value types since the values will be boxed before they are passed to the method, creating two different references.
 
 ## How to fix violations
 

--- a/docs/_rules/xUnit2006.md
+++ b/docs/_rules/xUnit2006.md
@@ -7,7 +7,7 @@ severity: Warning
 
 ## Cause
 
-A violation of this rule occurs when using the generic overload of `Assert.Equal` or `Assert.StrictEqual` with `string`.
+A violation of this rule occurs when the generic overloads of `Assert.Equal` or `Assert.StrictEqual` are used with `string`.
 
 ## Reason for rule
 

--- a/docs/_rules/xUnit2006.md
+++ b/docs/_rules/xUnit2006.md
@@ -5,37 +5,47 @@ category: Assertions
 severity: Warning
 ---
 
-# This is a documentation stub
-
-Please submit a PR with updates to the [appropriate file]({{ site.github.repository_url }}/tree/master/docs/{{ page.relative_path }}) or create an [issue](https://github.com/xunit/xunit/issues) if you see this.
-
 ## Cause
 
-A concise-as-possible description of when this rule is violated. If there's a lot to explain, begin with "A violation of this rule occurs when..."
+A violation of this rule occurs when using the generic overload of `Assert.Equal` or `Assert.StrictEqual` with `string`.
 
 ## Reason for rule
 
-Explain why the user should care about the violation.
+There is an optimized overload of both `Assert.Equal` and `Assert.StrictEqual` for `string` arguments.
 
 ## How to fix violations
 
-To fix a violation of this rule, [describe how to fix a violation].
+To fix a violation of this rule, remove the generic argument to use the `string` overload.
 
 ## Examples
 
 ### Violates
 
-Example(s) of code that violates the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    string result = "foo";
+
+    Assert.Equal<string>("foo", result);
+}
+```
 
 ### Does not violate
 
-Example(s) of code that does not violate the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    string result = "foo";
+
+    Assert.Equal("foo", result);
+}
+```
 
 ## How to suppress violations
 
-**If the severity of your analyzer isn't _Warning_, delete this section.**
-
 ```csharp
-#pragma warning disable xUnit0000 // <Rule name>
-#pragma warning restore xUnit0000 // <Rule name>
+#pragma warning disable xUnit2006 // Do not use invalid string equality check
+#pragma warning restore xUnit2006 // Do not use invalid string equality check
 ```

--- a/docs/_rules/xUnit2007.md
+++ b/docs/_rules/xUnit2007.md
@@ -5,37 +5,47 @@ category: Assertions
 severity: Warning
 ---
 
-# This is a documentation stub
-
-Please submit a PR with updates to the [appropriate file]({{ site.github.repository_url }}/tree/master/docs/{{ page.relative_path }}) or create an [issue](https://github.com/xunit/xunit/issues) if you see this.
-
 ## Cause
 
-A concise-as-possible description of when this rule is violated. If there's a lot to explain, begin with "A violation of this rule occurs when..."
+A violation of this rule occurs when using the `typeof` operator with a type checking assert.
 
 ## Reason for rule
 
-Explain why the user should care about the violation.
+When the expected type is known at compile-time, the generic overload should be used to check against types.
 
 ## How to fix violations
 
-To fix a violation of this rule, [describe how to fix a violation].
+Use the generic overload of `Assert.IsType`, `Assert.IsNotType`, and `Assert.IsAssignableFrom`.
 
 ## Examples
 
 ### Violates
 
-Example(s) of code that violates the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    string result = "foo bar baz";
+
+    Assert.IsType(typeof(string), result.GetType());
+}
+```
 
 ### Does not violate
 
-Example(s) of code that does not violate the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    string result = "foo bar baz";
+
+    Assert.IsType<string>(result.GetType());
+}
+```
 
 ## How to suppress violations
 
-**If the severity of your analyzer isn't _Warning_, delete this section.**
-
 ```csharp
-#pragma warning disable xUnit0000 // <Rule name>
-#pragma warning restore xUnit0000 // <Rule name>
+#pragma warning disable xUnit2007 // Do not use typeof expression to check the type
+#pragma warning restore xUnit2007 // Do not use typeof expression to check the type
 ```

--- a/docs/_rules/xUnit2007.md
+++ b/docs/_rules/xUnit2007.md
@@ -7,15 +7,15 @@ severity: Warning
 
 ## Cause
 
-A violation of this rule occurs when using the `typeof` operator with a type checking assert.
+A violation of this rule occurs when the `typeof` operator is used with a type checking assert.
 
 ## Reason for rule
 
-When the expected type is known at compile-time, the generic overload should be used to check against types.
+When the expected type is known at compile-time, the generic overload should be used.
 
 ## How to fix violations
 
-Use the generic overload of `Assert.IsType`, `Assert.IsNotType`, and `Assert.IsAssignableFrom`.
+Use the generic overload of `Assert.IsType`, `Assert.IsNotType`, or `Assert.IsAssignableFrom`.
 
 ## Examples
 
@@ -27,7 +27,7 @@ public void ExampleMethod()
 {
     string result = "foo bar baz";
 
-    Assert.IsType(typeof(string), result.GetType());
+    Assert.IsType(typeof(string), result);
 }
 ```
 
@@ -39,7 +39,7 @@ public void ExampleMethod()
 {
     string result = "foo bar baz";
 
-    Assert.IsType<string>(result.GetType());
+    Assert.IsType<string>(result);
 }
 ```
 

--- a/docs/_rules/xUnit2008.md
+++ b/docs/_rules/xUnit2008.md
@@ -5,37 +5,49 @@ category: Assertions
 severity: Warning
 ---
 
-# This is a documentation stub
-
-Please submit a PR with updates to the [appropriate file]({{ site.github.repository_url }}/tree/master/docs/{{ page.relative_path }}) or create an [issue](https://github.com/xunit/xunit/issues) if you see this.
-
 ## Cause
 
-A concise-as-possible description of when this rule is violated. If there's a lot to explain, begin with "A violation of this rule occurs when..."
+A violation of this rule occurs when using `Assert.True` or `Assert.False` to check for regular expression matches.
 
 ## Reason for rule
 
-Explain why the user should care about the violation.
+There are specialized assert methods for regular expression matching.
 
 ## How to fix violations
 
-To fix a violation of this rule, [describe how to fix a violation].
+Replace the uses by `Assert.Matches` or `Assert.DoesNotMatch`.
 
 ## Examples
 
 ### Violates
 
-Example(s) of code that violates the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    string result = "foo bar baz";
+
+    Assert.True(Regex.IsMatch(result, "foo (.*?) baz"));
+    Assert.False(Regex.IsMatch(result, "hello (.*?)"));
+}
+```
 
 ### Does not violate
 
-Example(s) of code that does not violate the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    string result = "foo bar baz";
+
+    Assert.Matches("foo (.*?) baz", result);
+    Assert.DoesNotMatch("hello (.*?)", result);
+}
+```
 
 ## How to suppress violations
 
-**If the severity of your analyzer isn't _Warning_, delete this section.**
-
 ```csharp
-#pragma warning disable xUnit0000 // <Rule name>
-#pragma warning restore xUnit0000 // <Rule name>
+#pragma warning disable xUnit2008 // Do not use boolean check to match on regular expressions
+#pragma warning restore xUnit2008 // Do not use boolean check to match on regular expressions
 ```

--- a/docs/_rules/xUnit2008.md
+++ b/docs/_rules/xUnit2008.md
@@ -7,15 +7,15 @@ severity: Warning
 
 ## Cause
 
-A violation of this rule occurs when using `Assert.True` or `Assert.False` to check for regular expression matches.
+A violation of this rule occurs when `Assert.True` or `Assert.False` are used to check for regular expression matches.
 
 ## Reason for rule
 
-There are specialized assert methods for regular expression matching.
+There are specialized assertions for regular expression matching that give more detailed information upon failure.
 
 ## How to fix violations
 
-Replace the uses by `Assert.Matches` or `Assert.DoesNotMatch`.
+Replace the assertions with `Assert.Matches` or `Assert.DoesNotMatch`.
 
 ## Examples
 

--- a/docs/_rules/xUnit2009.md
+++ b/docs/_rules/xUnit2009.md
@@ -7,13 +7,15 @@ severity: Warning
 
 ## Cause
 
-A violation of this rule occurs when using `Assert.True` or `Assert.False` to check for substrings with string methods like `string.Contains`, `string.StartsWith` and `string.EndsWith`.
+A violation of this rule occurs when `Assert.True` or `Assert.False` are used to check for substrings with string methods like `string.Contains`, `string.StartsWith` and `string.EndsWith`.
 
 ## Reason for rule
 
-There are specialized assert methods for substring checks.
+There are specialized assertions for substring checks.
 
 ## How to fix violations
+
+To fix a violation of this rule, replace the offending assertion according to this:
 
 - `Assert.True(str.Contains(word))` => `Assert.Contains(word, str)`
 - `Assert.False(str.Contains(word))` => `Assert.DoesNotContain(word, str)`

--- a/docs/_rules/xUnit2009.md
+++ b/docs/_rules/xUnit2009.md
@@ -5,37 +5,52 @@ category: Assertions
 severity: Warning
 ---
 
-# This is a documentation stub
-
-Please submit a PR with updates to the [appropriate file]({{ site.github.repository_url }}/tree/master/docs/{{ page.relative_path }}) or create an [issue](https://github.com/xunit/xunit/issues) if you see this.
-
 ## Cause
 
-A concise-as-possible description of when this rule is violated. If there's a lot to explain, begin with "A violation of this rule occurs when..."
+A violation of this rule occurs when using `Assert.True` or `Assert.False` to check for substrings with string methods like `string.Contains`, `string.StartsWith` and `string.EndsWith`.
 
 ## Reason for rule
 
-Explain why the user should care about the violation.
+There are specialized assert methods for substring checks.
 
 ## How to fix violations
 
-To fix a violation of this rule, [describe how to fix a violation].
+- `Assert.True(str.Contains(word))` => `Assert.Contains(word, str)`
+- `Assert.False(str.Contains(word))` => `Assert.DoesNotContain(word, str)`
+- `Assert.True(str.StartsWith(word))` => `Assert.StartsWith(word, str)`
+- `Assert.True(str.EndsWith(word))` => `Assert.EndsWith(word, str)`
 
 ## Examples
 
 ### Violates
 
-Example(s) of code that violates the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    string result = "foo bar baz";
+
+    Assert.True(result.Contains("bar"));
+    Assert.True(result.StartsWith("foo"));
+}
+```
 
 ### Does not violate
 
-Example(s) of code that does not violate the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    string result = "foo bar baz";
+
+    Assert.Contains("bar", result);
+    Assert.StartsWith("foo", result);
+}
+```
 
 ## How to suppress violations
 
-**If the severity of your analyzer isn't _Warning_, delete this section.**
-
 ```csharp
-#pragma warning disable xUnit0000 // <Rule name>
-#pragma warning restore xUnit0000 // <Rule name>
+#pragma warning disable xUnit2009 // Do not use boolean check to check for substrings
+#pragma warning restore xUnit2009 // Do not use boolean check to check for substrings
 ```

--- a/docs/_rules/xUnit2010.md
+++ b/docs/_rules/xUnit2010.md
@@ -5,37 +5,49 @@ category: Assertions
 severity: Warning
 ---
 
-# This is a documentation stub
-
-Please submit a PR with updates to the [appropriate file]({{ site.github.repository_url }}/tree/master/docs/{{ page.relative_path }}) or create an [issue](https://github.com/xunit/xunit/issues) if you see this.
-
 ## Cause
 
-A concise-as-possible description of when this rule is violated. If there's a lot to explain, begin with "A violation of this rule occurs when..."
+A violation of this rule occurs when using `Assert.True` or `Assert.False` to check for string equality with `string.Equals`.
 
 ## Reason for rule
 
-Explain why the user should care about the violation.
+There are specialized assert methods for equality checks.
 
 ## How to fix violations
 
-To fix a violation of this rule, [describe how to fix a violation].
+Use `Assert.Equal` or `Assert.NotEqual` to check for string equality.
 
 ## Examples
 
 ### Violates
 
-Example(s) of code that violates the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    string result = "foo bar baz";
+
+    Assert.True(string.Equals("foo bar baz", result));
+    Assert.False(string.Equals("hello world", result));
+}
+```
 
 ### Does not violate
 
-Example(s) of code that does not violate the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    string result = "foo bar baz";
+
+    Assert.Equal("foo bar baz", result);
+    Assert.NotEqual("hello world", result);
+}
+```
 
 ## How to suppress violations
 
-**If the severity of your analyzer isn't _Warning_, delete this section.**
-
 ```csharp
-#pragma warning disable xUnit0000 // <Rule name>
-#pragma warning restore xUnit0000 // <Rule name>
+#pragma warning disable xUnit2010 // Do not use boolean check to check for string equality
+#pragma warning restore xUnit2010 // Do not use boolean check to check for string equality
 ```

--- a/docs/_rules/xUnit2010.md
+++ b/docs/_rules/xUnit2010.md
@@ -7,15 +7,15 @@ severity: Warning
 
 ## Cause
 
-A violation of this rule occurs when using `Assert.True` or `Assert.False` to check for string equality with `string.Equals`.
+A violation of this rule occurs when `Assert.True` or `Assert.False` are used with `string.Equals` to check if two strings are equal.
 
 ## Reason for rule
 
-There are specialized assert methods for equality checks.
+`Assert.Equal` or `Assert.Equal` should be used because they give more detailed information upon failure.
 
 ## How to fix violations
 
-Use `Assert.Equal` or `Assert.NotEqual` to check for string equality.
+Replace the assertions with `Assert.Equal` or `Assert.NotEqual`.
 
 ## Examples
 

--- a/docs/_rules/xUnit2011.md
+++ b/docs/_rules/xUnit2011.md
@@ -5,37 +5,47 @@ category: Assertions
 severity: Warning
 ---
 
-# This is a documentation stub
-
-Please submit a PR with updates to the [appropriate file]({{ site.github.repository_url }}/tree/master/docs/{{ page.relative_path }}) or create an [issue](https://github.com/xunit/xunit/issues) if you see this.
-
 ## Cause
 
-A concise-as-possible description of when this rule is violated. If there's a lot to explain, begin with "A violation of this rule occurs when..."
+A violation of this rule occurs when using `Assert.Collection` without element inspectors to check for an empty collection.
 
 ## Reason for rule
 
-Explain why the user should care about the violation.
+There are specialized assert methods for checking collection sizes.
 
 ## How to fix violations
 
-To fix a violation of this rule, [describe how to fix a violation].
+Use `Assert.Empty` instead.
 
 ## Examples
 
 ### Violates
 
-Example(s) of code that violates the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    IEnumerable<string> result = GetItems();
+
+    Assert.Collection(result);
+}
+```
 
 ### Does not violate
 
-Example(s) of code that does not violate the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    IEnumerable<string> result = GetItems();
+
+    Assert.Empty(result);
+}
+```
 
 ## How to suppress violations
 
-**If the severity of your analyzer isn't _Warning_, delete this section.**
-
 ```csharp
-#pragma warning disable xUnit0000 // <Rule name>
-#pragma warning restore xUnit0000 // <Rule name>
+#pragma warning disable xUnit2011 // Do not use empty collection check
+#pragma warning restore xUnit2011 // Do not use empty collection check
 ```

--- a/docs/_rules/xUnit2011.md
+++ b/docs/_rules/xUnit2011.md
@@ -7,11 +7,11 @@ severity: Warning
 
 ## Cause
 
-A violation of this rule occurs when using `Assert.Collection` without element inspectors to check for an empty collection.
+A violation of this rule occurs when `Assert.Collection` is used without element inspectors to check for an empty collection.
 
 ## Reason for rule
 
-There are specialized assert methods for checking collection sizes.
+There are specialized assertions for checking collection sizes.
 
 ## How to fix violations
 

--- a/docs/_rules/xUnit2012.md
+++ b/docs/_rules/xUnit2012.md
@@ -5,37 +5,49 @@ category: Assertions
 severity: Warning
 ---
 
-# This is a documentation stub
-
-Please submit a PR with updates to the [appropriate file]({{ site.github.repository_url }}/tree/master/docs/{{ page.relative_path }}) or create an [issue](https://github.com/xunit/xunit/issues) if you see this.
-
 ## Cause
 
-A concise-as-possible description of when this rule is violated. If there's a lot to explain, begin with "A violation of this rule occurs when..."
+A violation of this rule occurs when using `Enumerable.Any()` to check if a value exists in a collection.
 
 ## Reason for rule
 
-Explain why the user should care about the violation.
+There are specialized assert methods for checking for elements in collections.
 
 ## How to fix violations
 
-To fix a violation of this rule, [describe how to fix a violation].
+Use `Assert.Contains` and `Assert.DoesNotContain` instead.
 
 ## Examples
 
 ### Violates
 
-Example(s) of code that violates the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    IEnumerable<string> result = GetItems();
+
+    Assert.True(result.Any(x => x == "foo"));
+    Assert.False(result.Any(x => x == "bar"));
+}
+```
 
 ### Does not violate
 
-Example(s) of code that does not violate the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    IEnumerable<string> result = GetItems();
+
+    Assert.Contains(result, x => x == "foo");
+    Assert.DoesNotContain(result, x => x == "bar");
+}
+```
 
 ## How to suppress violations
 
-**If the severity of your analyzer isn't _Warning_, delete this section.**
-
 ```csharp
-#pragma warning disable xUnit0000 // <Rule name>
-#pragma warning restore xUnit0000 // <Rule name>
+#pragma warning disable xUnit2012 // Do not use Enumerable.Any() to check if a value exists in a collection
+#pragma warning restore xUnit2012 // Do not use Enumerable.Any() to check if a value exists in a collection
 ```

--- a/docs/_rules/xUnit2012.md
+++ b/docs/_rules/xUnit2012.md
@@ -7,15 +7,15 @@ severity: Warning
 
 ## Cause
 
-A violation of this rule occurs when using `Enumerable.Any()` to check if a value exists in a collection.
+A violation of this rule occurs when `Enumerable.Any` is used to check if a value matching a predicate exists in a collection.
 
 ## Reason for rule
 
-There are specialized assert methods for checking for elements in collections.
+There are specialized assertions for checking for elements in collections.
 
 ## How to fix violations
 
-Use `Assert.Contains` and `Assert.DoesNotContain` instead.
+Use `Assert.Contains` or `Assert.DoesNotContain` instead.
 
 ## Examples
 

--- a/docs/_rules/xUnit2013.md
+++ b/docs/_rules/xUnit2013.md
@@ -7,15 +7,15 @@ severity: Warning
 
 ## Cause
 
-A violation of this rule occurs when using `Assert.Equals` to check for the specific collection sizes.
+A violation of this rule occurs when `Assert.Equals` or `Assert.NotEquals` are used to check if a collection has 0 or 1 elements.
 
 ## Reason for rule
 
-There are specialized assert methods for checking collection sizes.
+There are specialized assertions for checking collection sizes.
 
 ## How to fix violations
 
-Use `Assert.Empty`, `Assert.NotEmpty`, and `Assert.Single` instead.
+Use `Assert.Empty`, `Assert.NotEmpty`, or `Assert.Single` instead.
 
 ## Examples
 

--- a/docs/_rules/xUnit2013.md
+++ b/docs/_rules/xUnit2013.md
@@ -5,37 +5,51 @@ category: Assertions
 severity: Warning
 ---
 
-# This is a documentation stub
-
-Please submit a PR with updates to the [appropriate file]({{ site.github.repository_url }}/tree/master/docs/{{ page.relative_path }}) or create an [issue](https://github.com/xunit/xunit/issues) if you see this.
-
 ## Cause
 
-A concise-as-possible description of when this rule is violated. If there's a lot to explain, begin with "A violation of this rule occurs when..."
+A violation of this rule occurs when using `Assert.Equals` to check for the specific collection sizes.
 
 ## Reason for rule
 
-Explain why the user should care about the violation.
+There are specialized assert methods for checking collection sizes.
 
 ## How to fix violations
 
-To fix a violation of this rule, [describe how to fix a violation].
+Use `Assert.Empty`, `Assert.NotEmpty`, and `Assert.Single` instead.
 
 ## Examples
 
 ### Violates
 
-Example(s) of code that violates the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    IEnumerable<string> result = GetItems();
+
+    Assert.Equal(1, result.Count());
+    Assert.Equal(0, result.Count());
+    Assert.NotEqual(0, result.Count());
+}
+```
 
 ### Does not violate
 
-Example(s) of code that does not violate the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    IEnumerable<string> result = GetItems();
+
+    Assert.Single(result);
+    Assert.Empty(result);
+    Assert.NotEmpty(result);
+}
+```
 
 ## How to suppress violations
 
-**If the severity of your analyzer isn't _Warning_, delete this section.**
-
 ```csharp
-#pragma warning disable xUnit0000 // <Rule name>
-#pragma warning restore xUnit0000 // <Rule name>
+#pragma warning disable xUnit2013 // Do not use equality check to check for collection size.
+#pragma warning restore xUnit2013 // Do not use equality check to check for collection size.
 ```

--- a/docs/_rules/xUnit2017.md
+++ b/docs/_rules/xUnit2017.md
@@ -7,15 +7,15 @@ severity: Warning
 
 ## Cause
 
-A violation of this rule occurs when using `Enumerable.Contains()` to check if a value exists in a collection.
+A violation of this rule occurs when `Enumerable.Contains()` is used to check if a value exists in a collection.
 
 ## Reason for rule
 
-There are specialized assert methods for checking for elements in collections.
+There are specialized assertions for checking for elements in collections.
 
 ## How to fix violations
 
-Use `Assert.Contains` and `Assert.DoesNotContain` instead.
+Use `Assert.Contains` or `Assert.DoesNotContain` instead.
 
 ## Examples
 

--- a/docs/_rules/xUnit2017.md
+++ b/docs/_rules/xUnit2017.md
@@ -5,37 +5,49 @@ category: Assertions
 severity: Warning
 ---
 
-# This is a documentation stub
-
-Please submit a PR with updates to the [appropriate file]({{ site.github.repository_url }}/tree/master/docs/{{ page.relative_path }}) or create an [issue](https://github.com/xunit/xunit/issues) if you see this.
-
 ## Cause
 
-A concise-as-possible description of when this rule is violated. If there's a lot to explain, begin with "A violation of this rule occurs when..."
+A violation of this rule occurs when using `Enumerable.Contains()` to check if a value exists in a collection.
 
 ## Reason for rule
 
-Explain why the user should care about the violation.
+There are specialized assert methods for checking for elements in collections.
 
 ## How to fix violations
 
-To fix a violation of this rule, [describe how to fix a violation].
+Use `Assert.Contains` and `Assert.DoesNotContain` instead.
 
 ## Examples
 
 ### Violates
 
-Example(s) of code that violates the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    IEnumerable<string> result = GetItems();
+
+    Assert.True(result.Contains("foo"));
+    Assert.False(result.Contains("bar"));
+}
+```
 
 ### Does not violate
 
-Example(s) of code that does not violate the rule.
+```csharp
+[Fact]
+public void ExampleMethod()
+{
+    IEnumerable<string> result = GetItems();
+
+    Assert.Contains("foo", result);
+    Assert.DoesNotContain("bar", result);
+}
+```
 
 ## How to suppress violations
 
-**If the severity of your analyzer isn't _Warning_, delete this section.**
-
 ```csharp
-#pragma warning disable xUnit0000 // <Rule name>
-#pragma warning restore xUnit0000 // <Rule name>
+#pragma warning disable xUnit2017 // Do not use Contains() to check if a value exists in a collection
+#pragma warning restore xUnit2017 // Do not use Contains() to check if a value exists in a collection
 ```


### PR DESCRIPTION
I’ve added the rule documentations for most 20xx rules. I wasn’t always sure with the reasoning (and also got a bit lazy in the end) and the wording is probably also not perfect but at least there’s content.