### PR TITLE
Use 'context' as the name for analyzer context parameters

### DIFF
--- a/src/xunit.analyzers/Analysis/AssertUsageAnalyzerBase.cs
+++ b/src/xunit.analyzers/Analysis/AssertUsageAnalyzerBase.cs
@@ -29,17 +29,17 @@ namespace Xunit.Analyzers
 			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
 			context.EnableConcurrentExecution();
 
-			context.RegisterCompilationStartAction(compilationContext =>
+			context.RegisterCompilationStartAction(context =>
 			{
-				var assertType = compilationContext.Compilation.GetTypeByMetadataName(Constants.Types.XunitAssert);
+				var assertType = context.Compilation.GetTypeByMetadataName(Constants.Types.XunitAssert);
 				if (assertType == null)
 					return;
 
-				compilationContext.RegisterSyntaxNodeAction(syntaxContext =>
+				context.RegisterSyntaxNodeAction(context =>
 				{
-					var invocation = (InvocationExpressionSyntax)syntaxContext.Node;
+					var invocation = (InvocationExpressionSyntax)context.Node;
 
-					var symbolInfo = syntaxContext.SemanticModel.GetSymbolInfo(invocation, syntaxContext.CancellationToken);
+					var symbolInfo = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken);
 					if (symbolInfo.Symbol?.Kind != SymbolKind.Method)
 						return;
 
@@ -49,7 +49,7 @@ namespace Xunit.Analyzers
 							!methodNames.Contains(methodSymbol.Name))
 						return;
 
-					Analyze(syntaxContext, invocation, methodSymbol);
+					Analyze(context, invocation, methodSymbol);
 
 				}, SyntaxKind.InvocationExpression);
 			});

--- a/src/xunit.analyzers/Analysis/XunitDiagnosticAnalyzer.cs
+++ b/src/xunit.analyzers/Analysis/XunitDiagnosticAnalyzer.cs
@@ -20,17 +20,17 @@ namespace Xunit.Analyzers
 			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
 			context.EnableConcurrentExecution();
 
-			context.RegisterCompilationStartAction(compilationStartContext =>
+			context.RegisterCompilationStartAction(context =>
 			{
-				var xunitContext = new XunitContext(compilationStartContext.Compilation, versionOverride);
+				var xunitContext = new XunitContext(context.Compilation, versionOverride);
 				if (ShouldAnalyze(xunitContext))
-					AnalyzeCompilation(compilationStartContext, xunitContext);
+					AnalyzeCompilation(context, xunitContext);
 			});
 		}
 
 		protected virtual bool ShouldAnalyze(XunitContext xunitContext)
 			=> xunitContext.HasCoreReference;
 
-		internal abstract void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext);
+		internal abstract void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext);
 	}
 }

--- a/src/xunit.analyzers/ClassDataAttributeMustPointAtValidClass.cs
+++ b/src/xunit.analyzers/ClassDataAttributeMustPointAtValidClass.cs
@@ -13,15 +13,15 @@ namespace Xunit.Analyzers
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
 		   ImmutableArray.Create(Descriptors.X1007_ClassDataAttributeMustPointAtValidClass);
 
