### PR TITLE
Add xUnit1027: Collection definition classes must be public

### DIFF
--- a/docs/_rules/xUnit1027.md
+++ b/docs/_rules/xUnit1027.md
@@ -1,0 +1,40 @@
+---
+title: xUnit1027
+description: Collection definition classes must be public
+category: Usage
+severity: Error
+---
+
+## Cause
+
+A collection definition class is not public.
+
+## Reason for rule
+
+xUnit.net will not discover the collection definition class if the class is not public.
+
+## How to fix violations
+
+To fix a violation of this rule, make the collection definition class public.
+
+## Examples
+
+### Violates
+
+```csharp
+[CollectionDefinition("CollectionName")]
+class CollectionDefinitionClass
+{
+
+}
+```
+
+### Does not violate
+
+```csharp
+[CollectionDefinition("CollectionName")]
+public class CollectionDefinitionClass
+{
+
+}
+```

--- a/src/xunit.analyzers/Analysis/CoreContext.cs
+++ b/src/xunit.analyzers/Analysis/CoreContext.cs
@@ -9,6 +9,7 @@ namespace Xunit.Analyzers
         static readonly Version Version_2_2_0 = new Version("2.2.0");
         static readonly Version Version_2_4_0 = new Version("2.4.0");
 
+        readonly Lazy<INamedTypeSymbol> lazyCollectionDefinitionAttributeType;
         readonly Lazy<INamedTypeSymbol> lazyClassDataAttributeType;
         readonly Lazy<INamedTypeSymbol> lazyDataAttributeType;
         readonly Lazy<INamedTypeSymbol> lazyFactAttributeType;
@@ -22,6 +23,7 @@ namespace Xunit.Analyzers
                                                     .FirstOrDefault(a => a.Name.Equals("xunit.core", StringComparison.OrdinalIgnoreCase))
                                                    ?.Version;
 
+            lazyCollectionDefinitionAttributeType = new Lazy<INamedTypeSymbol>(() => compilation.GetTypeByMetadataName(Constants.Types.XunitCollectionDefinitionAttribute));
             lazyClassDataAttributeType = new Lazy<INamedTypeSymbol>(() => compilation.GetTypeByMetadataName(Constants.Types.XunitClassDataAttribute));
             lazyDataAttributeType = new Lazy<INamedTypeSymbol>(() => compilation.GetTypeByMetadataName(Constants.Types.XunitSdkDataAttribute));
             lazyFactAttributeType = new Lazy<INamedTypeSymbol>(() => compilation.GetTypeByMetadataName(Constants.Types.XunitFactAttribute));
@@ -29,6 +31,9 @@ namespace Xunit.Analyzers
             lazyMemberDataAttributeType = new Lazy<INamedTypeSymbol>(() => compilation.GetTypeByMetadataName(Constants.Types.XunitMemberDataAttribute));
             lazyTheoryAttributeType = new Lazy<INamedTypeSymbol>(() => compilation.GetTypeByMetadataName(Constants.Types.XunitTheoryAttribute));
         }
+
+        public INamedTypeSymbol CollectionDefinitionAttributeType
+            => lazyCollectionDefinitionAttributeType?.Value;
 
         public INamedTypeSymbol ClassDataAttributeType
             => lazyClassDataAttributeType?.Value;

--- a/src/xunit.analyzers/CollectionDefinitionClassesMustBePublic.cs
+++ b/src/xunit.analyzers/CollectionDefinitionClassesMustBePublic.cs
@@ -1,0 +1,40 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Xunit.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class CollectionDefinitionClassesMustBePublic : XunitDiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(Descriptors.X1027_CollectionDefinitionClassMustBePublic);
+
+        internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, 
+            XunitContext xunitContext)
+        {
+            compilationStartContext.RegisterSymbolAction(context =>
+            {
+                if (context.Symbol.DeclaredAccessibility == Accessibility.Public)
+                    return;
+
+                var classSymbol = (INamedTypeSymbol) context.Symbol;
+
+                var doesClassContainCollectionDefinitionAttribute = classSymbol
+                    .GetAttributes()
+                    .Any(a => xunitContext.Core.CollectionDefinitionAttributeType.IsAssignableFrom(a.AttributeClass));
+
+                if (!doesClassContainCollectionDefinitionAttribute)
+                    return;
+
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Descriptors.X1027_CollectionDefinitionClassMustBePublic,
+                    classSymbol.Locations.First(),
+                    classSymbol.Locations.Skip(1),
+                    classSymbol.Name));
+
+            }, SymbolKind.NamedType);
+        }
+    }
+}

