### PR TITLE
Remove unused code fixer logic after relaxation of xUnit3001

### DIFF
--- a/src/xunit.analyzers/SerializableClassMustHaveParameterlessConstructorFixer.cs
+++ b/src/xunit.analyzers/SerializableClassMustHaveParameterlessConstructorFixer.cs
@@ -48,7 +48,6 @@ namespace Xunit.Analyzers
             var generator = editor.Generator;
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
             var parameterlessCtor = declaration.Members.OfType<ConstructorDeclarationSyntax>().FirstOrDefault(c => c.ParameterList.Parameters.Count == 0);
-            var obsoleteAttribute = generator.Attribute(Constants.Types.SystemObsoleteAttribute, obsoleteText);
 
             var updatedCtor = generator.WithAccessibility(parameterlessCtor, Accessibility.Public);
 
@@ -56,7 +55,10 @@ namespace Xunit.Analyzers
                                                .SelectMany(al => al.Attributes)
                                                .Any(@as => semanticModel.GetTypeInfo(@as, cancellationToken).Type?.ToDisplayString() == Constants.Types.SystemObsoleteAttribute);
             if (!hasObsolete)
+            {
+                var obsoleteAttribute = generator.Attribute(Constants.Types.SystemObsoleteAttribute, obsoleteText);
                 updatedCtor = generator.AddAttributes(updatedCtor, obsoleteAttribute);
+            }
 
             editor.ReplaceNode(parameterlessCtor, updatedCtor);
 

--- a/src/xunit.analyzers/SerializableClassMustHaveParameterlessConstructorFixer.cs
+++ b/src/xunit.analyzers/SerializableClassMustHaveParameterlessConstructorFixer.cs
@@ -50,25 +50,15 @@ namespace Xunit.Analyzers
             var parameterlessCtor = declaration.Members.OfType<ConstructorDeclarationSyntax>().FirstOrDefault(c => c.ParameterList.Parameters.Count == 0);
             var obsoleteAttribute = generator.Attribute(Constants.Types.SystemObsoleteAttribute, obsoleteText);
 
-            if (parameterlessCtor == null)
-            {
-                var constructor = generator.ConstructorDeclaration(accessibility: Accessibility.Public);
-                var constructorWithAttributes = generator.AddAttributes(constructor, obsoleteAttribute);
-                var updatedDeclaration = editor.Generator.InsertMembers(declaration, 0, constructorWithAttributes);
-                editor.ReplaceNode(declaration, updatedDeclaration);
-            }
-            else
-            {
-                var updatedCtor = generator.WithAccessibility(parameterlessCtor, Accessibility.Public);
+            var updatedCtor = generator.WithAccessibility(parameterlessCtor, Accessibility.Public);
 
-                var hasObsolete = parameterlessCtor.AttributeLists
-                                                   .SelectMany(al => al.Attributes)
-                                                   .Any(@as => semanticModel.GetTypeInfo(@as, cancellationToken).Type?.ToDisplayString() == Constants.Types.SystemObsoleteAttribute);
-                if (!hasObsolete)
-                    updatedCtor = generator.AddAttributes(updatedCtor, obsoleteAttribute);
+            var hasObsolete = parameterlessCtor.AttributeLists
+                                               .SelectMany(al => al.Attributes)
+                                               .Any(@as => semanticModel.GetTypeInfo(@as, cancellationToken).Type?.ToDisplayString() == Constants.Types.SystemObsoleteAttribute);
+            if (!hasObsolete)
+                updatedCtor = generator.AddAttributes(updatedCtor, obsoleteAttribute);
 
-                editor.ReplaceNode(parameterlessCtor, updatedCtor);
-            }
+            editor.ReplaceNode(parameterlessCtor, updatedCtor);
 
             return editor.GetChangedDocument();
         }


### PR DESCRIPTION
#105 removed the alerting on implicit constructors, so the code fixer doesn't need to generate them anymore, when missing. In #105, I've removed the tests, but failed to update the fixer. This does that.