### PR TITLE
Add analyzer and fixer for test classes nested in generic classes

### DIFF
--- a/src/xunit.analyzers.fixes/Utility/CodeAnalysisExtensions.cs
+++ b/src/xunit.analyzers.fixes/Utility/CodeAnalysisExtensions.cs
@@ -156,10 +156,11 @@ public static class CodeAnalysisExtensions
 		{
 			editor.RemoveNode(node);
 
-			var formattedNode = node
-				.WithLeadingTrivia(SyntaxFactory.ElasticMarker)
-				.WithTrailingTrivia(SyntaxFactory.ElasticMarker)
-				.WithAdditionalAnnotations(Formatter.Annotation, Simplifier.Annotation);
+			var formattedNode =
+				node
+					.WithLeadingTrivia(SyntaxFactory.ElasticMarker)
+					.WithTrailingTrivia(SyntaxFactory.ElasticMarker)
+					.WithAdditionalAnnotations(Formatter.Annotation, Simplifier.Annotation);
 
 			editor.InsertAfter(parent, formattedNode);
 		}

--- a/src/xunit.analyzers.fixes/Utility/CodeAnalysisExtensions.cs
+++ b/src/xunit.analyzers.fixes/Utility/CodeAnalysisExtensions.cs
@@ -4,6 +4,8 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Simplification;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -138,6 +140,29 @@ public static class CodeAnalysisExtensions
 	{
 		var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 		editor.RemoveNode(node);
+
+		return editor.GetChangedDocument();
+	}
+
+	public static async Task<Document> ExtractNodeFromParent(
+		this Document document,
+		SyntaxNode node,
+		CancellationToken cancellationToken)
+	{
+		var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+		var parent = node.Parent;
+
+		if (parent is not null)
+		{
+			editor.RemoveNode(node);
+
+			var formattedNode = node
+				.WithLeadingTrivia(SyntaxFactory.ElasticMarker)
+				.WithTrailingTrivia(SyntaxFactory.ElasticMarker)
+				.WithAdditionalAnnotations(Formatter.Annotation, Simplifier.Annotation);
+
+			editor.InsertAfter(parent, formattedNode);
+		}
 
 		return editor.GetChangedDocument();
 	}

--- a/src/xunit.analyzers.fixes/X1000/TestClassCannotBeNestedInGenericClassFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/TestClassCannotBeNestedInGenericClassFixer.cs
@@ -1,0 +1,38 @@
+using System.Composition;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Xunit.Analyzers.Fixes;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public class TestClassCannotBeNestedInGenericClassFixer : BatchedCodeFixProvider
+{
+	public const string Key_ExtractTestClass = "xUnit1032_TestClassCannotBeNestedInGenericClass";
+
+	public TestClassCannotBeNestedInGenericClassFixer() :
+		base(Descriptors.X1032_TestClassCannotBeNestedInGenericClass.Id)
+	{ }
+
+	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+	{
+		var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+		if (root is null)
+			return;
+
+		var classDeclaration = root.FindNode(context.Span).FirstAncestorOrSelf<ClassDeclarationSyntax>();
+		if (classDeclaration is null)
+			return;
+
+		context.RegisterCodeFix(
+			CodeAction.Create(
+				"Extract test class from parent class",
+				ct => context.Document.ExtractNodeFromParent(classDeclaration, ct),
+				Key_ExtractTestClass
+			),
+			context.Diagnostics
+		);
+	}
+}

--- a/src/xunit.analyzers.tests/Analyzers/X1000/TestClassCannotBeNestedInGenericClassTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/TestClassCannotBeNestedInGenericClassTests.cs
@@ -1,7 +1,5 @@
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Testing;
 using Xunit;
-using Xunit.Analyzers;
 using Verify = CSharpVerifier<Xunit.Analyzers.TestClassCannotBeNestedInGenericClass>;
 
 public class TestClassCannotBeNestedInGenericClassTests
