### PR TITLE
Fix xUnit1000 for partial classes.

### DIFF
--- a/test/xunit.analyzers.tests/TestClassMustBePublicFixerTests.cs
+++ b/test/xunit.analyzers.tests/TestClassMustBePublicFixerTests.cs
@@ -10,12 +10,51 @@ namespace Xunit.Analyzers
 
         [Theory]
         [InlineData("")]
-        [InlineData("internal ")]
-        public async void MakesClassPublic(string visibility)
+        [InlineData("internal")]
+        public async void MakesClassPublic(string nonPublicAccessModifier)
         {
-            var result = await CodeAnalyzerHelper.GetFixedCodeAsync(analyzer, fixer, $"{visibility}class TestClass {{ [Xunit.Fact] public void TestMethod() {{ }} }}");
+            var source = $"{nonPublicAccessModifier} class TestClass {{ [Xunit.Fact] public void TestMethod() {{ }} }}";
 
-            Assert.Equal("public class TestClass { [Xunit.Fact] public void TestMethod() { } }", result);
+            var expected = "public class TestClass { [Xunit.Fact] public void TestMethod() { } }";
+
+            var actual = await CodeAnalyzerHelper.GetFixedCodeAsync(analyzer, fixer, source);
+
+            Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public async void ForPartialClassDeclarations_MakesSingleDeclarationPublic()
+        {
+            var source = @"
+partial class TestClass
+{
+    [Xunit.Fact]
+    public void TestMethod1() {}
+}
+
+partial class TestClass
+{
+    [Xunit.Fact]
+    public void TestMethod2() {}
+}";
+
+            var expected = @"
+public partial class TestClass
+{
+    [Xunit.Fact]
+    public void TestMethod1() {}
+}
+
+partial class TestClass
+{
+    [Xunit.Fact]
+    public void TestMethod2() {}
+}";
+
+            var actual = await CodeAnalyzerHelper.GetFixedCodeAsync(analyzer, fixer, source);
+
+            Assert.Equal(expected, actual);
+        }
+
     }
 }

--- a/test/xunit.analyzers.tests/TestClassMustBePublicTests.cs
+++ b/test/xunit.analyzers.tests/TestClassMustBePublicTests.cs
@@ -1,25 +1,146 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Xunit.Analyzers
 {
     public class TestClassMustBePublicTests
     {
-        readonly DiagnosticAnalyzer analyzer = new TestClassMustBePublic();
+        private readonly DiagnosticAnalyzer analyzer = new TestClassMustBePublic();
+
+        private static IEnumerable<object[]> CreateFactsInNonPublicClassCases()
+        {
+            foreach (var factAttribute in new[] {"Xunit.Fact", "Xunit.Theory"})
+            {
+                foreach (var nonPublicAccessModifierForClass in new[] {"", "internal"})
+                {
+                    yield return new object[] {factAttribute, nonPublicAccessModifierForClass};
+                }
+            }
+        }
 
         [Fact]
-        public async void DoesNotFindErrorForPublicClass()
+        public async void ForPublicClass_DoesNotFindError()
         {
-            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, "public class TestClass { [Xunit.Fact] public void TestMethod() { } }");
+            var source = "public class TestClass { [Xunit.Fact] public void TestMethod() { } }";
+
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, source);
 
             Assert.Empty(diagnostics);
         }
 
         [Theory]
-        [InlineData("Xunit.Fact")]
-        [InlineData("Xunit.Theory")]
-        public async void FindsErrorForPrivateClass(string attribute)
+        [MemberData(nameof(CreateFactsInNonPublicClassCases))]
+        public async void ForFriendOrInternalClass_FindsError(
+            string factRelatedAttribute,
+            string classAccessModifier)
         {
-            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, "class TestClass { [" + attribute + "] public void TestMethod() { } }");
+            var source =   @"
+" + classAccessModifier + @" class TestClass 
+{ 
+    [" + factRelatedAttribute + @"] public void TestMethod() { } 
+}";
+
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, source);
+
+            Assert.Collection(diagnostics,
+                d =>
+                {
+                    Assert.Equal("Test classes must be public", d.GetMessage());
+                    Assert.Equal("xUnit1000", d.Descriptor.Id);
+                });
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("public")]
+        public async void ForPartialClassInSameFile_WhenClassIsPublic_DoesNotFindError(string otherPartAccessModifier)
+        {
+            string source = @"
+public partial class TestClass
+{
+    [Xunit.Fact] public void Test1() {}
+}
+
+" + otherPartAccessModifier + @" partial class TestClass
+{
+    [Xunit.Fact] public void Test2() {}
+}
+";
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, source);
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("public")]
+        public async void ForPartialClassInOtherFiles_WhenClassIsPublic_DoesNotFindError(string otherPartAccessModifier)
+        {
+            string source1 = @"
+public partial class TestClass
+{
+    [Xunit.Fact] public void Test1() {}
+}";
+            string source2 = @"
+" + otherPartAccessModifier + @" partial class TestClass
+{
+    [Xunit.Fact] public void Test2() {}
+}
+";
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, source1, source2);
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("", "internal")]
+        [InlineData("internal", "internal")]
+        public async void ForPartialClassInSameFile_WhenClassIsNonPublic_FindsError(
+            string part1AccessModifier,
+            string part2AccessModifier)
+        {
+            string source = @"
+" + part1AccessModifier + @" partial class TestClass
+{
+    [Xunit.Fact] public void Test1() {}
+}
+
+" + part2AccessModifier + @" partial class TestClass
+{
+    [Xunit.Fact] public void Test2() {}
+}
+";
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, source);
+
+            Assert.Collection(diagnostics,
+                d =>
+                {
+                    Assert.Equal("Test classes must be public", d.GetMessage());
+                    Assert.Equal("xUnit1000", d.Descriptor.Id);
+                });
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("", "internal")]
+        [InlineData("internal", "internal")]
+        public async void ForPartialClassInOtherFiles_WhenClassIsNonPublic_FindsError(
+            string part1AccessModifier,
+            string part2AccessModifier)
+        {
+            string source1 = @"
+" + part1AccessModifier + @" partial class TestClass
+{
+    [Xunit.Fact] public void Test1() {}
+}";
+            string source2 = @"
+" + part2AccessModifier + @" partial class TestClass
+{
+    [Xunit.Fact] public void Test2() {}
+}
+";
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, source1, source2);
 
             Assert.Collection(diagnostics,
                 d =>


### PR DESCRIPTION
TestClassMustBePublic analyzer has been rewritten to analyze class
declaration symbols rather than syntaxes.

The fixer remains unchanged as it corrects code to have proper semantic.

Closes xunit/xunit#1602