### PR TITLE
Updates CodeFix.Testing.XUnit

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,7 +3,6 @@
 	<packageSources>
 		<clear />
 		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-		<add key="roslyn-analyzers" value="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json" protocolVersion="3" />
 		<add key="dev.azure.com/andrewarnott/OSS/PublicCI" value="https://pkgs.dev.azure.com/andrewarnott/OSS/_packaging/PublicCI/nuget/v3/index.json" protocolVersion="3" />
 	</packageSources>
 </configuration>

--- a/src/xunit.analyzers.tests/xunit.analyzers.tests.csproj
+++ b/src/xunit.analyzers.tests/xunit.analyzers.tests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.0.1-beta1.20478.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />


### PR DESCRIPTION
Previous version relied on the old dotnet.myget.org nuget source which caused everything to fail on building the project. This drops that source from nuget.config and updates the CodeFix.Testing.XUnit package to the latest release.