### PR TITLE
check for ConfigureAwaited tasks

### DIFF
--- a/src/xunit.analyzers/AssertThrowsShouldNotBeUsedForAsyncThrowsCheck.cs
+++ b/src/xunit.analyzers/AssertThrowsShouldNotBeUsedForAsyncThrowsCheck.cs
@@ -71,7 +71,15 @@ namespace Xunit.Analyzers
                 return false;
 
             var taskType = context.Compilation.GetTypeByMetadataName(Constants.Types.SystemThreadingTasksTask);
-            return taskType.IsAssignableFrom(((IMethodSymbol)symbol.Symbol).ReturnType);
+            var returnType = ((IMethodSymbol) symbol.Symbol).ReturnType;
+            if (taskType.IsAssignableFrom(returnType))
+                return true;
+
+            var configuredTaskAwaitableType = context.Compilation.GetTypeByMetadataName(Constants.Types.SystemRuntimeCompilerServicesConfiguredTaskAwaitable);
+            if (configuredTaskAwaitableType.IsAssignableFrom(returnType))
+                return true;
+
+            return false;
         }
     }
 }

--- a/src/xunit.analyzers/Constants.cs
+++ b/src/xunit.analyzers/Constants.cs
@@ -21,6 +21,7 @@
             internal static readonly string SystemObsoleteAttribute = "System.ObsoleteAttribute";
             internal static readonly string SystemCollectionsICollection = "System.Collections.ICollection";
             internal static readonly string SystemThreadingTasksTask = "System.Threading.Tasks.Task";
+            internal static readonly string SystemRuntimeCompilerServicesConfiguredTaskAwaitable = "System.Runtime.CompilerServices.ConfiguredTaskAwaitable";
             internal static readonly string SystemRuntimeInteropServicesOptionalAttribute = "System.Runtime.InteropServices.OptionalAttribute";
         }
     }

