### PR TITLE
Docs: xUnit -> xUnit.net in various places.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ To build the project, you will need Visual Studio 2017. The VSIX project can be 
 
 ### How to install
 
-- xUnit 2.3.0 and higher: the analyzer package is referenced by the main [`xunit` NuGet package](https://www.nuget.org/packages/xunit) out of the box
+- xUnit.net 2.3.0 and higher: the analyzer package is referenced by the main [`xunit` NuGet package](https://www.nuget.org/packages/xunit) out of the box
 
-- xUnit 2.2.0 and earlier: you have to install the [`xunit.analyzers` NuGet package](https://www.nuget.org/packages/xunit.analyzers) explicitly
+- xUnit.net 2.2.0 and earlier: you have to install the [`xunit.analyzers` NuGet package](https://www.nuget.org/packages/xunit.analyzers) explicitly
 
 ### How to uninstall
 
-If you installed xUnit 2.3.0 or higher and do not wish to use the analyzers package, replace the package reference to [`xunit`](https://www.nuget.org/packages/xunit) with the correspoding versions of [`xunit.core` ](https://www.nuget.org/packages/xunit.core) and [`xunit.assert`](https://www.nuget.org/packages/xunit.assert)
+If you installed xUnit.net 2.3.0 or higher and do not wish to use the analyzers package, replace the package reference to [`xunit`](https://www.nuget.org/packages/xunit) with the correspoding versions of [`xunit.core` ](https://www.nuget.org/packages/xunit.core) and [`xunit.assert`](https://www.nuget.org/packages/xunit.assert)
 
 ## Analysis and Code Fix in Action
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -39,7 +39,7 @@
 
     <h6>
       Copyright &copy; 2017 .NET Foundation. Contributions welcomed at
-      <a href="https://github.com/xunit/xunit.analyzers" title="xUnit Analzyers GitHub repository">https://github.com/xunit/xunit.analyzers</a>.
+      <a href="https://github.com/xunit/xunit.analyzers" title="xUnit.net Analyzers GitHub repository">https://github.com/xunit/xunit.analyzers</a>.
     </h6>
   </div>
 

--- a/docs/_rules/xUnit1000.md
+++ b/docs/_rules/xUnit1000.md
@@ -11,7 +11,7 @@ A class containing test methods is not public.
 
 ## Reason for rule
 
-xUnit will not run the test methods in a class if the class is not public.
+xUnit.net will not run the test methods in a class if the class is not public.
 
 ## How to fix violations
 

--- a/src/xunit.analyzers/Descriptors.cs
+++ b/src/xunit.analyzers/Descriptors.cs
@@ -77,7 +77,7 @@ namespace Xunit.Analyzers
         internal static DiagnosticDescriptor X1012_InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameter { get; } =
             Rule("xUnit1012", "Null should not be used for value type parameters", Usage, Warning,
                 "Null should not be used for value type parameter '{0}' of type '{1}'.",
-            description: "XUnit will execute the theory initializing the parameter to the default value of the type, which might not be the desired behavior");
+            description: "XUnit.net will execute the theory initializing the parameter to the default value of the type, which might not be the desired behavior");
 
         internal static DiagnosticDescriptor X1013_PublicMethodShouldBeMarkedAsTest { get; } =
             Rule("xUnit1013", "Public method should be marked as test", Usage, Warning,
@@ -121,12 +121,12 @@ namespace Xunit.Analyzers
         internal static DiagnosticDescriptor X1022_TheoryMethodCannotHaveParameterArray { get; } =
             Rule("xUnit1022", "Theory methods cannot have a parameter array", Usage, Error,
                 "Theory method '{0}' on test class '{1}' cannot have a parameter array '{2}'.",
-            description: "Params array support was added in Xunit 2.2. Remove the parameter or upgrade the Xunit binaries.");
+            description: "Params array support was added in Xunit.net 2.2. Remove the parameter or upgrade the Xunit.net binaries.");
 
         internal static DiagnosticDescriptor X1023_TheoryMethodCannotHaveDefaultParameter { get; } =
             Rule("xUnit1023", "Theory methods cannot have default parameter values", Usage, Error,
                 "Theory method '{0}' on test class '{1}' parameter '{2}' cannot have a default value.",
-            description: "Default parameter values support was added in Xunit 2.2. Remove the default value or upgrade the Xunit binaries.");
+            description: "Default parameter values support was added in Xunit.net 2.2. Remove the default value or upgrade the Xunit.net binaries.");
 
         internal static DiagnosticDescriptor X1024_TestMethodCannotHaveOverloads { get; } =
             Rule("xUnit1024", "Test methods cannot have overloads", Usage, Error,
@@ -159,7 +159,7 @@ namespace Xunit.Analyzers
         internal static DiagnosticDescriptor X2000_AssertEqualLiteralValueShouldBeFirst { get; } =
             Rule("xUnit2000", "Expected value should be first", Assertions, Warning,
                 "The literal or constant value {0} should be the first argument in the call to '{1}' in method '{2}' on type '{3}'.",
-            description: "The xUnit Assertion library produces the best error messages if the expected value is passed in as the first argument.");
+            description: "The xUnit.net Assertion library produces the best error messages if the expected value is passed in as the first argument.");
 
         internal static DiagnosticDescriptor X2001_AssertEqualsShouldNotBeUsed { get; } =
             Rule("xUnit2001", "Do not use invalid equality check", Assertions, Hidden,


### PR DESCRIPTION
There is still lots of inconsistency xUnit vs Xunit vs XUnit v xunit.
And it deserves its own treatment.