### PR TITLE
Fix for false positive of xUnit1026 when an out parameter is used for Moq setup (#1802)

### DIFF
--- a/src/xunit.analyzers/TheoryMethodShouldUseAllParameters.cs
+++ b/src/xunit.analyzers/TheoryMethodShouldUseAllParameters.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -41,7 +43,7 @@ namespace Xunit.Analyzers
 			if (!flowAnalysis.Succeeded)
 				return;
 
-			var usedParameters = new HashSet<ISymbol>(flowAnalysis.ReadInside);
+			var usedParameters = new HashSet<ISymbol>(flowAnalysis.ReadInside.Concat(flowAnalysis.Captured).Distinct());
 
 			for (var i = 0; i < methodSymbol.Parameters.Length; i++)
 			{

--- a/src/xunit.analyzers/TheoryMethodShouldUseAllParameters.cs
+++ b/src/xunit.analyzers/TheoryMethodShouldUseAllParameters.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/test/xunit.analyzers.tests/TheoryMethodShouldUseAllParametersTests.cs
+++ b/test/xunit.analyzers.tests/TheoryMethodShouldUseAllParametersTests.cs
@@ -125,6 +125,28 @@ class TestClass
 		}
 
 		[Fact]
+		public async void DoesNotFindWarning_ParameterCapturedAsOutParameterInMockSetup()
+		{
+			var source = @"
+using System;
+using Xunit;
+
+class TestClass
+{
+    [Theory]
+    void TestMethod(string used, int usedOut)
+    {
+        // mimicking mock setup use case
+        // var mock = new Mock<IHaveOutParameter>();
+        // mock.Setup(m => m.SomeMethod(out used));
+		Action setup = () => int.TryParse(used, out usedOut);
+    }
+}";
+
+			await Verify.VerifyAnalyzerAsync(source);
+		}
+
+		[Fact]
 		public async void DoesNotFindWarning_ExpressionBodiedMethod()
 		{
 			var source = @"

--- a/test/xunit.analyzers.tests/TheoryMethodShouldUseAllParametersTests.cs
+++ b/test/xunit.analyzers.tests/TheoryMethodShouldUseAllParametersTests.cs
@@ -139,7 +139,7 @@ class TestClass
         // mimicking mock setup use case
         // var mock = new Mock<IHaveOutParameter>();
         // mock.Setup(m => m.SomeMethod(out used));
-		Action setup = () => int.TryParse(used, out usedOut);
+        Action setup = () => int.TryParse(used, out usedOut);
     }
 }";
 


### PR DESCRIPTION
Fix for issue https://github.com/xunit/xunit/issues/1802
It basically not only looks for read parameters in the code analysis but also respects captured ones. Since Moq is using this capturing to actually read the value.