### PR TITLE
Update 1033 fixer to generate public constructor

### DIFF
--- a/src/xunit.analyzers.fixes/CodeActions/CodeAnalysisExtensions.cs
+++ b/src/xunit.analyzers.fixes/CodeActions/CodeAnalysisExtensions.cs
@@ -31,6 +31,7 @@ namespace Xunit.Analyzers.CodeActions
 
 			var constructor =
 				ConstructorDeclaration(Identifier(declaration.Identifier.Text))
+				.WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
 				.WithParameterList(
 					ParameterList(
 						SingletonSeparatedList(

--- a/src/xunit.analyzers.tests/Fixes/TestClassShouldHaveTFixtureArgumentFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/TestClassShouldHaveTFixtureArgumentFixerTests.cs
@@ -20,7 +20,7 @@ public class FixtureData { }
 public class [|TestClass|]: Xunit.IClassFixture<FixtureData> {
     private readonly FixtureData _fixtureData;
 
-    TestClass(FixtureData fixtureData)
+    public TestClass(FixtureData fixtureData)
     {
         _fixtureData = fixtureData;
     }
@@ -49,7 +49,7 @@ public class FixtureData<T> { }
 public class [|TestClass|]: Xunit.IClassFixture<FixtureData<object>> {
     private readonly FixtureData<object> _fixtureData;
 
-    TestClass(FixtureData<object> fixtureData)
+    public TestClass(FixtureData<object> fixtureData)
     {
         _fixtureData = fixtureData;
     }


### PR DESCRIPTION
Closes xunit/xunit#2721

Adds public modifier to constructor on `AddConstructor` extension method. Applying change directly into extension method as it is not used by any other code at the moment and constructors are commonly public.