### PR TITLE
Closes xunit/xunit#1877 and fixes for surfaced bugs after the first fix

### DIFF
--- a/src/xunit.analyzers/InlineDataShouldBeUniqueWithinTheory.cs
+++ b/src/xunit.analyzers/InlineDataShouldBeUniqueWithinTheory.cs
@@ -130,7 +130,7 @@ namespace Xunit.Analyzers
                                         return false;
                                     break;
                                 case IParameterSymbol yMethodParamDefault:
-                                    if (xArgPrimitive.Value != yMethodParamDefault.ExplicitDefaultValue)
+                                    if (!object.Equals(xArgPrimitive.Value, yMethodParamDefault.ExplicitDefaultValue))
                                         return false;
                                     break;
                                 default:
@@ -141,11 +141,11 @@ namespace Xunit.Analyzers
                             switch (y)
                             {
                                 case TypedConstant yArgPrimitive when yArgPrimitive.Kind != TypedConstantKind.Array:
-                                    if (xMethodParamDefault.ExplicitDefaultValue != yArgPrimitive.Value)
+                                    if (!object.Equals(xMethodParamDefault.ExplicitDefaultValue, yArgPrimitive.Value))
                                         return false;
                                     break;
                                 case IParameterSymbol yMethodParamDefault:
-                                    if (xMethodParamDefault.ExplicitDefaultValue != yMethodParamDefault.ExplicitDefaultValue)
+                                    if (!object.Equals(xMethodParamDefault.ExplicitDefaultValue, yMethodParamDefault.ExplicitDefaultValue))
                                         return false;
                                     break;
                                 default:
@@ -156,12 +156,16 @@ namespace Xunit.Analyzers
                             switch (y)
                             {
                                 case TypedConstant yArgArray when yArgArray.Kind == TypedConstantKind.Array:
-                                    return AreArgumentsEqual(
+                                    if (!AreArgumentsEqual(
                                         xArgArray.Values.Cast<object>().ToImmutableArray(),
-                                        yArgArray.Values.Cast<object>().ToImmutableArray());
+                                        yArgArray.Values.Cast<object>().ToImmutableArray()))
+                                        return false;
+                                    break;
                                 default:
                                     return false;
                             }
+
+                            break;
                         default:
                             return false;
                     }


### PR DESCRIPTION
Closes xunit/xunit#1877. This was a fairly straightforward fix.

But the fix made the test [FindsError_WhenArgumentsAreArrayOfValuesAndTestMethodOffersDefaultParameterValues ](https://github.com/xunit/xunit.analyzers/blob/cebd67a5c3534e43a2e7b5fa0367d9ed1260bb3c/test/xunit.analyzers.tests/InlineDataShouldBeUniqueWithinTheoryTests.cs#L264) fail. The reason turned out to be a different bug that was hidden by the first bug, and was found by a little luck. The root cause for that was object reference comparison of boxed values, and while there was one test case for it, [FindsError_WhenDuplicatedByDefaultValueOfParameter](https://github.com/xunit/xunit.analyzers/blob/cebd67a5c3534e43a2e7b5fa0367d9ed1260bb3c/test/xunit.analyzers.tests/InlineDataShouldBeUniqueWithinTheoryTests.cs#L282), it used the value 1 as the default parameter value. That value did not trigger the lurking bug for some reason, but other values, such as 40 (that was used in FindsError_WhenArgumentsAreArrayOfValuesAndTestMethodOffersDefaultParameterValues), and 2, would trigger it. There were actually three similar bugs in that method. I added test cases for all of them.

Since this is my first contribution here, there might be something that I have overlooked. Let me know if there is something further to do here.