--- a/src/xunit.analyzers/PublicMethodShouldBeMarkedAsTest.cs
+++ b/src/xunit.analyzers/PublicMethodShouldBeMarkedAsTest.cs
@@ -15,6 +15,7 @@ namespace Xunit.Analyzers
         internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext)
         {
             var taskType = compilationStartContext.Compilation.GetTypeByMetadataName(Constants.Types.SystemThreadingTasksTask);
+            var configuredTaskAwaitableType = compilationStartContext.Compilation.GetTypeByMetadataName(Constants.Types.SystemRuntimeCompilerServicesConfiguredTaskAwaitable);
             var interfacesToIgnore = new List<INamedTypeSymbol>
                 {
                     compilationStartContext.Compilation.GetSpecialType(SpecialType.System_IDisposable),
@@ -60,7 +61,10 @@ namespace Xunit.Analyzers
                         continue;
 
                     if (method.DeclaredAccessibility == Accessibility.Public &&
-                        (method.ReturnsVoid || (taskType != null && Equals(method.ReturnType, taskType))))
+                        (method.ReturnsVoid ||
+                         (taskType != null && Equals(method.ReturnType, taskType)) ||
+                         (configuredTaskAwaitableType != null && Equals(method.ReturnType, configuredTaskAwaitableType))
+                         ))
                     {
                         var shouldIgnore = false;
                         while (!shouldIgnore || method.IsOverride)

--- a/test/xunit.analyzers.tests/AssertThrowsShouldNotBeUsedForAsyncThrowsCheckTests.cs
+++ b/test/xunit.analyzers.tests/AssertThrowsShouldNotBeUsedForAsyncThrowsCheckTests.cs
@@ -194,8 +194,8 @@ void TestMethod() {
             Assert.Collection(diagnostics, d =>
             {
                 Assert.Equal("Do not use Assert.Throws() to check for asynchronously thrown exceptions.", d.GetMessage());
-                Assert.Equal("xUnit2019", d.Id);
-                Assert.Equal(DiagnosticSeverity.Hidden, d.Severity);
+                Assert.Equal("xUnit2014", d.Id);
+                Assert.Equal(DiagnosticSeverity.Error, d.Severity);
             });
         }
 

--- a/test/xunit.analyzers.tests/AssertThrowsShouldNotBeUsedForAsyncThrowsCheckTests.cs
+++ b/test/xunit.analyzers.tests/AssertThrowsShouldNotBeUsedForAsyncThrowsCheckTests.cs
@@ -12,7 +12,7 @@ namespace Xunit.Analyzers
         public async Task FindsWarning_ForThrowsCheck_WithExceptionParameter_OnThrowingMethod()
         {
             var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
-                @"class TestClass { 
+                @"class TestClass {
 System.Threading.Tasks.Task ThrowingMethod() {
     throw new System.NotImplementedException();
 }
@@ -62,10 +62,26 @@ void TestMethod() {
         }
 
         [Fact]
+        public async Task FindsWarning_ForThrowsCheck_WithExceptionParameter_OnAsyncThrowingLambda_ConfiguredTaskAwaitable()
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
+                @"class TestClass { void TestMethod() {
+    Xunit.Assert.Throws(typeof(System.NotImplementedException), async () => await System.Threading.Tasks.Task.Delay(0).ConfigureAwait(false));
+} }");
+
+            Assert.Collection(diagnostics, d =>
+            {
+                Assert.Equal("Do not use Assert.Throws() to check for asynchronously thrown exceptions.", d.GetMessage());
+                Assert.Equal("xUnit2014", d.Id);
+                Assert.Equal(DiagnosticSeverity.Error, d.Severity);
+            });
+        }
+
+        [Fact]
         public async Task FindsWarning_ForThrowsCheck_WithExceptionTypeArgument_OnThrowingMethod()
         {
             var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, CompilationReporting.IgnoreErrors,
-                @"class TestClass { 
+                @"class TestClass {
 System.Threading.Tasks.Task ThrowingMethod() {
     throw new System.NotImplementedException();
 }
@@ -115,10 +131,26 @@ void TestMethod() {
         }
 
         [Fact]
+        public async Task FindsWarning_ForThrowsCheck_WithExceptionTypeArgument_OnAsyncThrowingLambda_ConfiguredTaskAwaitable()
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, CompilationReporting.IgnoreErrors,
+                @"class TestClass { void TestMethod() {
+    Xunit.Assert.Throws<System.NotImplementedException>(async () => await System.Threading.Tasks.Task.Delay(0).ConfigureAwait(false));
+} }");
+
+            Assert.Collection(diagnostics, d =>
+            {
+                Assert.Equal("Do not use obsolete Assert.Throws() to check for asynchronously thrown exceptions.", d.GetMessage());
+                Assert.Equal("xUnit2019", d.Id);
+                Assert.Equal(DiagnosticSeverity.Hidden, d.Severity);
+            });
+        }
+
+        [Fact]
         public async Task FindsWarning_ForThrowsCheck_WithExceptionTypeArgument_OnThrowingMethodWithParamName()
         {
             var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, CompilationReporting.IgnoreErrors,
-                @"class TestClass { 
+                @"class TestClass {
 System.Threading.Tasks.Task ThrowingMethod() {
     throw new System.NotImplementedException();
 }
@@ -152,6 +184,22 @@ void TestMethod() {
         }
 
         [Fact]
+        public async Task FindsWarning_ForThrowsCheck_WithExceptionTypeArgument_OnThrowingLambdaWithParamName_ConfiguredTaskAwaitable()
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, CompilationReporting.IgnoreErrors,
+                @"class TestClass { void TestMethod() {
+    Xunit.Assert.Throws<System.ArgumentException>(""param1"", () => System.Threading.Tasks.Task.Delay(0).ConfigureAwait(false));
+} }");
+
+            Assert.Collection(diagnostics, d =>
+            {
+                Assert.Equal("Do not use Assert.Throws() to check for asynchronously thrown exceptions.", d.GetMessage());
+                Assert.Equal("xUnit2019", d.Id);
+                Assert.Equal(DiagnosticSeverity.Hidden, d.Severity);
+            });
+        }
+
+        [Fact]
         public async Task FindsWarning_ForThrowsCheck_WithExceptionTypeArgument_OnAsyncThrowingLambdaWithParamName()
         {
             var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, CompilationReporting.IgnoreErrors,
@@ -168,10 +216,26 @@ void TestMethod() {
         }
 
         [Fact]
+        public async Task FindsWarning_ForThrowsCheck_WithExceptionTypeArgument_OnAsyncThrowingLambdaWithParamName_ConfiguredTaskAwaitable()
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, CompilationReporting.IgnoreErrors,
+                @"class TestClass { void TestMethod() {
+    Xunit.Assert.Throws<System.ArgumentException>(""param1"", async () => await System.Threading.Tasks.Task.Delay(0).ConfigureAwait(false));
+} }");
+
+            Assert.Collection(diagnostics, d =>
+            {
+                Assert.Equal("Do not use obsolete Assert.Throws() to check for asynchronously thrown exceptions.", d.GetMessage());
+                Assert.Equal("xUnit2019", d.Id);
+                Assert.Equal(DiagnosticSeverity.Hidden, d.Severity);
+            });
+        }
+
+        [Fact]
         public async Task FindsWarning_ForThrowsAnyCheck_WithExceptionTypeArgument_OnThrowingMethod()
         {
             var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, CompilationReporting.IgnoreErrors,
-                @"class TestClass { 
+                @"class TestClass {
 System.Threading.Tasks.Task ThrowingMethod() {
     throw new System.NotImplementedException();
 }
@@ -205,11 +269,43 @@ void TestMethod() {
         }
 
         [Fact]
+        public async Task FindsWarning_ForThrowsAnyCheck_WithExceptionTypeArgument_OnThrowingLambda_ConfiguredTaskAwaitable()
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, CompilationReporting.IgnoreErrors,
+                @"class TestClass { void TestMethod() {
+    Xunit.Assert.ThrowsAny<System.NotImplementedException>(() => System.Threading.Tasks.Task.Delay(0).ConfigureAwait(false));
+} }");
+
+            Assert.Collection(diagnostics, d =>
+            {
+                Assert.Equal("Do not use Assert.ThrowsAny() to check for asynchronously thrown exceptions.", d.GetMessage());
+                Assert.Equal("xUnit2014", d.Id);
+                Assert.Equal(DiagnosticSeverity.Error, d.Severity);
+            });
+        }
+
+        [Fact]
         public async Task FindsWarning_ForThrowsAnyCheck_WithExceptionTypeArgument_OnAsyncThrowingLambda()
         {
             var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, CompilationReporting.IgnoreErrors,
                 @"class TestClass { void TestMethod() {
     Xunit.Assert.ThrowsAny<System.NotImplementedException>(async () => await System.Threading.Tasks.Task.Delay(0));
+} }");
+
+            Assert.Collection(diagnostics, d =>
+            {
+                Assert.Equal("Do not use Assert.ThrowsAny() to check for asynchronously thrown exceptions.", d.GetMessage());
+                Assert.Equal("xUnit2014", d.Id);
+                Assert.Equal(DiagnosticSeverity.Error, d.Severity);
+            });
+        }
+
+        [Fact]
+        public async Task FindsWarning_ForThrowsAnyCheck_WithExceptionTypeArgument_OnAsyncThrowingLambda_ConfiguredTaskAwaitable()
+        {
+            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, CompilationReporting.IgnoreErrors,
+                @"class TestClass { void TestMethod() {
+    Xunit.Assert.ThrowsAny<System.NotImplementedException>(async () => await System.Threading.Tasks.Task.Delay(0).ConfigureAwait(false));
 } }");
 
             Assert.Collection(diagnostics, d =>

--- a/test/xunit.analyzers.tests/AssertThrowsShouldNotBeUsedForAsyncThrowsCheckTests.cs
+++ b/test/xunit.analyzers.tests/AssertThrowsShouldNotBeUsedForAsyncThrowsCheckTests.cs
@@ -51,17 +51,13 @@ void TestMethod() {
         [Fact]
         public async Task FindsWarning_ForThrowsCheck_WithExceptionParameter_OnAsyncThrowingLambda_ConfiguredTaskAwaitable()
         {
-            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer,
+            var source =
                 @"class TestClass { void TestMethod() {
     Xunit.Assert.Throws(typeof(System.NotImplementedException), async () => await System.Threading.Tasks.Task.Delay(0).ConfigureAwait(false));
-} }");
+} }";
 