@@ -19,8 +17,10 @@ public abstract class OpenGenericType<T>
     }
 }";
 
-		var expected = new DiagnosticResult(Descriptors.X1032_TestClassCannotBeNestedInGenericClass)
-			.WithLocation(4, 18);
+		var expected =
+			Verify
+				.Diagnostic()
+				.WithLocation(4, 18);
 
 		await Verify.VerifyAnalyzer(source, expected);
 	}
@@ -42,8 +42,10 @@ public abstract class OpenGenericType<T>
     }
 }";
 
-		var expected = new DiagnosticResult(Descriptors.X1032_TestClassCannotBeNestedInGenericClass)
-			.WithLocation(10, 18);
+		var expected =
+			Verify
+				.Diagnostic()
+				.WithLocation(10, 18);
 
 		await Verify.VerifyAnalyzer(source, expected);
 	}

--- a/src/xunit.analyzers.tests/Analyzers/X1000/TestClassCannotBeNestedInGenericClassTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/TestClassCannotBeNestedInGenericClassTests.cs
@@ -1,0 +1,100 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Xunit.Analyzers;
+using Verify = CSharpVerifier<Xunit.Analyzers.TestClassCannotBeNestedInGenericClass>;
+
+public class TestClassCannotBeNestedInGenericClassTests
+{
+	[Fact]
+	public async Task ReportsDiagnostic_WhenTestClassIsNestedInOpenGenericType()
+	{
+		var source = @"
+public abstract class OpenGenericType<T>
+{
+    public class NestedTestClass
+    {
+        [Xunit.Fact]
+        public void TestMethod() { }
+    }
+}";
+
+		var expected = new DiagnosticResult(Descriptors.X1032_TestClassCannotBeNestedInGenericClass)
+			.WithLocation(4, 18);
+
+		await Verify.VerifyAnalyzer(source, expected);
+	}
+
+	[Fact]
+	public async Task ReportsDiagnostic_WhenDerivedTestClassIsNestedInOpenGenericType()
+	{
+		var source = @"
+public abstract class BaseTestClass
+{
+    [Xunit.Fact]
+    public void TestMethod() { }
+}
+
+public abstract class OpenGenericType<T>
+{
+    public class NestedTestClass : BaseTestClass
+    {
+    }
+}";
+
+		var expected = new DiagnosticResult(Descriptors.X1032_TestClassCannotBeNestedInGenericClass)
+			.WithLocation(10, 18);
+
+		await Verify.VerifyAnalyzer(source, expected);
+	}
+
+	[Fact]
+	public async Task DoesNotReportDiagnostic_WhenTestClassIsNestedInClosedGenericType()
+	{
+		var source = @"
+public abstract class OpenGenericType<T>
+{
+}
+
+public abstract class ClosedGenericType : OpenGenericType<int>
+{
+    public class NestedTestClass
+    {
+        [Xunit.Fact]
+        public void TestMethod() { }
+    }
+}";
+
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Fact]
+	public async Task DoesNotReportDiagnostic_WhenNestedClassIsNotTestClass()
+	{
+		var source = @"
+public abstract class OpenGenericType<T>
+{
+    public class NestedClass
+    {
+    }
+}";
+
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Fact]
+	public async Task DoesNotReportDiagnostic_WhenTestClassIsNotNestedInOpenGenericType()
+	{
+		var source = @"
+public abstract class NonGenericType
+{
+    public class NestedTestClass
+    {
+        [Xunit.Fact]
+        public void TestMethod() { }
+    }
+}";
+
+		await Verify.VerifyAnalyzer(source);
+	}
+}

--- a/src/xunit.analyzers.tests/Fixes/X1000/TestClassCannotBeNestedInGenericClassFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/TestClassCannotBeNestedInGenericClassFixerTests.cs
@@ -1,4 +1,6 @@
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using Xunit.Analyzers;
 using Xunit.Analyzers.Fixes;
 using Verify = CSharpVerifier<Xunit.Analyzers.TestClassCannotBeNestedInGenericClass>;
 
