### PR TITLE
Fix xUnit2000 for named arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,8 @@ _TeamCity*
 _NCrunch_*
 .*crunch*.local.xml
 nCrunchTemp_*
+*.ncrunchsolution
+*.ncrunchproject
 
 # MightyMoose
 *.mm.*

--- a/docs/_rules/xUnit2000.md
+++ b/docs/_rules/xUnit2000.md
@@ -1,17 +1,17 @@
 ---
 title: xUnit2000
-description: Expected value should be first
+description: Constants and literals should be the expected argument
 category: Assertions
 severity: Warning
 ---
 
 ## Cause
 
-A violation of this rule occurs when the first argument to `Assert.Equal`, `AssertNotEqual`, `Assert.StrictEqual`, or `Assert.NotStrictEqual` is not the expected value.
+A violation of this rule occurs when the expected argument to `Assert.Equal`, `AssertNotEqual`, `Assert.StrictEqual`, or `Assert.NotStrictEqual` is not the expected value (such as a constant or literal).
 
 ## Reason for rule
 
-The expected value in equality assertions should always be the first argument. This will ensure that generated messages explaining the test failure will correctly match the situation.
+The expected value in equality assertions should always be the expected argument. This will ensure that generated messages explaining the test failure will correctly match the situation.
 
 ## How to fix violations
 
@@ -46,6 +46,6 @@ public void AdditionExample()
 ## How to suppress violations
 
 ```csharp
-#pragma warning disable xUnit2000 // Expected value should be first
-#pragma warning restore xUnit2000 // Expected value should be first
+#pragma warning disable xUnit2000 // Constants and literals should be the expected argument
+#pragma warning restore xUnit2000 // Constants and literals should be the expected argument
 ```

--- a/src/xunit.analyzers/Descriptors.cs
+++ b/src/xunit.analyzers/Descriptors.cs
@@ -157,9 +157,9 @@ namespace Xunit.Analyzers
         // Placeholder for rule X1032
 
         internal static DiagnosticDescriptor X2000_AssertEqualLiteralValueShouldBeFirst { get; } =
-            Rule("xUnit2000", "Expected value should be first", Assertions, Warning,
-                "The literal or constant value {0} should be the first argument in the call to '{1}' in method '{2}' on type '{3}'.",
-            description: "The xUnit.net Assertion library produces the best error messages if the expected value is passed in as the first argument.");
+            Rule("xUnit2000", "Constants and literals should be the expected argument", Assertions, Warning,
+                "The literal or constant value {0} should be passed as the 'expected' argument in the call to '{1}' in method '{2}' on type '{3}'.",
+            description: "The xUnit.net Assertion library produces the best error messages if the expected value is passed in as the expected argument.");
 
         internal static DiagnosticDescriptor X2001_AssertEqualsShouldNotBeUsed { get; } =
             Rule("xUnit2001", "Do not use invalid equality check", Assertions, Hidden,

--- a/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstTests.cs
+++ b/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstTests.cs
@@ -60,5 +60,41 @@ namespace Xunit.Analyzers
                 Assert.Equal(DiagnosticSeverity.Warning, d.Severity);
             });
         }
+
+        [Theory]
+        [MemberData(nameof(TypesAndValues))]
+        public async void DoesNotFindWarningForExpectedConstantOrLiteralValueAsNamedExpectedArgument(string type, string value)
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
+@"class TestClass { void TestMethod() { 
+    var v = default(" + type + @");
+    Xunit.Assert.Equal(actual: v, expected: " + value + @");
+} }");
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Theory]
+        [MemberData(nameof(TypesAndValues))]
+        public async void FindsWarningForExpectedConstantOrLiteralValueAsNamedExpectedArgument(string type, string value)
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
+@"class TestClass { void TestMethod() { 
+    var v = default(" + type + @");
+    Xunit.Assert.Equal(actual: " + value + @",expected: v);
+} }");
+
+            Assert.Collection(diagnostics, d =>
+            {
+                Assert.Equal($"The literal or constant value {value} should be the first argument in the call to 'Assert.Equal(expected, actual)' in method 'TestMethod' on type 'TestClass'.", d.GetMessage());
+                Assert.Equal("xUnit2000", d.Id);
+                Assert.Equal(DiagnosticSeverity.Warning, d.Severity);
+            });
+        }
+
+        // TODO: handle case where expected or actual is not present on argument list
+        // where expected or actual is multiple times on the list
+        // fix documentation
+
     }
 }

