### PR TITLE
Fix OptionalAttributes included in v2.2 analysis.

### DIFF
--- a/src/xunit.analyzers/Analysis/CoreContext.cs
+++ b/src/xunit.analyzers/Analysis/CoreContext.cs
@@ -54,7 +54,8 @@ namespace Xunit.Analyzers
         public virtual bool TheorySupportsDefaultParameterValues 
             => Version >= Version_2_2_0;
 
-
+        public virtual bool TheorySupportsOptionalAttributes
+            => Version >= Version_2_2_0;
 
         /// <summary>
         /// See: https://github.com/xunit/xunit/pull/1546

--- a/src/xunit.analyzers/InlineDataMustMatchTheoryParameters.cs
+++ b/src/xunit.analyzers/InlineDataMustMatchTheoryParameters.cs
@@ -39,6 +39,7 @@ namespace Xunit.Analyzers
         {
             var xunitSupportsParameterArrays = xunitContext.Core.TheorySupportsParameterArrays;
             var xunitSupportsDefaultParameterValues = xunitContext.Core.TheorySupportsDefaultParameterValues;
+            var xuniSupportsOptionalAttributes = xunitContext.Core.TheorySupportsOptionalAttributes;
 
             var compilation = compilationStartContext.Compilation;
             var systemRuntimeInteropServicesOptionalAttribute =
@@ -80,7 +81,8 @@ namespace Xunit.Analyzers
                     var values = dataArrayArgument.IsNull ? ImmutableArray.Create(dataArrayArgument) : dataArrayArgument.Values;
                     if (values.Length < method.Parameters.Count(p => RequiresMatchingValue(p, 
                                                                         xunitSupportsParameterArrays, 
-                                                                        xunitSupportsDefaultParameterValues, 
+                                                                        xunitSupportsDefaultParameterValues,
+                                                                        xuniSupportsOptionalAttributes,
                                                                         systemRuntimeInteropServicesOptionalAttribute)))
                     {
                         var builder = ImmutableDictionary.CreateBuilder<string, string>();
@@ -170,11 +172,11 @@ namespace Xunit.Analyzers
         }
 
         private static bool RequiresMatchingValue(IParameterSymbol parameter, bool supportsParamsArray,
-            bool supportsDefaultValue, INamedTypeSymbol optionalAttribute)
+            bool supportsDefaultValue, bool supportsOptionalAttributes, INamedTypeSymbol optionalAttribute)
         {
             return !(parameter.HasExplicitDefaultValue && supportsDefaultValue)
                 && !(parameter.IsParams && supportsParamsArray)
-                && !parameter.GetAttributes().Any(a => a.AttributeClass.Equals(optionalAttribute));
+                && !(supportsOptionalAttributes && parameter.GetAttributes().Any(a => a.AttributeClass.Equals(optionalAttribute)));
         }
 
         static IList<ExpressionSyntax> GetParameterExpressionsFromArrayArgument(AttributeSyntax attribute)


### PR DESCRIPTION
BTW - I see `CoreContext.cs` is getting more and more capability markers (`TheorySupports...`). Maybe it's time to make it sth like `XUnitCapabilities` immutable value type created once at the beginning for to pass around?