@@ -27,6 +29,10 @@ public class NestedTestClass
     public void TestMethod() { }
 }";
 
-		await Verify.VerifyCodeFix(before, after, TestClassCannotBeNestedInGenericClassFixer.Key_ExtractTestClass);
+		await Verify.VerifyCodeFix(
+			before,
+			after,
+			TestClassCannotBeNestedInGenericClassFixer.Key_ExtractTestClass,
+			new DiagnosticResult(Descriptors.X1032_TestClassCannotBeNestedInGenericClass).WithLocation(4, 18));
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/TestClassCannotBeNestedInGenericClassFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/TestClassCannotBeNestedInGenericClassFixerTests.cs
@@ -1,6 +1,4 @@
-using Microsoft.CodeAnalysis.Testing;
 using Xunit;
-using Xunit.Analyzers;
 using Xunit.Analyzers.Fixes;
 using Verify = CSharpVerifier<Xunit.Analyzers.TestClassCannotBeNestedInGenericClass>;
 
@@ -12,7 +10,7 @@ public class TestClassCannotBeNestedInGenericClassFixerTests
 		const string before = @"
 public abstract class OpenGenericType<T>
 {
-    public class NestedTestClass
+    public class [|NestedTestClass|]
     {
         [Xunit.Fact]
         public void TestMethod() { }
@@ -29,10 +27,6 @@ public class NestedTestClass
     public void TestMethod() { }
 }";
 
-		await Verify.VerifyCodeFix(
-			before,
-			after,
-			TestClassCannotBeNestedInGenericClassFixer.Key_ExtractTestClass,
-			new DiagnosticResult(Descriptors.X1032_TestClassCannotBeNestedInGenericClass).WithLocation(4, 18));
+		await Verify.VerifyCodeFix(before, after, TestClassCannotBeNestedInGenericClassFixer.Key_ExtractTestClass);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/TestClassCannotBeNestedInGenericClassFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/TestClassCannotBeNestedInGenericClassFixerTests.cs
@@ -1,0 +1,32 @@
+using Xunit;
+using Xunit.Analyzers.Fixes;
+using Verify = CSharpVerifier<Xunit.Analyzers.TestClassCannotBeNestedInGenericClass>;
+
+public class TestClassCannotBeNestedInGenericClassFixerTests
+{
+	[Fact]
+	public async void MovesTestClassOutOfGenericParent()
+	{
+		const string before = @"
+public abstract class OpenGenericType<T>
+{
+    public class NestedTestClass
+    {
+        [Xunit.Fact]
+        public void TestMethod() { }
+    }
+}";
+		const string after = @"
+public abstract class OpenGenericType<T>
+{
+}
+
+public class NestedTestClass
+{
+    [Xunit.Fact]
+    public void TestMethod() { }
+}";
+
+		await Verify.VerifyCodeFix(before, after, TestClassCannotBeNestedInGenericClassFixer.Key_ExtractTestClass);
+	}
+}

--- a/src/xunit.analyzers/Utility/Descriptors.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.cs
@@ -322,8 +322,14 @@ public static class Descriptors
 			Error,
 			"Test methods must not use blocking task operations, as they can cause deadlocks. Use an async test method and await instead."
 		);
-
-	// Placeholder for rule X1032
+	public static DiagnosticDescriptor X1032_TestClassCannotBeNestedInGenericClass { get; } =
+		Rule(
+			"xUnit1032",
+			"Test classes cannot be nested within a generic class",
+			Usage,
+			Error,
+			"Test classes cannot be nested within a generic class. Move the test class out of the class it is nested in."
+		);
 
 	public static DiagnosticDescriptor X1033_TestClassShouldHaveTFixtureArgument { get; } =
 		Rule(

--- a/src/xunit.analyzers/X1000/TestClassCannotBeNestedInGenericClass.cs
+++ b/src/xunit.analyzers/X1000/TestClassCannotBeNestedInGenericClass.cs
@@ -40,16 +40,19 @@ public class TestClassCannotBeNestedInGenericClass : XunitDiagnosticAnalyzer
 		}, SymbolKind.NamedType);
 	}
 