-		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext)
+		internal override void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext)
 		{
-			var compilation = compilationStartContext.Compilation;
+			var compilation = context.Compilation;
 			var iEnumerableOfObjectArray = TypeSymbolFactory.IEnumerableOfObjectArray(compilation);
 
-			compilationStartContext.RegisterSyntaxNodeAction(syntaxNodeContext =>
+			context.RegisterSyntaxNodeAction(context =>
 			{
-				var attribute = (AttributeSyntax)syntaxNodeContext.Node;
-				var semanticModel = syntaxNodeContext.SemanticModel;
+				var attribute = (AttributeSyntax)context.Node;
+				var semanticModel = context.SemanticModel;
 				if (!Equals(semanticModel.GetTypeInfo(attribute).Type, xunitContext.Core.ClassDataAttributeType))
 					return;
 
@@ -38,7 +38,7 @@ namespace Xunit.Analyzers
 
 				if (missingInterface || isAbstract || noValidConstructor)
 				{
-					syntaxNodeContext.ReportDiagnostic(Diagnostic.Create(
+					context.ReportDiagnostic(Diagnostic.Create(
 						Descriptors.X1007_ClassDataAttributeMustPointAtValidClass,
 						argumentExpression.Type.GetLocation(),
 						classType.Name));

--- a/src/xunit.analyzers/DataAttributeShouldBeUsedOnATheory.cs
+++ b/src/xunit.analyzers/DataAttributeShouldBeUsedOnATheory.cs
@@ -11,11 +11,11 @@ namespace Xunit.Analyzers
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
 			=> ImmutableArray.Create(Descriptors.X1008_DataAttributeShouldBeUsedOnATheory);
 
-		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext)
+		internal override void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext)
 		{
-			compilationStartContext.RegisterSymbolAction(symbolContext =>
+			context.RegisterSymbolAction(context =>
 			{
-				var methodSymbol = (IMethodSymbol)symbolContext.Symbol;
+				var methodSymbol = (IMethodSymbol)context.Symbol;
 				var attributes = methodSymbol.GetAttributes();
 				if (attributes.Length == 0)
 					return;
@@ -23,7 +23,7 @@ namespace Xunit.Analyzers
 				// Instead of checking for Theory, we check for any Fact. If it is a Fact which is not a Theory,
 				// we will let other rules (i.e. FactMethodShouldNotHaveTestData) handle that case.
 				if (!attributes.ContainsAttributeType(xunitContext.Core.FactAttributeType) && attributes.ContainsAttributeType(xunitContext.Core.DataAttributeType))
-					symbolContext.ReportDiagnostic(
+					context.ReportDiagnostic(
 						Diagnostic.Create(
 							Descriptors.X1008_DataAttributeShouldBeUsedOnATheory,
 							methodSymbol.Locations.First()));

--- a/src/xunit.analyzers/FactMethodMustNotHaveParameters.cs
+++ b/src/xunit.analyzers/FactMethodMustNotHaveParameters.cs
@@ -14,17 +14,17 @@ namespace Xunit.Analyzers
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
 			=> ImmutableArray.Create(Descriptors.X1001_FactMethodMustNotHaveParameters);
 
-		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext)
+		internal override void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext)
 		{
-			compilationStartContext.RegisterSyntaxNodeAction(syntaxNodeContext =>
+			context.RegisterSyntaxNodeAction(context =>
 			{
-				var methodDeclaration = (MethodDeclarationSyntax)syntaxNodeContext.Node;
+				var methodDeclaration = (MethodDeclarationSyntax)context.Node;
 				if (methodDeclaration.ParameterList.Parameters.Count == 0)
 					return;
 
-				if (methodDeclaration.AttributeLists.ContainsAttributeType(syntaxNodeContext.SemanticModel, xunitContext.Core.FactAttributeType, exactMatch: true))
+				if (methodDeclaration.AttributeLists.ContainsAttributeType(context.SemanticModel, xunitContext.Core.FactAttributeType, exactMatch: true))
 				{
-					syntaxNodeContext.ReportDiagnostic(
+					context.ReportDiagnostic(
 						Diagnostic.Create(
 							Descriptors.X1001_FactMethodMustNotHaveParameters,
 							methodDeclaration.Identifier.GetLocation(),

--- a/src/xunit.analyzers/FactMethodShouldNotHaveTestData.cs
+++ b/src/xunit.analyzers/FactMethodShouldNotHaveTestData.cs
@@ -12,18 +12,18 @@ namespace Xunit.Analyzers
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
 			=> ImmutableArray.Create(Descriptors.X1005_FactMethodShouldNotHaveTestData);
 
-		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext)
+		internal override void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext)
 		{
-			compilationStartContext.RegisterSymbolAction(symbolContext =>
+			context.RegisterSymbolAction(context =>
 			{
-				var symbol = (IMethodSymbol)symbolContext.Symbol;
+				var symbol = (IMethodSymbol)context.Symbol;
 				var attributes = symbol.GetAttributes();
 				if (attributes.Length > 1 &&
 					attributes.ContainsAttributeType(xunitContext.Core.FactAttributeType, exactMatch: true) &&
 					!attributes.ContainsAttributeType(xunitContext.Core.TheoryAttributeType) &&
 					attributes.ContainsAttributeType(xunitContext.Core.DataAttributeType))
 				{
-					symbolContext.ReportDiagnostic(
+					context.ReportDiagnostic(
 						Diagnostic.Create(
 							Descriptors.X1005_FactMethodShouldNotHaveTestData,
 							symbol.Locations.First()));

--- a/src/xunit.analyzers/InlineDataShouldBeUniqueWithinTheory.cs
+++ b/src/xunit.analyzers/InlineDataShouldBeUniqueWithinTheory.cs
@@ -13,8 +13,8 @@ namespace Xunit.Analyzers
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
 			=> ImmutableArray.Create(Descriptors.X1025_InlineDataShouldBeUniqueWithinTheory);
 
-		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext)
-			=> compilationStartContext.RegisterSymbolAction(symbolContext => AnalyzeMethod(symbolContext, xunitContext), SymbolKind.Method);
+		internal override void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext)
+			=> context.RegisterSymbolAction(context => AnalyzeMethod(context, xunitContext), SymbolKind.Method);
 
 		private static void AnalyzeMethod(SymbolAnalysisContext context, XunitContext xunitContext)
 		{

--- a/src/xunit.analyzers/PublicMethodShouldBeMarkedAsTest.cs
+++ b/src/xunit.analyzers/PublicMethodShouldBeMarkedAsTest.cs
@@ -12,19 +12,19 @@ namespace Xunit.Analyzers
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
 			=> ImmutableArray.Create(Descriptors.X1013_PublicMethodShouldBeMarkedAsTest);
 
-		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext)
+		internal override void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext)
 		{
-			var taskType = compilationStartContext.Compilation.GetTypeByMetadataName(Constants.Types.SystemThreadingTasksTask);
-			var configuredTaskAwaitableType = compilationStartContext.Compilation.GetTypeByMetadataName(Constants.Types.SystemRuntimeCompilerServicesConfiguredTaskAwaitable);
+			var taskType = context.Compilation.GetTypeByMetadataName(Constants.Types.SystemThreadingTasksTask);
+			var configuredTaskAwaitableType = context.Compilation.GetTypeByMetadataName(Constants.Types.SystemRuntimeCompilerServicesConfiguredTaskAwaitable);
 			var interfacesToIgnore = new List<INamedTypeSymbol>
 			{
-				compilationStartContext.Compilation.GetSpecialType(SpecialType.System_IDisposable),
-				compilationStartContext.Compilation.GetTypeByMetadataName(Constants.Types.XunitIAsyncLifetime),
+				context.Compilation.GetSpecialType(SpecialType.System_IDisposable),
+				context.Compilation.GetTypeByMetadataName(Constants.Types.XunitIAsyncLifetime),
 			};
 
-			compilationStartContext.RegisterSymbolAction(symbolContext =>
+			context.RegisterSymbolAction(context =>
 			{
-				var type = (INamedTypeSymbol)symbolContext.Symbol;
+				var type = (INamedTypeSymbol)context.Symbol;
 
 				if (type.TypeKind != TypeKind.Class ||
 					type.DeclaredAccessibility != Accessibility.Public ||
@@ -41,7 +41,7 @@ namespace Xunit.Analyzers
 				var violations = new List<IMethodSymbol>();
 				foreach (var member in type.GetMembers().Where(m => m.Kind == SymbolKind.Method))
 				{
-					symbolContext.CancellationToken.ThrowIfCancellationRequested();
+					context.CancellationToken.ThrowIfCancellationRequested();
 
 					var method = (IMethodSymbol)member;
 					// Check for method.IsAbstract and earlier for type.IsAbstract is done
@@ -92,7 +92,7 @@ namespace Xunit.Analyzers
 					foreach (var method in violations)
 					{
 						var testType = method.Parameters.Any() ? "Theory" : "Fact";
-						symbolContext.ReportDiagnostic(
+						context.ReportDiagnostic(
 							Diagnostic.Create(
 								Descriptors.X1013_PublicMethodShouldBeMarkedAsTest,
 								method.Locations.First(),

--- a/src/xunit.analyzers/SerializableClassMustHaveParameterlessConstructor.cs
+++ b/src/xunit.analyzers/SerializableClassMustHaveParameterlessConstructor.cs
@@ -13,19 +13,19 @@ namespace Xunit.Analyzers
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
 			=> ImmutableArray.Create(Descriptors.X3001_SerializableClassMustHaveParameterlessConstructor);
 
-		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext)
+		internal override void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext)
 		{
-			compilationStartContext.RegisterSyntaxNodeAction(syntaxNodeContext =>
+			context.RegisterSyntaxNodeAction(context =>
 			{
-				var classDeclaration = (ClassDeclarationSyntax)syntaxNodeContext.Node;
+				var classDeclaration = (ClassDeclarationSyntax)context.Node;
 				if (classDeclaration.BaseList == null)
 					return;
 
-				var semanticModel = syntaxNodeContext.SemanticModel;
+				var semanticModel = context.SemanticModel;
 
 				foreach (var baseType in classDeclaration.BaseList.Types)
 				{
-					var type = semanticModel.GetTypeInfo(baseType.Type, compilationStartContext.CancellationToken).Type;
+					var type = semanticModel.GetTypeInfo(baseType.Type, context.CancellationToken).Type;
 					if (xunitContext.Abstractions.IXunitSerializableType?.IsAssignableFrom(type) == true)
 					{
 						if (!classDeclaration.Members.OfType<ConstructorDeclarationSyntax>().Any())
@@ -33,7 +33,7 @@ namespace Xunit.Analyzers
 
 						var parameterlessCtor = classDeclaration.Members.OfType<ConstructorDeclarationSyntax>().FirstOrDefault(c => c.ParameterList.Parameters.Count == 0);
 						if (parameterlessCtor == null || !parameterlessCtor.Modifiers.Any(m => m.Text == "public"))
-							syntaxNodeContext.ReportDiagnostic(
+							context.ReportDiagnostic(
 								Diagnostic.Create(
 									Descriptors.X3001_SerializableClassMustHaveParameterlessConstructor,
 									classDeclaration.Identifier.GetLocation(),

--- a/src/xunit.analyzers/TestCaseMustBeLongLivedMarshalByRefObject.cs
+++ b/src/xunit.analyzers/TestCaseMustBeLongLivedMarshalByRefObject.cs
@@ -12,21 +12,21 @@ namespace Xunit.Analyzers
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
 			=> ImmutableArray.Create(Descriptors.X3000_TestCaseMustBeLongLivedMarshalByRefObject);
 
-		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext)
+		internal override void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext)
 		{
-			compilationStartContext.RegisterSyntaxNodeAction(syntaxNodeContext =>
+			context.RegisterSyntaxNodeAction(context =>
 			{
-				var classDeclaration = (ClassDeclarationSyntax)syntaxNodeContext.Node;
+				var classDeclaration = (ClassDeclarationSyntax)context.Node;
 				if (classDeclaration.BaseList == null)
 					return;
 
-				var semanticModel = syntaxNodeContext.SemanticModel;
+				var semanticModel = context.SemanticModel;
 				var isTestCase = false;
 				var hasMBRO = false;
 
 				foreach (var baseType in classDeclaration.BaseList.Types)
 				{
-					var type = semanticModel.GetTypeInfo(baseType.Type, compilationStartContext.CancellationToken).Type;
+					var type = semanticModel.GetTypeInfo(baseType.Type, context.CancellationToken).Type;
 					if (xunitContext.Abstractions.ITestCaseType?.IsAssignableFrom(type) == true)
 						isTestCase = true;
 					if (xunitContext.Execution.LongLivedMarshalByRefObjectType?.IsAssignableFrom(type) == true)
@@ -35,7 +35,7 @@ namespace Xunit.Analyzers
 
 				if (isTestCase && !hasMBRO)
 				{
-					syntaxNodeContext.ReportDiagnostic(Diagnostic.Create(
+					context.ReportDiagnostic(Diagnostic.Create(
 						Descriptors.X3000_TestCaseMustBeLongLivedMarshalByRefObject,
 						classDeclaration.Identifier.GetLocation(),
 						classDeclaration.Identifier.ValueText));

--- a/src/xunit.analyzers/TestClassMustBePublic.cs
+++ b/src/xunit.analyzers/TestClassMustBePublic.cs
@@ -11,9 +11,9 @@ namespace Xunit.Analyzers
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
 			=> ImmutableArray.Create(Descriptors.X1000_TestClassMustBePublic);
 
-		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext)
+		internal override void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext)
 		{
-			compilationStartContext.RegisterSymbolAction(context =>
+			context.RegisterSymbolAction(context =>
 			{
 				if (context.Symbol.DeclaredAccessibility == Accessibility.Public)
 					return;

--- a/src/xunit.analyzers/TestClassShouldHaveTFixtureArgument.cs
+++ b/src/xunit.analyzers/TestClassShouldHaveTFixtureArgument.cs
@@ -14,9 +14,9 @@ namespace Xunit.Analyzers
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
 			=> ImmutableArray.Create(Descriptors.X1033_TestClassShouldHaveTFixtureArgument);
 
-		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext)
+		internal override void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext)
 		{
-			compilationStartContext.RegisterSymbolAction(context =>
+			context.RegisterSymbolAction(context =>
 			{
 				if (context.Symbol.DeclaredAccessibility != Accessibility.Public)
 					return;

--- a/src/xunit.analyzers/TestMethodCannotHaveOverloads.cs
+++ b/src/xunit.analyzers/TestMethodCannotHaveOverloads.cs
@@ -14,11 +14,11 @@ namespace Xunit.Analyzers
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
 			ImmutableArray.Create(Descriptors.X1024_TestMethodCannotHaveOverloads);
 
-		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext)
+		internal override void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext)
 		{
-			compilationStartContext.RegisterSymbolAction(symbolContext =>
+			context.RegisterSymbolAction(context =>
 			{
-				var typeSymbol = (INamedTypeSymbol)symbolContext.Symbol;
+				var typeSymbol = (INamedTypeSymbol)context.Symbol;
 				if (typeSymbol.TypeKind != TypeKind.Class)
 					return;
 
@@ -30,7 +30,7 @@ namespace Xunit.Analyzers
 
 				foreach (var grouping in methodsByName)
 				{
-					symbolContext.CancellationToken.ThrowIfCancellationRequested();
+					context.CancellationToken.ThrowIfCancellationRequested();
 
 					var methods = grouping.ToList();
 					var methodName = grouping.Key;
@@ -51,7 +51,7 @@ namespace Xunit.Analyzers
 							.OrderBy(m => m.ContainingType, TypeHierarchyComparer.Instance)
 							.First().ContainingType;
 
-						symbolContext.ReportDiagnostic(
+						context.ReportDiagnostic(
 							Diagnostic.Create(
 								Descriptors.X1024_TestMethodCannotHaveOverloads,
 								method.Locations.First(),

--- a/src/xunit.analyzers/TestMethodMustNotHaveMultipleFactAttributes.cs
+++ b/src/xunit.analyzers/TestMethodMustNotHaveMultipleFactAttributes.cs
@@ -12,11 +12,11 @@ namespace Xunit.Analyzers
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
 			=> ImmutableArray.Create(Descriptors.X1002_TestMethodMustNotHaveMultipleFactAttributes);
 
-		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext)
+		internal override void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext)
 		{
-			compilationStartContext.RegisterSymbolAction(symbolContext =>
+			context.RegisterSymbolAction(context =>
 			{
-				var symbol = (IMethodSymbol)symbolContext.Symbol;
+				var symbol = (IMethodSymbol)context.Symbol;
 				var attributeTypes = new HashSet<INamedTypeSymbol>();
 				var count = 0;
 				foreach (var attribute in symbol.GetAttributes())
@@ -31,7 +31,7 @@ namespace Xunit.Analyzers
 
 				if (count > 1)
 				{
-					symbolContext.ReportDiagnostic(
+					context.ReportDiagnostic(
 						Diagnostic.Create(
 							Descriptors.X1002_TestMethodMustNotHaveMultipleFactAttributes,
 							symbol.Locations.First(),

--- a/src/xunit.analyzers/TestMethodShouldNotBeSkipped.cs
+++ b/src/xunit.analyzers/TestMethodShouldNotBeSkipped.cs
@@ -13,21 +13,21 @@ namespace Xunit.Analyzers
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
 			=> ImmutableArray.Create(Descriptors.X1004_TestMethodShouldNotBeSkipped);
 
-		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext)
+		internal override void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext)
 		{
-			compilationStartContext.RegisterSyntaxNodeAction(syntaxNodeContext =>
+			context.RegisterSyntaxNodeAction(context =>
 			{
-				var attribute = (AttributeSyntax)syntaxNodeContext.Node;
+				var attribute = (AttributeSyntax)context.Node;
 				if (!(attribute.ArgumentList?.Arguments.Any() ?? false))
 					return;
 
-				var attributeType = syntaxNodeContext.SemanticModel.GetTypeInfo(attribute).Type;
+				var attributeType = context.SemanticModel.GetTypeInfo(attribute).Type;
 				if (!xunitContext.Core.FactAttributeType.IsAssignableFrom(attributeType))
 					return;
 
 				var skipArgument = attribute.ArgumentList.Arguments.FirstOrDefault(arg => arg.NameEquals?.Name?.Identifier.ValueText == "Skip");
 				if (skipArgument != null)
-					syntaxNodeContext.ReportDiagnostic(
+					context.ReportDiagnostic(
 						Diagnostic.Create(
 							Descriptors.X1004_TestMethodShouldNotBeSkipped,
 							skipArgument.GetLocation()));

--- a/src/xunit.analyzers/TheoryMethodCannotHaveDefaultParameter.cs
+++ b/src/xunit.analyzers/TheoryMethodCannotHaveDefaultParameter.cs
@@ -24,25 +24,25 @@ namespace Xunit.Analyzers
 		protected override bool ShouldAnalyze(XunitContext xunitContext)
 			=> !xunitContext.Core.TheorySupportsDefaultParameterValues;
 
-		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext)
+		internal override void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext)
 		{
-			compilationStartContext.RegisterSymbolAction(symbolContext =>
+			context.RegisterSymbolAction(context =>
 			{
-				var method = (IMethodSymbol)symbolContext.Symbol;
+				var method = (IMethodSymbol)context.Symbol;
 				var attributes = method.GetAttributes();
 				if (!attributes.ContainsAttributeType(xunitContext.Core.TheoryAttributeType))
 					return;
 
 				foreach (var parameter in method.Parameters)
 				{
-					symbolContext.CancellationToken.ThrowIfCancellationRequested();
+					context.CancellationToken.ThrowIfCancellationRequested();
 					if (parameter.HasExplicitDefaultValue)
 					{
 						var syntaxNode = parameter.DeclaringSyntaxReferences.First()
-							.GetSyntax(compilationStartContext.CancellationToken)
+							.GetSyntax(context.CancellationToken)
 							.FirstAncestorOrSelf<ParameterSyntax>();
 
-						symbolContext.ReportDiagnostic(
+						context.ReportDiagnostic(
 							Diagnostic.Create(
 								Descriptors.X1023_TheoryMethodCannotHaveDefaultParameter,
 								syntaxNode.Default.GetLocation(),

--- a/src/xunit.analyzers/TheoryMethodCannotHaveParamsArray.cs
+++ b/src/xunit.analyzers/TheoryMethodCannotHaveParamsArray.cs
@@ -23,11 +23,11 @@ namespace Xunit.Analyzers
 		protected override bool ShouldAnalyze(XunitContext xunitContext)
 			=> xunitContext.HasCoreReference && !xunitContext.Core.TheorySupportsParameterArrays;
 
-		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext)
+		internal override void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext)
 		{
-			compilationStartContext.RegisterSymbolAction(symbolContext =>
+			context.RegisterSymbolAction(context =>
 			{
-				var method = (IMethodSymbol)symbolContext.Symbol;
+				var method = (IMethodSymbol)context.Symbol;
 				var parameter = method.Parameters.LastOrDefault();
 				if (!(parameter?.IsParams ?? false))
 					return;
@@ -35,10 +35,10 @@ namespace Xunit.Analyzers
 				var attributes = method.GetAttributes();
 				if (attributes.ContainsAttributeType(xunitContext.Core.TheoryAttributeType))
 				{
-					symbolContext.ReportDiagnostic(
+					context.ReportDiagnostic(
 						Diagnostic.Create(
 							Descriptors.X1022_TheoryMethodCannotHaveParameterArray,
-							parameter.DeclaringSyntaxReferences.First().GetSyntax(compilationStartContext.CancellationToken).GetLocation(),
+							parameter.DeclaringSyntaxReferences.First().GetSyntax(context.CancellationToken).GetLocation(),
 							method.Name,
 							method.ContainingType.ToDisplayString(),
 							parameter.Name));

--- a/src/xunit.analyzers/TheoryMethodMustHaveTestData.cs
+++ b/src/xunit.analyzers/TheoryMethodMustHaveTestData.cs
@@ -11,16 +11,16 @@ namespace Xunit.Analyzers
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
 		   ImmutableArray.Create(Descriptors.X1003_TheoryMethodMustHaveTestData);
 
-		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext)
+		internal override void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext)
 		{
-			compilationStartContext.RegisterSymbolAction(symbolContext =>
+			context.RegisterSymbolAction(context =>
 			{
-				var symbol = (IMethodSymbol)symbolContext.Symbol;
+				var symbol = (IMethodSymbol)context.Symbol;
 				var attributes = symbol.GetAttributes();
 				if (attributes.ContainsAttributeType(xunitContext.Core.TheoryAttributeType) &&
 					(attributes.Length == 1 || !attributes.ContainsAttributeType(xunitContext.Core.DataAttributeType)))
 				{
-					symbolContext.ReportDiagnostic(
+					context.ReportDiagnostic(
 						Diagnostic.Create(
 							Descriptors.X1003_TheoryMethodMustHaveTestData,
 							symbol.Locations.First()));

--- a/src/xunit.analyzers/TheoryMethodShouldHaveParameters.cs
+++ b/src/xunit.analyzers/TheoryMethodShouldHaveParameters.cs
@@ -11,17 +11,17 @@ namespace Xunit.Analyzers
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
 		   ImmutableArray.Create(Descriptors.X1006_TheoryMethodShouldHaveParameters);
 
-		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext)
+		internal override void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext)
 		{
-			compilationStartContext.RegisterSymbolAction(symbolContext =>
+			context.RegisterSymbolAction(context =>
 			{
-				var symbol = (IMethodSymbol)symbolContext.Symbol;
+				var symbol = (IMethodSymbol)context.Symbol;
 				if (symbol.Parameters.Length > 0)
 					return;
 
 				var attributes = symbol.GetAttributes();
 				if (attributes.ContainsAttributeType(xunitContext.Core.TheoryAttributeType))
-					symbolContext.ReportDiagnostic(Diagnostic.Create(Descriptors.X1006_TheoryMethodShouldHaveParameters, symbol.Locations.First()));
+					context.ReportDiagnostic(Diagnostic.Create(Descriptors.X1006_TheoryMethodShouldHaveParameters, symbol.Locations.First()));
 			}, SymbolKind.Method);
 		}
 	}

--- a/src/xunit.analyzers/TheoryMethodShouldUseAllParameters.cs
+++ b/src/xunit.analyzers/TheoryMethodShouldUseAllParameters.cs
@@ -14,21 +14,21 @@ namespace Xunit.Analyzers
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
 			=> ImmutableArray.Create(Descriptors.X1026_TheoryMethodShouldUseAllParameters);
 
-		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, XunitContext xunitContext)
+		internal override void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext)
 		{
-			compilationStartContext.RegisterSyntaxNodeAction(syntaxNodeContext =>
+			context.RegisterSyntaxNodeAction(context =>
 			{
-				var methodSyntax = (MethodDeclarationSyntax)syntaxNodeContext.Node;
+				var methodSyntax = (MethodDeclarationSyntax)context.Node;
 				if (methodSyntax.ParameterList.Parameters.Count == 0)
 					return;
 
-				var methodSymbol = syntaxNodeContext.SemanticModel.GetDeclaredSymbol(methodSyntax);
+				var methodSymbol = context.SemanticModel.GetDeclaredSymbol(methodSyntax);
 
 				var attributes = methodSymbol.GetAttributes();
 				if (!attributes.ContainsAttributeType(xunitContext.Core.TheoryAttributeType))
 					return;
 
-				AnalyzeTheoryParameters(syntaxNodeContext, methodSyntax, methodSymbol);
+				AnalyzeTheoryParameters(context, methodSyntax, methodSymbol);
 			}, SyntaxKind.MethodDeclaration);
 		}
 


### PR DESCRIPTION
The intentional aliasing ensures that context objects will not be used in the wrong scope. Examples shown in comments.