### PR TITLE
Update AssertNullShouldNotBeCalledOnValueType and AssertSameShouldNotBeCalledOnValueTypes to not trigger on arguments containing user-defined implicit conversions

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/AssertNullShouldNotBeCalledOnValueTypesTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/AssertNullShouldNotBeCalledOnValueTypesTests.cs
@@ -108,4 +108,36 @@ class Class<T> {{
 
 		await Verify.VerifyAnalyzerAsyncV2(source);
 	}
+
+	[Theory]
+	[MemberData(nameof(Methods))]
+	// https://github.com/xunit/xunit/issues/2395
+	public async void DoesNotFindWarning_ForUserDefinedImplicitConversion(string method)
+	{
+		var source = $@"
+public class TestClass
+{{
+    public void TestMethod()
+    {{
+        Xunit.Assert.{method}((MyBuggyInt)42);
+        Xunit.Assert.{method}((MyBuggyInt)(int?)42);
+        Xunit.Assert.{method}((MyBuggyIntBase)42);
+        Xunit.Assert.{method}((MyBuggyIntBase)(int?)42);
+    }}
+}}
+
+public abstract class MyBuggyIntBase
+{{
+    public static implicit operator MyBuggyIntBase(int i) => new MyBuggyInt();
+}}
+
+public class MyBuggyInt : MyBuggyIntBase
+{{
+    public MyBuggyInt()
+	{{
+	}}
+}}";
+
+		await Verify.VerifyAnalyzerAsyncV2(source);
+	}
 }

--- a/src/xunit.analyzers/Utilities/IOperationExtensions.cs
+++ b/src/xunit.analyzers/Utilities/IOperationExtensions.cs
@@ -8,7 +8,7 @@ namespace Xunit.Analyzers
 		public static IOperation WalkDownImplicitConversions(this IOperation operation)
 		{
 			var current = operation;
-			while (current is IConversionOperation conversion && conversion.IsImplicit)
+			while (current is IConversionOperation conversion && conversion.Conversion.IsImplicit)
 				current = conversion.Operand;
 
 			return current;


### PR DESCRIPTION
Fixes https://github.com/xunit/xunit/issues/2395

The old code in WalkDownImplicitConversions checked `IOperation.IsImplicit` instead of `IConversionOperation.Conversion.IsImplicit`, which apparently was not the same thing.