### PR TITLE
Create NuGet packages as part of the PR build

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -7,9 +7,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Clone source
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Get .NET Core information
         run: dotnet --info

--- a/build.ps1
+++ b/build.ps1
@@ -12,6 +12,9 @@ Push-Location (Split-Path $MyInvocation.MyCommand.Definition)
 
 try {
     & dotnet run --project tools/builder --no-launch-profile -- $args
+    if (-not $?) {
+        Exit $LASTEXITCODE
+    }
 }
 finally {
     Pop-Location

--- a/src/xunit.analyzers.nuspec
+++ b/src/xunit.analyzers.nuspec
@@ -15,8 +15,8 @@
     <tags>xunit.analyzers, analyzers, roslyn, xunit, xunit.net</tags>
   </metadata>
   <files>
-    <file src="xunit.analyzers.fixes\bin\$Configuration$\netstandard1.1\xunit.analyzers.dll" target="analyzers\dotnet\cs\" />
-    <file src="xunit.analyzers.fixes\bin\$Configuration$\netstandard1.1\xunit.analyzers.fixes.dll" target="analyzers\dotnet\cs\" />
+    <file src="xunit.analyzers.fixes\bin\$Configuration$\netstandard1.3\xunit.analyzers.dll" target="analyzers\dotnet\cs\" />
+    <file src="xunit.analyzers.fixes\bin\$Configuration$\netstandard1.3\xunit.analyzers.fixes.dll" target="analyzers\dotnet\cs\" />
     <file src="xunit.analyzers.fixes\tools\*.ps1" target="tools\" />
   </files>
 </package>

--- a/tools/builder/targets/CI.cs
+++ b/tools/builder/targets/CI.cs
@@ -1,5 +1,5 @@
 [Target(
 	BuildTarget.CI,
-	BuildTarget.PR, BuildTarget.Packages, BuildTarget.SignPackages, BuildTarget.PublishPackages
+	BuildTarget.PR, BuildTarget.SignPackages, BuildTarget.PublishPackages
 )]
 public class CI { }

--- a/tools/builder/targets/PR.cs
+++ b/tools/builder/targets/PR.cs
@@ -1,5 +1,5 @@
 [Target(
 	BuildTarget.PR,
-	BuildTarget.AnalyzeSource, BuildTarget.Test
+	BuildTarget.AnalyzeSource, BuildTarget.Test, BuildTarget.Packages
 )]
 public class PR { }


### PR DESCRIPTION
* Fix failure to report build errors as CI failures
* Fix failure to calculate the version number in PR builds (https://github.com/dotnet/Nerdbank.GitVersioning/issues/423#issuecomment-598802930)
* Fix failure to create NuGet packages during PR builds
* Fix failure to create NuGet package due to output directory change
