### PR TITLE
Allowing analyzers to pass derived Xunit attributes

### DIFF
--- a/src/xunit.analyzers/TheoryMethodMustHaveTestData.cs
+++ b/src/xunit.analyzers/TheoryMethodMustHaveTestData.cs
@@ -17,8 +17,10 @@ namespace Xunit.Analyzers
             {
                 var symbol = (IMethodSymbol)symbolContext.Symbol;
                 var attributes = symbol.GetAttributes();
-                if (attributes.ContainsAttributeType(xunitContext.Core.TheoryAttributeType) &&
-                    (attributes.Length == 1 || !attributes.ContainsAttributeType(xunitContext.Core.DataAttributeType)))
+                if ((attributes.ContainsAttributeType(xunitContext.Core.TheoryAttributeType) || 
+                            (!attributes.ContainsAttributeType(xunitContext.Core.FactAttributeType) && 
+                              attributes.Any(a => a.AttributeClass.IsAssignableFrom(xunitContext.Core.TheoryAttributeType)))) &&
+                   (attributes.Length == 1 || !attributes.ContainsAttributeType(xunitContext.Core.DataAttributeType)))
                 {
                     symbolContext.ReportDiagnostic(Diagnostic.Create(Descriptors.X1003_TheoryMethodMustHaveTestData, symbol.Locations.First()));
                 }

--- a/test/xunit.analyzers.tests/TheoryMethodMustHaveTestDataTests.cs
+++ b/test/xunit.analyzers.tests/TheoryMethodMustHaveTestDataTests.cs
@@ -32,5 +32,13 @@ namespace Xunit.Analyzers
             var expected = Verify.Diagnostic().WithSpan(1, 46, 1, 56);
             await Verify.VerifyAnalyzerAsync(source, expected);
         }
+
+        [Fact]
+        public async void DoesNotFindErrorForMethodUsingInheritedTheoryAttribute()
+        {
+            var source = "public class CustomTheory : Xunit.TheoryAttribute { } public class TestClass { [CustomTheory] [Xunit.InlineData(1)] public void TestMethod(int x) { } }";
+
+            await Verify.VerifyAnalyzerAsync(source);
+        }
     }
 }


### PR DESCRIPTION
This pull request is to address [#1963](https://github.com/xunit/xunit/issues/1963) by adding a use case to the TheoryMethodMustHaveTestData analyzer to allow attributes that inherit from the Xunit.TheoryAttribute class.

Excited and ready for feedback!