-            Assert.Collection(diagnostics, d =>
-            {
-                Assert.Equal("Do not use Assert.Throws() to check for asynchronously thrown exceptions.", d.GetMessage());
-                Assert.Equal("xUnit2014", d.Id);
-                Assert.Equal(DiagnosticSeverity.Error, d.Severity);
-            });
+            var expected = Verify.Diagnostic("xUnit2014").WithSpan(2, 5, 2, 142).WithSeverity(DiagnosticSeverity.Error).WithArguments("Assert.Throws()");
+            await Verify.VerifyAnalyzerAsync(source, expected);
         }
 
         [Fact]
@@ -120,17 +116,17 @@ void TestMethod() {
         [Fact]
         public async Task FindsWarning_ForThrowsCheck_WithExceptionTypeArgument_OnAsyncThrowingLambda_ConfiguredTaskAwaitable()
         {
-            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, CompilationReporting.IgnoreErrors,
+            var source =
                 @"class TestClass { void TestMethod() {
     Xunit.Assert.Throws<System.NotImplementedException>(async () => await System.Threading.Tasks.Task.Delay(0).ConfigureAwait(false));
-} }");
+} }";
 
-            Assert.Collection(diagnostics, d =>
+            DiagnosticResult[] expected =
             {
-                Assert.Equal("Do not use obsolete Assert.Throws() to check for asynchronously thrown exceptions.", d.GetMessage());
-                Assert.Equal("xUnit2019", d.Id);
-                Assert.Equal(DiagnosticSeverity.Hidden, d.Severity);
-            });
+                Verify.CompilerError("CS0619").WithSpan(2, 5, 2, 134).WithMessage("'Assert.Throws<T>(Func<Task>)' is obsolete: 'You must call Assert.ThrowsAsync<T> (and await the result) when testing async code.'"),
+                Verify.Diagnostic("xUnit2019").WithSpan(2, 5, 2, 134).WithSeverity(DiagnosticSeverity.Hidden).WithArguments("Assert.Throws()"),
+            };
+            await Verify.VerifyAnalyzerAsync(source, expected);
         }
 
         [Fact]
