### PR TITLE
[xUnit2189] Extend xUnit1012 to test reference type nullability for InlineDataAttribute

### DIFF
--- a/src/xunit.analyzers.fixes/X1000/InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameterFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameterFixer.cs
@@ -65,11 +65,14 @@ public class InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompati
 
 			if (semanticModel is not null && param.Type is not null)
 			{
-				var nullableT = TypeSymbolFactory.NullableOfT(semanticModel.Compilation);
 				var paramTypeSymbol = semanticModel.GetTypeInfo(param.Type, cancellationToken).Type;
-
 				if (paramTypeSymbol is not null)
-					editor.SetType(param, editor.Generator.TypeExpression(nullableT.Construct(paramTypeSymbol)));
+				{
+					var nullableT = paramTypeSymbol.IsReferenceType
+						? paramTypeSymbol.WithNullableAnnotation(NullableAnnotation.Annotated)
+						: TypeSymbolFactory.NullableOfT(semanticModel.Compilation).Construct(paramTypeSymbol);
+					editor.SetType(param, editor.Generator.TypeExpression(nullableT));
+				}
 			}
 		}
 

--- a/src/xunit.analyzers.tests/Analyzers/X1000/InlineDataMustMatchTheoryParametersTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/InlineDataMustMatchTheoryParametersTests.cs
@@ -1355,6 +1355,99 @@ public class TestClass {{
 			await Verify.VerifyAnalyzer(source);
 		}
 
+		[Theory]
+		[InlineData("object")]
+		[InlineData("string")]
+		[InlineData("System.Exception")]
+		public async void NonNullableReferenceTypes(string type)
+		{
+			var source = $@"
+#nullable enable
+public class TestClass {{
+    [Xunit.Theory]
+    [Xunit.InlineData(1, null)]
+    public void TestMethod(int a, {type} b) {{ }}
+#nullable restore
+}}";
+
+			DiagnosticResult[] expected =
+			{
+				Verify
+					.Diagnostic("xUnit1012")
+					.WithSpan(5, 26, 5, 30)
+					.WithSeverity(DiagnosticSeverity.Warning)
+					.WithArguments("b", type)
+			};
+
+			await Verify.VerifyAnalyzer(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp8, source, expected);
+		}
+
+		[Theory]
+		[InlineData("object")]
+		[InlineData("string")]
+		[InlineData("System.Exception")]
+		public async void NullableReferenceTypes(string type)
+		{
+			var source = $@"
+#nullable enable
+public class TestClass {{
+    [Xunit.Theory]
+    [Xunit.InlineData(1, null)]
+    public void TestMethod(int a, {type}? b) {{ }}
+#nullable restore
+}}";
+
+			await Verify.VerifyAnalyzer(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp8, source);
+		}
+
+		[Theory]
+		[InlineData("1", "object")]
+		[InlineData("\"bob\"", "string")]
+		public async void NullableParamsReferenceTypes(string param, string type)
+		{
+			var source = $@"
+#nullable enable
+public class TestClass {{
+    [Xunit.Theory]
+    [Xunit.InlineData(1, {param}, null, null)]
+    public void TestMethod(int a, params {type}?[] b) {{ }}
+#nullable restore
+}}";
+
+			await Verify.VerifyAnalyzer(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp8, source);
+		}
+
+		[Theory]
+		[InlineData("1", "object")]
+		[InlineData("\"bob\"", "string")]
+		public async void NonNullableParamsReferenceTypes(string param, string type)
+		{
+			var source = $@"
+#nullable enable
+public class TestClass {{
+    [Xunit.Theory]
+    [Xunit.InlineData(1, {param}, null, null)]
+    public void TestMethod(int a, params {type}[] b) {{ }}
+#nullable restore
+}}";
+
+			DiagnosticResult[] expected =
+			{
+				Verify
+					.Diagnostic("xUnit1012")
+					.WithSpan(5, 28 + param.Length, 5, 32 + param.Length)
+					.WithSeverity(DiagnosticSeverity.Warning)
+					.WithArguments("b", type),
+				Verify
+					.Diagnostic("xUnit1012")
+					.WithSpan(5, 34 + param.Length, 5, 38 + param.Length)
+					.WithSeverity(DiagnosticSeverity.Warning)
+					.WithArguments("b", type),
+			};
+
+			await Verify.VerifyAnalyzer(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp8, source, expected);
+		}
+
 		public static TheoryData<string> ValueTypes = new()
 		{
 			"bool",

--- a/src/xunit.analyzers.tests/Analyzers/X1000/InlineDataMustMatchTheoryParametersTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/InlineDataMustMatchTheoryParametersTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using Xunit.Analyzers;
@@ -1379,7 +1380,7 @@ public class TestClass {{
 					.WithArguments("b", type)
 			};
 
-			await Verify.VerifyAnalyzer(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp8, source, expected);
+			await Verify.VerifyAnalyzer(LanguageVersion.CSharp8, source, expected);
 		}
 
 		[Theory]
@@ -1397,7 +1398,7 @@ public class TestClass {{
 #nullable restore
 }}";
 
-			await Verify.VerifyAnalyzer(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp8, source);
+			await Verify.VerifyAnalyzer(LanguageVersion.CSharp8, source);
 		}
 
 		[Theory]
@@ -1414,7 +1415,7 @@ public class TestClass {{
 #nullable restore
 }}";
 
-			await Verify.VerifyAnalyzer(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp8, source);
+			await Verify.VerifyAnalyzer(LanguageVersion.CSharp8, source);
 		}
 
 		[Theory]
