### PR TITLE
remove redundant 'as' checks

### DIFF
--- a/src/xunit.analyzers/ClassDataAttributeMustPointAtValidClass.cs
+++ b/src/xunit.analyzers/ClassDataAttributeMustPointAtValidClass.cs
@@ -20,7 +20,7 @@ namespace Xunit.Analyzers
 
             compilationStartContext.RegisterSyntaxNodeAction(syntaxNodeContext =>
             {
-                var attribute = syntaxNodeContext.Node as AttributeSyntax;
+                var attribute = (AttributeSyntax)syntaxNodeContext.Node;
                 var semanticModel = syntaxNodeContext.SemanticModel;
                 if (!Equals(semanticModel.GetTypeInfo(attribute).Type, xunitContext.Core.ClassDataAttributeType))
                     return;

--- a/src/xunit.analyzers/FactMethodMustNotHaveParameters.cs
+++ b/src/xunit.analyzers/FactMethodMustNotHaveParameters.cs
@@ -18,7 +18,7 @@ namespace Xunit.Analyzers
         {
             compilationStartContext.RegisterSyntaxNodeAction(syntaxNodeContext =>
             {
-                var methodDeclaration = syntaxNodeContext.Node as MethodDeclarationSyntax;
+                var methodDeclaration = (MethodDeclarationSyntax)syntaxNodeContext.Node;
                 if (methodDeclaration.ParameterList.Parameters.Count == 0)
                     return;
 

--- a/src/xunit.analyzers/MemberDataShouldReferenceValidMember.cs
+++ b/src/xunit.analyzers/MemberDataShouldReferenceValidMember.cs
@@ -34,7 +34,7 @@ namespace Xunit.Analyzers
 
             compilationStartContext.RegisterSyntaxNodeAction(symbolContext =>
             {
-                var attribute = symbolContext.Node as AttributeSyntax;
+                var attribute = (AttributeSyntax)symbolContext.Node;
                 var semanticModel = symbolContext.SemanticModel;
                 if (!Equals(semanticModel.GetTypeInfo(attribute, symbolContext.CancellationToken).Type, xunitContext.Core.MemberDataAttributeType))
                     return;

--- a/src/xunit.analyzers/SerializableClassMustHaveParameterlessConstructor.cs
+++ b/src/xunit.analyzers/SerializableClassMustHaveParameterlessConstructor.cs
@@ -17,7 +17,7 @@ namespace Xunit.Analyzers
         {
             compilationStartContext.RegisterSyntaxNodeAction(syntaxNodeContext =>
             {
-                var classDeclaration = syntaxNodeContext.Node as ClassDeclarationSyntax;
+                var classDeclaration = (ClassDeclarationSyntax)syntaxNodeContext.Node;
                 if (classDeclaration.BaseList == null)
                     return;
 

--- a/src/xunit.analyzers/TestCaseMustBeLongLivedMarshalByRefObject.cs
+++ b/src/xunit.analyzers/TestCaseMustBeLongLivedMarshalByRefObject.cs
@@ -16,7 +16,7 @@ namespace Xunit.Analyzers
         {
             compilationStartContext.RegisterSyntaxNodeAction(syntaxNodeContext =>
             {
-                var classDeclaration = syntaxNodeContext.Node as ClassDeclarationSyntax;
+                var classDeclaration = (ClassDeclarationSyntax)syntaxNodeContext.Node;
                 if (classDeclaration.BaseList == null)
                     return;
 

--- a/src/xunit.analyzers/TestMethodShouldNotBeSkipped.cs
+++ b/src/xunit.analyzers/TestMethodShouldNotBeSkipped.cs
@@ -17,7 +17,7 @@ namespace Xunit.Analyzers
         {
             compilationStartContext.RegisterSyntaxNodeAction(syntaxNodeContext =>
             {
-                var attribute = syntaxNodeContext.Node as AttributeSyntax;
+                var attribute = (AttributeSyntax)syntaxNodeContext.Node;
                 if (!(attribute.ArgumentList?.Arguments.Any() ?? false))
                     return;
 


### PR DESCRIPTION
Since Analyzers are filtered by node type. the `as` type checks are redundant