### PR TITLE
Fix xUnit2000 fixer: support named parameters in swap arguments

### DIFF
--- a/src/xunit.analyzers/AssertEqualLiteralValueShouldBeFirst.cs
+++ b/src/xunit.analyzers/AssertEqualLiteralValueShouldBeFirst.cs
@@ -26,8 +26,8 @@ namespace Xunit.Analyzers
             ArgumentSyntax expectedArg, actualArg;
             if (arguments.All(x => x.NameColon != null))
             {
-                expectedArg = arguments.Single(x => x.NameColon.Name.Identifier.Text == "expected");
-                actualArg = arguments.Single(x => x.NameColon.Name.Identifier.Text == "actual");
+                expectedArg = arguments.Single(x => x.NameColon.Name.Identifier.ValueText == "expected");
+                actualArg = arguments.Single(x => x.NameColon.Name.Identifier.ValueText == "actual");
             }
             else
             {

--- a/src/xunit.analyzers/AssertEqualLiteralValueShouldBeFirstFixer.cs
+++ b/src/xunit.analyzers/AssertEqualLiteralValueShouldBeFirstFixer.cs
@@ -39,11 +39,11 @@ namespace Xunit.Analyzers
             var arguments = invocation.ArgumentList.Arguments;
             if (arguments.All(x => x.NameColon != null))
             {
-                var firstArg = arguments[0];
-                var secondArg = arguments[1];
+                var expectedArg = arguments.Single(x => x.NameColon.Name.Identifier.ValueText == "expected");
+                var actualArg = arguments.Single(x => x.NameColon.Name.Identifier.ValueText == "actual");
 
-                editor.ReplaceNode(firstArg, firstArg.WithExpression(secondArg.Expression));
-                editor.ReplaceNode(secondArg, secondArg.WithExpression(firstArg.Expression));
+                editor.ReplaceNode(expectedArg, expectedArg.WithExpression(actualArg.Expression));
+                editor.ReplaceNode(actualArg, actualArg.WithExpression(expectedArg.Expression));
             }
             else
             {

--- a/src/xunit.analyzers/AssertEqualLiteralValueShouldBeFirstFixer.cs
+++ b/src/xunit.analyzers/AssertEqualLiteralValueShouldBeFirstFixer.cs
@@ -37,13 +37,24 @@ namespace Xunit.Analyzers
             var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
             var arguments = invocation.ArgumentList.Arguments;
-            if (arguments.All(x => x.NameColon != null))
+            if (arguments.Any(x => x.NameColon != null))
             {
-                var expectedArg = arguments.Single(x => x.NameColon.Name.Identifier.ValueText == "expected");
-                var actualArg = arguments.Single(x => x.NameColon.Name.Identifier.ValueText == "actual");
+                if (arguments.All(x => x.NameColon != null))
+                {
+                    var expectedArg = arguments.Single(x => x.NameColon.Name.Identifier.ValueText == "expected");
+                    var actualArg = arguments.Single(x => x.NameColon.Name.Identifier.ValueText == "actual");
 
-                editor.ReplaceNode(expectedArg, expectedArg.WithExpression(actualArg.Expression));
-                editor.ReplaceNode(actualArg, actualArg.WithExpression(expectedArg.Expression));
+                    editor.ReplaceNode(expectedArg, expectedArg.WithExpression(actualArg.Expression));
+                    editor.ReplaceNode(actualArg, actualArg.WithExpression(expectedArg.Expression));
+                }
+                else
+                {
+                    var firstArg = arguments[0];
+                    var secondArg = arguments[1];
+
+                    editor.ReplaceNode(firstArg, firstArg.WithExpression(secondArg.Expression));
+                    editor.ReplaceNode(secondArg, secondArg.WithExpression(firstArg.Expression));
+                }
             }
             else
             {

--- a/src/xunit.analyzers/AssertEqualLiteralValueShouldBeFirstFixer.cs
+++ b/src/xunit.analyzers/AssertEqualLiteralValueShouldBeFirstFixer.cs
@@ -37,32 +37,22 @@ namespace Xunit.Analyzers
             var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
             var arguments = invocation.ArgumentList.Arguments;
-            if (arguments.Any(x => x.NameColon != null))
+
+            ArgumentSyntax expectedArg, actualArg;
+            if (arguments.All(x => x.NameColon != null))
             {
-                if (arguments.All(x => x.NameColon != null))
-                {
-                    var expectedArg = arguments.Single(x => x.NameColon.Name.Identifier.ValueText == "expected");
-                    var actualArg = arguments.Single(x => x.NameColon.Name.Identifier.ValueText == "actual");
-
-                    editor.ReplaceNode(expectedArg, expectedArg.WithExpression(actualArg.Expression));
-                    editor.ReplaceNode(actualArg, actualArg.WithExpression(expectedArg.Expression));
-                }
-                else
-                {
-                    var firstArg = arguments[0];
-                    var secondArg = arguments[1];
-
-                    editor.ReplaceNode(firstArg, firstArg.WithExpression(secondArg.Expression));
-                    editor.ReplaceNode(secondArg, secondArg.WithExpression(firstArg.Expression));
-                }
+                expectedArg = arguments.Single(x => x.NameColon.Name.Identifier.ValueText == "expected");
+                actualArg = arguments.Single(x => x.NameColon.Name.Identifier.ValueText == "actual");
             }
             else
             {
-                var firstArg = arguments[0];
-                var secondArg = arguments[1];
-                editor.RemoveNode(firstArg);
-                editor.InsertAfter(secondArg, firstArg);
+                expectedArg = arguments[0];
+                actualArg = arguments[1];
             }
+
+            editor.ReplaceNode(expectedArg, expectedArg.WithExpression(actualArg.Expression));
+            editor.ReplaceNode(actualArg, actualArg.WithExpression(expectedArg.Expression));
+
             return editor.GetChangedDocument();
         }
     }

--- a/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstFixerTests.cs
+++ b/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstFixerTests.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Xunit.Analyzers
+{
+    public class AssertEqualLiteralValueShouldBeFirstFixerTests
+    {
+        readonly DiagnosticAnalyzer analyzer = new AssertEqualLiteralValueShouldBeFirst();
+        readonly CodeFixProvider fixer = new AssertEqualLiteralValueShouldBeFirstFixer();
+
+        [Fact]
+        public async void MakesClassPublic()
+        {
+            var source =
+@"public class TestClass
+{
+    [Xunit.Fact]
+    public void TestMethod()
+    {
+        var i = 0;
+        Xunit.Assert.Equal(i, 0);
+    }
+}";
+            var expected =
+                @"public class TestClass
+{
+    [Xunit.Fact]
+    public void TestMethod()
+    {
+        var i = 0;
+        Xunit.Assert.Equal(0, i);
+    }
+}";
+
+            var actual = await CodeAnalyzerHelper.GetFixedCodeAsync(analyzer, fixer, source);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstFixerTests.cs
+++ b/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstFixerTests.cs
@@ -40,5 +40,16 @@ public class TestClass
 
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public async void NamedArgumentsTakePossibleThirdParameterIntoAccount()
+        {
+            var source = string.Format(Template, "Assert.Equal(comparer: null, actual: 0, expected: i)");
+            var expected = string.Format(Template, "Assert.Equal(comparer: null, actual: i, expected: 0)");
+
+            var actual = await CodeAnalyzerHelper.GetFixedCodeAsync(analyzer, fixer, source);
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstFixerTests.cs
+++ b/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstFixerTests.cs
@@ -9,7 +9,7 @@ namespace Xunit.Analyzers
         readonly CodeFixProvider fixer = new AssertEqualLiteralValueShouldBeFirstFixer();
 
         [Fact]
-        public async void MakesClassPublic()
+        public async void SwapArguments()
         {
             var source =
 @"public class TestClass
@@ -29,6 +29,35 @@ namespace Xunit.Analyzers
     {
         var i = 0;
         Xunit.Assert.Equal(0, i);
+    }
+}";
+
+            var actual = await CodeAnalyzerHelper.GetFixedCodeAsync(analyzer, fixer, source);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public async void NamedArgumentsOnlySwapsArgumentValues()
+        {
+            var source =
+@"public class TestClass
+{
+    [Xunit.Fact]
+    public void TestMethod()
+    {
+        var i = 0;
+        Xunit.Assert.Equal(actual: 0, expected: i);
+    }
+}";
+            var expected =
+                @"public class TestClass
+{
+    [Xunit.Fact]
+    public void TestMethod()
+    {
+        var i = 0;
+        Xunit.Assert.Equal(actual: i, expected: 0);
     }
 }";
 

--- a/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstFixerTests.cs
+++ b/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstFixerTests.cs
@@ -62,5 +62,18 @@ public class TestClass
 
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public async void PartiallyNamedArgumentsInCorrectPositionOnlySwapsArgumentValues()
+        {
+            // C# 7.2 supports this new supported "non-trailing named arguments"
+
+            var source = string.Format(Template, "Assert.Equal(expected: i, 0)");
+            var expected = string.Format(Template, "Assert.Equal(expected: 0, i)");
+
+            var actual = await CodeAnalyzerHelper.GetFixedCodeAsync(analyzer, fixer, source, CompilationReporting.IgnoreErrors);
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstFixerTests.cs
+++ b/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstFixerTests.cs
@@ -8,29 +8,22 @@ namespace Xunit.Analyzers
         readonly DiagnosticAnalyzer analyzer = new AssertEqualLiteralValueShouldBeFirst();
         readonly CodeFixProvider fixer = new AssertEqualLiteralValueShouldBeFirstFixer();
 
+        static readonly string Template = @"
+public class TestClass
+{{
+    [Xunit.Fact]
+    public void TestMethod()
+    {{
+        var i = 0;
+        Xunit.{0};
+    }}
+}}";
+
         [Fact]
         public async void SwapArguments()
         {
-            var source =
-@"public class TestClass
-{
-    [Xunit.Fact]
-    public void TestMethod()
-    {
-        var i = 0;
-        Xunit.Assert.Equal(i, 0);
-    }
-}";
-            var expected =
-                @"public class TestClass
-{
-    [Xunit.Fact]
-    public void TestMethod()
-    {
-        var i = 0;
-        Xunit.Assert.Equal(0, i);
-    }
-}";
+            var source = string.Format(Template, "Assert.Equal(i, 0)");
+            var expected = string.Format(Template, "Assert.Equal(0, i)");
 
             var actual = await CodeAnalyzerHelper.GetFixedCodeAsync(analyzer, fixer, source);
 
@@ -40,26 +33,8 @@ namespace Xunit.Analyzers
         [Fact]
         public async void NamedArgumentsOnlySwapsArgumentValues()
         {
-            var source =
-@"public class TestClass
-{
-    [Xunit.Fact]
-    public void TestMethod()
-    {
-        var i = 0;
-        Xunit.Assert.Equal(actual: 0, expected: i);
-    }
-}";
-            var expected =
-                @"public class TestClass
-{
-    [Xunit.Fact]
-    public void TestMethod()
-    {
-        var i = 0;
-        Xunit.Assert.Equal(actual: i, expected: 0);
-    }
-}";
+            var source = string.Format(Template, "Assert.Equal(actual: 0, expected: i)");
+            var expected = string.Format(Template, "Assert.Equal(actual: i, expected: 0)");
 
             var actual = await CodeAnalyzerHelper.GetFixedCodeAsync(analyzer, fixer, source);
 

--- a/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstFixerTests.cs
+++ b/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstFixerTests.cs
@@ -42,6 +42,17 @@ public class TestClass
         }
 
         [Fact]
+        public async void NamedArgumentsInCorrectPositionOnlySwapsArgumentValues()
+        {
+            var source = string.Format(Template, "Assert.Equal(expected: i, actual: 0)");
+            var expected = string.Format(Template, "Assert.Equal(expected: 0, actual: i)");
+
+            var actual = await CodeAnalyzerHelper.GetFixedCodeAsync(analyzer, fixer, source);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public async void NamedArgumentsTakePossibleThirdParameterIntoAccount()
         {
             var source = string.Format(Template, "Assert.Equal(comparer: null, actual: 0, expected: i)");

--- a/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstTests.cs
+++ b/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstTests.cs
@@ -62,13 +62,15 @@ namespace Xunit.Analyzers
         }
 
         [Theory]
-        [MemberData(nameof(TypesAndValues))]
-        public async void DoesNotFindWarningForExpectedConstantOrLiteralValueAsNamedExpectedArgument(string type, string value)
+        [InlineData(true)]
+        [InlineData(false)]
+        public async void DoesNotFindWarningForExpectedConstantOrLiteralValueAsNamedExpectedArgument(bool useAlternateForm)
         {
+            var s = useAlternateForm ? "@" : "";
             var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
 @"class TestClass { void TestMethod() { 
-    var v = default(" + type + @");
-    Xunit.Assert.Equal(actual: v, expected: " + value + @");
+    var v = default(int);
+    Xunit.Assert.Equal(" + s + "actual: v, " + s + @"expected: 0);
 } }");
 
             Assert.Empty(diagnostics);


### PR DESCRIPTION
Follow up on PR #113 to fix the CodeFixer.