--- a/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstTests.cs
+++ b/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstTests.cs
@@ -92,9 +92,22 @@ namespace Xunit.Analyzers
             });
         }
 
-        // TODO: handle case where expected or actual is not present on argument list
-        // where expected or actual is multiple times on the list
-        // fix documentation
+        [Theory]
+        [InlineData("act", "exp")]
+        [InlineData("expected", "expected")]
+        [InlineData("actual", "actual")]
+        [InlineData("foo", "bar")]
+        public async void DoesNotFindWarningWhenArgumentsAreNotNamedCorrectly(string firstArgumentName, string secondArgumentName)
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, CompilationReporting.IgnoreErrors,
+@"class TestClass { void TestMethod() {
+    var v = default(int);
+    Xunit.Assert.Equal(" + firstArgumentName + @": 1, " + secondArgumentName + @": v);
+} }");
 
+            Assert.Empty(diagnostics);
+        }
+
+        // fix documentation
     }
 }

--- a/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstTests.cs
+++ b/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstTests.cs
@@ -55,7 +55,7 @@ namespace Xunit.Analyzers
 
             Assert.Collection(diagnostics, d =>
             {
-                Assert.Equal($"The literal or constant value {value} should be the first argument in the call to 'Assert.Equal(expected, actual)' in method 'TestMethod' on type 'TestClass'.", d.GetMessage());
+                Assert.Equal($"The literal or constant value {value} should be passed as the 'expected' argument in the call to 'Assert.Equal(expected, actual)' in method 'TestMethod' on type 'TestClass'.", d.GetMessage());
                 Assert.Equal("xUnit2000", d.Id);
                 Assert.Equal(DiagnosticSeverity.Warning, d.Severity);
             });
@@ -86,7 +86,7 @@ namespace Xunit.Analyzers
 
             Assert.Collection(diagnostics, d =>
             {
-                Assert.Equal($"The literal or constant value {value} should be the first argument in the call to 'Assert.Equal(expected, actual)' in method 'TestMethod' on type 'TestClass'.", d.GetMessage());
+                Assert.Equal($"The literal or constant value {value} should be passed as the 'expected' argument in the call to 'Assert.Equal(expected, actual)' in method 'TestMethod' on type 'TestClass'.", d.GetMessage());
                 Assert.Equal("xUnit2000", d.Id);
                 Assert.Equal(DiagnosticSeverity.Warning, d.Severity);
             });
@@ -107,7 +107,5 @@ namespace Xunit.Analyzers
 
             Assert.Empty(diagnostics);
         }
-
-        // fix documentation
     }
 }


### PR DESCRIPTION
This fixes [#1636](https://github.com/xunit/xunit/issues/1636). Couple notes:

 * I wanted to handle the edge case where you'd get passed in an invalid named argument (like `exp: `, instead of `expected: `), to avoid NREs from happening. However, I can't get that to fail (both in VS, as well as in unit tests with `compilationReporting` set to `CompilationReporting.IgnoreErrors`), so it seems the analyzers won't be called if those nodes have compilation errors, or so (maybe @sharwell can shine some light on that, since he's on one of the Roslyn teams, and reporter of this issue;) )
 * code fixer needs to be updated, as well, I'll do that in a subsequent PR, if that's ok
 * I've updated the gitignore to account for NCrunch, I hope that's ok
