### PR TITLE
Fix x2002 fixer - preserve leading trivia on node deletion

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
 
 clone_script:
 - ps: >-
+    git config --global --unset core.autocrlf;
     if (-not $env:appveyor_pull_request_number) {
         git clone -q --branch=$env:appveyor_repo_branch https://github.com/$env:appveyor_repo_name.git $env:appveyor_build_folder
         git checkout -qf $env:appveyor_repo_commit

--- a/test/xunit.analyzers.tests/AssertNullShouldNotBeCalledOnValueTypesFixerTests.cs
+++ b/test/xunit.analyzers.tests/AssertNullShouldNotBeCalledOnValueTypesFixerTests.cs
@@ -1,0 +1,92 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Xunit.Analyzers
+{
+    public class AssertNullShouldNotBeCalledOnValueTypesFixerTests
+    {
+        readonly DiagnosticAnalyzer analyzer = new AssertNullShouldNotBeCalledOnValueTypes();
+        readonly CodeFixProvider fixer = new AssertNullShouldNotBeCalledOnValueTypesFixer();
+
+        [Fact]
+        public async void ForValueTypeNullAssert_RemovesAssertion()
+        {
+            const string original = @"
+using Xunit;
+
+public class Tests
+{
+    [Fact]
+    public void TestMethod()
+    {
+        int i = 1;
+
+        Assert.NotNull(i);
+    }
+}";
+
+            const string expected = @"
+using Xunit;
+
+public class Tests
+{
+    [Fact]
+    public void TestMethod()
+    {
+        int i = 1;
+    }
+}";
+            var actual = await CodeAnalyzerHelper.GetFixedCodeAsync(analyzer, fixer, original);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        // https://github.com/xunit/xunit/issues/1753
+        public async void ForAssertionWithTrivia_RemovesAssertionAndLeavesLeadingTriviaInPlace()
+        {
+            const string original = @"
+using System;
+using Xunit;
+
+namespace XUnitTestProject1
+{
+    public class UnitTest1
+    {
+        [Fact]
+        public void Test1()
+        {
+            int i = 1;
+
+            // I am a comment which gets deleted by the quick fix
+            // Assert
+            Assert.NotNull(i);
+            Assert.Null(null);
+        }
+    }
+}";
+            const string expected = @"
+using System;
+using Xunit;
+
+namespace XUnitTestProject1
+{
+    public class UnitTest1
+    {
+        [Fact]
+        public void Test1()
+        {
+            int i = 1;
+
+            // I am a comment which gets deleted by the quick fix
+            // Assert
+            Assert.Null(null);
+        }
+    }
+}";
+            var actual = await CodeAnalyzerHelper.GetFixedCodeAsync(analyzer, fixer, original);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
Also:
Adds a step to appveyor clone procedure to checkout files CRLF
on Windows machines - particularly important for code fixer tests.

Closes xunit/xunit#1753