@@ -173,17 +169,13 @@ void TestMethod() {
         [Fact]
         public async Task FindsWarning_ForThrowsCheck_WithExceptionTypeArgument_OnThrowingLambdaWithParamName_ConfiguredTaskAwaitable()
         {
-            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, CompilationReporting.IgnoreErrors,
+            var source =
                 @"class TestClass { void TestMethod() {
     Xunit.Assert.Throws<System.ArgumentException>(""param1"", () => System.Threading.Tasks.Task.Delay(0).ConfigureAwait(false));
-} }");
+} }";
 
-            Assert.Collection(diagnostics, d =>
-            {
-                Assert.Equal("Do not use Assert.Throws() to check for asynchronously thrown exceptions.", d.GetMessage());
-                Assert.Equal("xUnit2014", d.Id);
-                Assert.Equal(DiagnosticSeverity.Error, d.Severity);
-            });
+            var expected = Verify.Diagnostic("xUnit2014").WithSpan(2, 5, 2, 126).WithSeverity(DiagnosticSeverity.Error).WithArguments("Assert.Throws()");
+            await Verify.VerifyAnalyzerAsync(source, expected);
         }
 
         [Fact]
@@ -205,17 +197,17 @@ void TestMethod() {
         [Fact]
         public async Task FindsWarning_ForThrowsCheck_WithExceptionTypeArgument_OnAsyncThrowingLambdaWithParamName_ConfiguredTaskAwaitable()
         {
-            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, CompilationReporting.IgnoreErrors,
+            var source =
                 @"class TestClass { void TestMethod() {
     Xunit.Assert.Throws<System.ArgumentException>(""param1"", async () => await System.Threading.Tasks.Task.Delay(0).ConfigureAwait(false));
-} }");
+} }";
 
