### PR TITLE
PR 114 follow up: explicitly specify C# language version

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -130,7 +130,7 @@ function __target__signpackages() {
 
 function __target__test() {
     _build_step "Running unit tests"
-        _xunit_console ("test\xunit.analyzers.tests\bin\" + $configuration + "\net452\xunit.analyzers.tests.dll -xml artifacts\test\TestResults.xml -diagnostics")
+        _xunit_console ("test\xunit.analyzers.tests\bin\" + $configuration + "\net46\xunit.analyzers.tests.dll -xml artifacts\test\TestResults.xml -diagnostics")
 }
 
 # Dispatch

--- a/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstFixerTests.cs
+++ b/test/xunit.analyzers.tests/AssertEqualLiteralValueShouldBeFirstFixerTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Xunit.Analyzers
 {
@@ -71,7 +72,7 @@ public class TestClass
             var source = string.Format(Template, "Assert.Equal(expected: i, 0)");
             var expected = string.Format(Template, "Assert.Equal(expected: 0, i)");
 
-            var actual = await CodeAnalyzerHelper.GetFixedCodeAsync(analyzer, fixer, source, CompilationReporting.IgnoreErrors);
+            var actual = await CodeAnalyzerHelper.GetFixedCodeAsync(analyzer, fixer, source, languageVersion: LanguageVersion.CSharp7_2);
 
             Assert.Equal(expected, actual);
         }

--- a/test/xunit.analyzers.tests/xunit.analyzers.tests.csproj
+++ b/test/xunit.analyzers.tests/xunit.analyzers.tests.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.8.2" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />

--- a/test/xunit.analyzers.tests/xunit.analyzers.tests.csproj
+++ b/test/xunit.analyzers.tests/xunit.analyzers.tests.csproj
@@ -2,10 +2,12 @@
 
   <PropertyGroup>
     <RootNamespace>Xunit.Analyzers</RootNamespace>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.8.2" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
     <PackageReference Include="xunit.assert" Version="2.3.1" />

--- a/test/xunit.analyzers.tests/xunit.runner.json
+++ b/test/xunit.analyzers.tests/xunit.runner.json
@@ -1,3 +1,3 @@
 ﻿{
-  "appDomain": "denied"
+  "appDomain": "ifAvailable"
 }


### PR DESCRIPTION
As [discussed](https://github.com/xunit/xunit.analyzers/pull/114/files#r190196126), specify C# language version for unit test, since that requires C# 7.2 syntax.

NOTE: I had to also change the target framework for the test project to 4.6, since the latest Roslyn packages are on [netstandard 1.3](https://docs.microsoft.com/en-us/dotnet/standard/net-standard).