--- a/src/xunit.analyzers/CollectionDefinitionClassesMustBePublicFixer.cs
+++ b/src/xunit.analyzers/CollectionDefinitionClassesMustBePublicFixer.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Immutable;
+using System.Composition;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit.Analyzers.CodeActions;
+
+namespace Xunit.Analyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+    public class CollectionDefinitionClassesMustBePublicFixer : CodeFixProvider
+    {
+        const string title = "Make Public";
+
+        public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(Descriptors.X1027_CollectionDefinitionClassMustBePublic.Id);
+
+        public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var classDeclaration = root.FindNode(context.Span).FirstAncestorOrSelf<ClassDeclarationSyntax>();
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: title,
+                    createChangedDocument: ct => Actions.ChangeAccessibility(context.Document, classDeclaration, Accessibility.Public, ct),
+                    equivalenceKey: title),
+                context.Diagnostics);
+        }
+    }
+}

--- a/src/xunit.analyzers/Constants.cs
+++ b/src/xunit.analyzers/Constants.cs
@@ -10,6 +10,7 @@
             internal static readonly string XunitInlineDataAttribute = "Xunit.InlineDataAttribute";
             internal static readonly string XunitLongLivedMarshalByRefObject = "Xunit.LongLivedMarshalByRefObject";
             internal static readonly string XunitMemberDataAttribute = "Xunit.MemberDataAttribute";
+            internal static readonly string XunitCollectionDefinitionAttribute = "Xunit.CollectionDefinitionAttribute";
             internal static readonly string XunitFactAttribute = "Xunit.FactAttribute";
             internal static readonly string XunitTheoryAttribute = "Xunit.TheoryAttribute";
 

--- a/src/xunit.analyzers/Descriptors.cs
+++ b/src/xunit.analyzers/Descriptors.cs
@@ -144,7 +144,9 @@ namespace Xunit.Analyzers
             Rule("xUnit1026", "Theory methods should use all of their parameters", Usage, Warning,
                 "Theory method '{0}' on test class '{1}' does not use parameter '{2}'.");
 
-        // Placeholder for rule X1027
+        internal static DiagnosticDescriptor X1027_CollectionDefinitionClassMustBePublic { get; } =
+            Rule("xUnit1027", "Collection definition classes must be public", Usage, Error,
+                "Collection definition classes must be public");
 
         // Placeholder for rule X1028
 

--- a/test/xunit.analyzers.tests/CollectionDefinitionClassesMustBePublicFixerTests.cs
+++ b/test/xunit.analyzers.tests/CollectionDefinitionClassesMustBePublicFixerTests.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Xunit.Analyzers
+{
+    public class CollectionDefinitionClassesMustBePublicFixerTests
+    {
+        readonly DiagnosticAnalyzer analyzer = new CollectionDefinitionClassesMustBePublic();
+        readonly CodeFixProvider fixer = new CollectionDefinitionClassesMustBePublicFixer();
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("internal ")]
+        public async void MakesClassPublic(string nonPublicAccessModifier)
+        {
+            var source = $@"
+[Xunit.CollectionDefinition(""MyCollection"")]
+{ nonPublicAccessModifier} class CollectionDefinitionClass {{ }}";
+
+            var expected = @"
+[Xunit.CollectionDefinition(""MyCollection"")]
+public class CollectionDefinitionClass { }";
+
+            var actual = await CodeAnalyzerHelper.GetFixedCodeAsync(analyzer, fixer, source);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public async void ForPartialClassDeclarations_MakesSingleDeclarationPublic()
+        {
+            var source = @"
+[Xunit.CollectionDefinition(""MyCollection"")]
+partial class CollectionDefinitionClass
+{
+
+}
+
+partial class CollectionDefinitionClass
+{
+
+}";
+
+            var expected = @"
+[Xunit.CollectionDefinition(""MyCollection"")]
+public partial class CollectionDefinitionClass
+{
+
+}
+
+partial class CollectionDefinitionClass
+{
+
+}";
+
+            var actual = await CodeAnalyzerHelper.GetFixedCodeAsync(analyzer, fixer, source);
+
+            Assert.Equal(expected, actual);
+        }
+
+    }
+}