-            Assert.Collection(diagnostics, d =>
+            DiagnosticResult[] expected =
             {
-                Assert.Equal("Do not use obsolete Assert.Throws() to check for asynchronously thrown exceptions.", d.GetMessage());
-                Assert.Equal("xUnit2019", d.Id);
-                Assert.Equal(DiagnosticSeverity.Hidden, d.Severity);
-            });
+                Verify.CompilerError("CS0619").WithSpan(2, 5, 2, 138).WithMessage("'Assert.Throws<T>(string, Func<Task>)' is obsolete: 'You must call Assert.ThrowsAsync<T> (and await the result) when testing async code.'"),
+                Verify.Diagnostic("xUnit2019").WithSpan(2, 5, 2, 138).WithSeverity(DiagnosticSeverity.Hidden).WithArguments("Assert.Throws()"),
+            };
+            await Verify.VerifyAnalyzerAsync(source, expected);
         }
 
         [Fact]
@@ -250,17 +242,13 @@ void TestMethod() {
         [Fact]
         public async Task FindsWarning_ForThrowsAnyCheck_WithExceptionTypeArgument_OnThrowingLambda_ConfiguredTaskAwaitable()
         {
-            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, CompilationReporting.IgnoreErrors,
+            var source =
                 @"class TestClass { void TestMethod() {
     Xunit.Assert.ThrowsAny<System.NotImplementedException>(() => System.Threading.Tasks.Task.Delay(0).ConfigureAwait(false));
-} }");
+} }";
 
-            Assert.Collection(diagnostics, d =>
-            {
-                Assert.Equal("Do not use Assert.ThrowsAny() to check for asynchronously thrown exceptions.", d.GetMessage());
-                Assert.Equal("xUnit2014", d.Id);
-                Assert.Equal(DiagnosticSeverity.Error, d.Severity);
-            });
+            var expected = Verify.Diagnostic("xUnit2014").WithSpan(2, 5, 2, 125).WithSeverity(DiagnosticSeverity.Error).WithArguments("Assert.ThrowsAny()");
+            await Verify.VerifyAnalyzerAsync(source, expected);
         }
 
         [Fact]
@@ -278,17 +266,13 @@ void TestMethod() {
         [Fact]
         public async Task FindsWarning_ForThrowsAnyCheck_WithExceptionTypeArgument_OnAsyncThrowingLambda_ConfiguredTaskAwaitable()
         {
-            var diagnostics = await CodeAnalyzerHelper.GetDiagnosticsAsync(analyzer, CompilationReporting.IgnoreErrors,
+            var source =
                 @"class TestClass { void TestMethod() {
     Xunit.Assert.ThrowsAny<System.NotImplementedException>(async () => await System.Threading.Tasks.Task.Delay(0).ConfigureAwait(false));
-} }");
+} }";
 
-            Assert.Collection(diagnostics, d =>
-            {
-                Assert.Equal("Do not use Assert.ThrowsAny() to check for asynchronously thrown exceptions.", d.GetMessage());
-                Assert.Equal("xUnit2014", d.Id);
-                Assert.Equal(DiagnosticSeverity.Error, d.Severity);
-            });
+            var expected = Verify.Diagnostic("xUnit2014").WithSpan(2, 5, 2, 137).WithSeverity(DiagnosticSeverity.Error).WithArguments("Assert.ThrowsAny()");
+            await Verify.VerifyAnalyzerAsync(source, expected);
         }
 
         [Fact]


### PR DESCRIPTION
so we get a warning for

```
class TestClass { void TestMethod() {
    Xunit.Assert.Throws<System.ArgumentException>(
"param1",
() => System.Threading.Tasks.Task.Delay(0));
} }
```