### PR TITLE
Update RemoveMethodParameterFix to not crash when parameter declaration is missing

### DIFF
--- a/src/xunit.analyzers.fixes/FixProviders/RemoveMethodParameterFix.cs
+++ b/src/xunit.analyzers.fixes/FixProviders/RemoveMethodParameterFix.cs
@@ -28,6 +28,10 @@ namespace Xunit.Analyzers.FixProviders
 		{
 			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 			var parameter = root.FindNode(context.Span).FirstAncestorOrSelf<ParameterSyntax>();
+			if (parameter == null)
+			{
+				return;
+			}
 			var parameterName = parameter.Identifier.Text;
 
 			context.RegisterCodeFix(

--- a/src/xunit.analyzers.tests/Fixes/FixProviders/RemoveMethodParameterFixTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/FixProviders/RemoveMethodParameterFixTests.cs
@@ -80,6 +80,53 @@ public class TestClass {
 		await Verify_X1026.VerifyCodeFixAsyncV2(before, after);
 	}
 
+	[Fact]
+	public async void X1026_DoesNotCrashWhenParameterDeclarationIsMissing()
+	{
+		var before = @"
+using Xunit;
+
+public class TestClass {
+	[Theory]
+	[InlineData(1, 1)]
+	public void Test1(int x, )
+	{
+		var x1 = x;
+	}
+}";
+
+		var after = @"
+using Xunit;
+
+public class TestClass {
+	[Theory]
+	[InlineData(1, 1)]
+	public void Test1(int x, )
+	{
+		var x1 = x;
+	}
+}";
+
+		var expected = new[]
+		{
+			Verify_X1026
+				.Diagnostic()
+				.WithSpan(7, 27, 7, 27)
+				.WithSeverity(DiagnosticSeverity.Warning)
+				.WithArguments("Test1", "TestClass", ""),
+			Verify_X1026
+				.CompilerError("CS1001")
+				.WithSpan(7, 27, 7, 28)
+				.WithMessage("Identifier expected"),
+			Verify_X1026
+				.CompilerError("CS1031")
+				.WithSpan(7, 27, 7, 28)
+				.WithMessage("Type expected"),
+		};
+
+		await Verify_X1026.VerifyCodeFixAsyncV2(before, after, diagnostics: expected);
+	}
+
 	internal class Analyzer_X1022 : TheoryMethodCannotHaveParamsArray
 	{
 		protected override XunitContext CreateXunitContext(Compilation compilation) =>

--- a/src/xunit.analyzers.tests/Utilities/CSharpVerifier.cs
+++ b/src/xunit.analyzers.tests/Utilities/CSharpVerifier.cs
@@ -55,13 +55,18 @@ public class CSharpVerifier<TAnalyzer>
 	public static Task VerifyCodeFixAsyncV2(
 		string before,
 		string after,
-		int? codeActionIndex = null) =>
-			new TestV2
-			{
-				TestCode = before.Replace("\n", "\r\n"),
-				FixedCode = after.Replace("\n", "\r\n"),
-				CodeActionIndex = codeActionIndex
-			}.RunAsync();
+		int? codeActionIndex = null,
+		params DiagnosticResult[] diagnostics)
+	{
+		var test = new TestV2
+		{
+			TestCode = before.Replace("\n", "\r\n"),
+			FixedCode = after.Replace("\n", "\r\n"),
+			CodeActionIndex = codeActionIndex
+		};
+		test.TestState.ExpectedDiagnostics.AddRange(diagnostics);
+		return test.RunAsync();
+	}
 
 	public class TestV2 : CSharpCodeFixTest<TAnalyzer, EmptyCodeFixProvider, XUnitVerifier>
 	{


### PR DESCRIPTION
Fixes [#2675](https://github.com/xunit/xunit/issues/2675)