--- a/test/xunit.analyzers.tests/CollectionDefinitionClassesMustBePublicTests.cs
+++ b/test/xunit.analyzers.tests/CollectionDefinitionClassesMustBePublicTests.cs
@@ -1,0 +1,119 @@
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Xunit.Analyzers
+{
+    public class CollectionDefinitionClassesMustBePublicTests
+    {
+        private readonly DiagnosticAnalyzer analyzer = new CollectionDefinitionClassesMustBePublic();
+
+        [Fact]
+        public async void ForPublicClass_DoesNotFindError()
+        {
+            var source = @"
+[Xunit.CollectionDefinition(""MyCollection"")]
+public class CollectionDefinitionClass { }";
+
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, source);
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("internal")]
+        public async void ForFriendOrInternalClass_FindsError(string classAccessModifier)
+        {
+            var source = @"
+[Xunit.CollectionDefinition(""MyCollection"")]
+" + classAccessModifier + @" class CollectionDefinitionClass { }";
+
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, source);
+
+            Assert.Collection(diagnostics,
+                d =>
+                {
+                    Assert.Equal("Collection definition classes must be public", d.GetMessage());
+                    Assert.Equal("xUnit1027", d.Descriptor.Id);
+                });
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("public")]
+        public async void ForPartialClassInSameFile_WhenClassIsPublic_DoesNotFindError(string otherPartAccessModifier)
+        {
+            string source = $@"
+[Xunit.CollectionDefinition(""MyCollection"")]
+public partial class CollectionDefinitionClass {{ }}
+{otherPartAccessModifier} partial class CollectionDefinitionClass {{ }}
+";
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, source);
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("public")]
+        public async void ForPartialClassInOtherFiles_WhenClassIsPublic_DoesNotFindError(string otherPartAccessModifier)
+        {
+            string source1 = @"
+[Xunit.CollectionDefinition(""MyCollection"")]
+public partial class CollectionDefinitionClass { }";
+            string source2 = @"
+" + otherPartAccessModifier + @" partial class CollectionDefinitionClass { }
+";
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, source1, source2);
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("", "internal")]
+        [InlineData("internal", "internal")]
+        public async void ForPartialClassInSameFile_WhenClassIsNonPublic_FindsError(
+            string part1AccessModifier,
+            string part2AccessModifier)
+        {
+            string source = @"
+[Xunit.CollectionDefinition(""MyCollection"")]
+" + part1AccessModifier + @" partial class CollectionDefinitionClass { }
+" + part2AccessModifier + @" partial class CollectionDefinitionClass { }
+";
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, source);
+
+            Assert.Collection(diagnostics,
+                d =>
+                {
+                    Assert.Equal("Collection definition classes must be public", d.GetMessage());
+                    Assert.Equal("xUnit1027", d.Descriptor.Id);
+                });
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("", "internal")]
+        [InlineData("internal", "internal")]
+        public async void ForPartialClassInOtherFiles_WhenClassIsNonPublic_FindsError(
+            string part1AccessModifier,
+            string part2AccessModifier)
+        {
+            string source1 = @"
+[Xunit.CollectionDefinition(""MyCollection"")]
+" + part1AccessModifier + @" partial class CollectionDefinitionClass { }";
+            string source2 = @"
+" + part2AccessModifier + @" partial class CollectionDefinitionClass { }
+";
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, source1, source2);
+
+            Assert.Collection(diagnostics,
+                d =>
+                {
+                    Assert.Equal("Collection definition classes must be public", d.GetMessage());
+                    Assert.Equal("xUnit1027", d.Descriptor.Id);
+                });
+        }
+    }
+}


### PR DESCRIPTION
Right now If you forget to make it public you get the error **The following constructor parameters did not have matching fixture data: FixtureClass fixture**. 

The problem is that this error is shown at runtime and doesn't really tell you where the problem lies and how to fix it. How long it takes you to find the missing piece depends on your xunit knowledge. In my case, it took me 20 minutes because I made this pull request 😄 