-	private bool DoesInheritenceTreeContainTests(INamedTypeSymbol classSymbol, XunitContext xunitContext, int depth)
+	private bool DoesInheritenceTreeContainTests(
+		INamedTypeSymbol classSymbol,
+		XunitContext xunitContext,
+		int depth)
 	{
-		var doesClassContainTests = classSymbol.GetMembers()
-					.OfType<IMethodSymbol>()
-					.Any(m => m.GetAttributes().Any(a => xunitContext.Core.FactAttributeType.IsAssignableFrom(a.AttributeClass)));
+		var doesClassContainTests =
+			classSymbol
+				.GetMembers()
+				.OfType<IMethodSymbol>()
+				.Any(m => m.GetAttributes().Any(a => xunitContext.Core.FactAttributeType.IsAssignableFrom(a.AttributeClass)));
 
 		if (!doesClassContainTests && classSymbol.BaseType is not null && depth > 0)
-		{
 			return DoesInheritenceTreeContainTests(classSymbol.BaseType, xunitContext, depth - 1);
-		}
 
 		return doesClassContainTests;
 	}

--- a/src/xunit.analyzers/X1000/TestClassCannotBeNestedInGenericClass.cs
+++ b/src/xunit.analyzers/X1000/TestClassCannotBeNestedInGenericClass.cs
@@ -1,0 +1,56 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Xunit.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class TestClassCannotBeNestedInGenericClass : XunitDiagnosticAnalyzer
+{
+	public TestClassCannotBeNestedInGenericClass() :
+		base(Descriptors.X1032_TestClassCannotBeNestedInGenericClass)
+	{ }
+
+	public override void AnalyzeCompilation(
+		CompilationStartAnalysisContext context,
+		XunitContext xunitContext)
+	{
+		context.RegisterSymbolAction(context =>
+		{
+			if (xunitContext.Core.FactAttributeType is null)
+				return;
+			if (context.Symbol is not INamedTypeSymbol classSymbol)
+				return;
+			if (classSymbol.ContainingType is null)
+				return;
+			if (!classSymbol.ContainingType.IsGenericType)
+				return;
+
+			var doesClassContainTests = DoesInheritenceTreeContainTests(classSymbol, xunitContext, depth: 3);
+
+			if (!doesClassContainTests)
+				return;
+
+			context.ReportDiagnostic(
+				Diagnostic.Create(
+					Descriptors.X1032_TestClassCannotBeNestedInGenericClass,
+					classSymbol.Locations.First()
+				)
+			);
+		}, SymbolKind.NamedType);
+	}
+
+	private bool DoesInheritenceTreeContainTests(INamedTypeSymbol classSymbol, XunitContext xunitContext, int depth)
+	{
+		var doesClassContainTests = classSymbol.GetMembers()
+					.OfType<IMethodSymbol>()
+					.Any(m => m.GetAttributes().Any(a => xunitContext.Core.FactAttributeType.IsAssignableFrom(a.AttributeClass)));
+
+		if (!doesClassContainTests && classSymbol.BaseType is not null && depth > 0)
+		{
+			return DoesInheritenceTreeContainTests(classSymbol.BaseType, xunitContext, depth - 1);
+		}
+
+		return doesClassContainTests;
+	}
+}


### PR DESCRIPTION
Closes https://github.com/xunit/xunit/issues/2528

Adds analyzer and fixer to prevent the error:
`System.ArgumentException: Cannot create an instance of Tests+A'1+B[T] because Type.ContainsGenericParameters is true.`

The analyzer includes a check for tests in the base classes if the derived class does not directly contain tests, and limits the search to a depth of 3 classes in case of circular dependencies.