@@ -1445,7 +1446,7 @@ public class TestClass {{
 					.WithArguments("b", type),
 			};
 
-			await Verify.VerifyAnalyzer(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp8, source, expected);
+			await Verify.VerifyAnalyzer(LanguageVersion.CSharp8, source, expected);
 		}
 
 		public static TheoryData<string> ValueTypes = new()

--- a/src/xunit.analyzers.tests/Fixes/X1000/InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameterFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameterFixerTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 using Xunit.Analyzers.Fixes;
 using Verify = CSharpVerifier<Xunit.Analyzers.InlineDataMustMatchTheoryParameters>;
@@ -26,5 +27,33 @@ public class TestClass {
 }";
 
 		await Verify.VerifyCodeFix(before, after, InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameterFixer.Key_MakeParameterNullable);
+	}
+
+	[Fact]
+	public async void MakesReferenceParameterNullable()
+	{
+		var before = @"
+using Xunit;
+
+#nullable enable
+public class TestClass {
+    [Theory]
+    [InlineData(42, {|xUnit1012:null|})]
+    public void TestMethod(int a, object b) { }
+#nullable restore
+}";
+
+		var after = @"
+using Xunit;
+
+#nullable enable
+public class TestClass {
+    [Theory]
+    [InlineData(42, null)]
+    public void TestMethod(int a, object? b) { }
+#nullable restore
+}";
+
+		await Verify.VerifyCodeFix(LanguageVersion.CSharp8, before, after, InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameterFixer.Key_MakeParameterNullable);
 	}
 }

--- a/src/xunit.analyzers/Utility/Descriptors.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.cs
@@ -146,7 +146,7 @@ public static class Descriptors
 	public static DiagnosticDescriptor X1012_InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameter { get; } =
 		Rule(
 			"xUnit1012",
-			"Null should not be used for value type or non-nullable reference type parameters",
+			"Null should not be used for nullable parameters",
 			Usage,
 			Warning,
 			"Null should not be used for type parameter '{0}' of type '{1}'. Use a non-null value, or convert the parameter to a nullable type."

--- a/src/xunit.analyzers/Utility/Descriptors.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.cs
@@ -146,7 +146,7 @@ public static class Descriptors
 	public static DiagnosticDescriptor X1012_InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameter { get; } =
 		Rule(
 			"xUnit1012",
-			"Null should not be used for nullable parameters",
+			"Null should only be used for nullable parameters",
 			Usage,
 			Warning,
 			"Null should not be used for type parameter '{0}' of type '{1}'. Use a non-null value, or convert the parameter to a nullable type."

--- a/src/xunit.analyzers/Utility/Descriptors.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.cs
@@ -146,10 +146,10 @@ public static class Descriptors
 	public static DiagnosticDescriptor X1012_InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameter { get; } =
 		Rule(
 			"xUnit1012",
-			"Null should not be used for value type parameters",
+			"Null should not be used for value type or non-nullable reference type parameters",
 			Usage,
 			Warning,
-			"Null should not be used for value type parameter '{0}' of type '{1}'. Use a non-null value, or convert the parameter to a nullable type."
+			"Null should not be used for type parameter '{0}' of type '{1}'. Use a non-null value, or convert the parameter to a nullable type."
 		);
 
 	public static DiagnosticDescriptor X1013_PublicMethodShouldBeMarkedAsTest { get; } =


### PR DESCRIPTION
Partial fix for this issue:
https://github.com/xunit/xunit/issues/2189

Extends the analyzer and fixer for xUnit1012 to checking null literals against nullability of parameter types for InlineDataAttribute. Without this change, null arguments in InlineDataAttribute are only flagged if they are to be passed to a method parameter that is value-typed and non-nullable. With this change, the analyzer also checks for nullable/non-nullable reference types, and allows the fixer to adjust it as well.