### PR TITLE
Fix false-positive errors from xunit/xunit#2826

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
@@ -863,7 +863,7 @@ public class TestClass
 	}
 
 	[Fact]
-	public async void DoesNotFindWarning_WithObjectArrayArguments()
+	public async void FindsWarning_WithObjectArrayArguments()
 	{
 		var source = $@"
 using System.Collections.Generic;
@@ -883,7 +883,21 @@ public class TestClass
 }}
 ";
 
-		await Verify.VerifyAnalyzer(LanguageVersion.CSharp10, source);
+		DiagnosticResult[] expected =
+		{
+			Verify
+				.Diagnostic("xUnit1035")
+				.WithSpan(11, 52, 11, 53)
+				.WithArguments("seq", "System.Collections.Generic.IEnumerable<object>")
+				.WithSeverity(DiagnosticSeverity.Error),
+			Verify
+				.Diagnostic("xUnit1036")
+				.WithSpan(11, 55, 11, 56)
+				.WithArguments("2")
+				.WithSeverity(DiagnosticSeverity.Error)
+		};
+
+		await Verify.VerifyAnalyzer(LanguageVersion.CSharp10, source, expected);
 	}
 
 	[Theory]

--- a/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
@@ -837,6 +837,30 @@ public class TestClass {{
 		await Verify.VerifyAnalyzer(LanguageVersion.CSharp10, source);
 	}
 
+	[Fact]
+	public async void DoesNotFindWarning_WithArrayArguments()
+	{
+		var source = $@"
+using System.Collections.Generic;
+using Xunit;
+public class TestClass
+{{
+  public static IEnumerable<object[]> GetSequences(IEnumerable<int> seq) =>
+    new List<object[]>();
+
+  [Theory]
+  [MemberData(nameof(GetSequences), new int[] {{ 1, 2 }})]
+  [MemberData(nameof(GetSequences), new [] {{ 3, 4, 5}})]
+  public void Test(IEnumerable<int> seq)
+  {{
+    Assert.NotEmpty(seq);
+  }}
+}}
+";
+
+		await Verify.VerifyAnalyzer(LanguageVersion.CSharp10, source);
+	}
+
 	[Theory]
 	[MemberData(nameof(MemberSyntaxAndArgs))]
 	public async void FindWarning_IfHasValidTheoryDataMemberWithTooManyTypeParameters(

--- a/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
@@ -838,11 +838,12 @@ public class TestClass {{
 	}
 
 	[Fact]
-	public async void DoesNotFindWarning_WithArrayArguments()
+	public async void DoesNotFindWarning_WithIntArrayArguments()
 	{
 		var source = $@"
 using System.Collections.Generic;
 using Xunit;
+
 public class TestClass
 {{
   public static IEnumerable<object[]> GetSequences(IEnumerable<int> seq) =>
@@ -851,6 +852,30 @@ public class TestClass
   [Theory]
   [MemberData(nameof(GetSequences), new int[] {{ 1, 2 }})]
   [MemberData(nameof(GetSequences), new [] {{ 3, 4, 5}})]
+  public void Test(IEnumerable<int> seq)
+  {{
+    Assert.NotEmpty(seq);
+  }}
+}}
+";
+
+		await Verify.VerifyAnalyzer(LanguageVersion.CSharp10, source);
+	}
+
+	[Fact]
+	public async void DoesNotFindWarning_WithObjectArrayArguments()
+	{
+		var source = $@"
+using System.Collections.Generic;
+using Xunit;
+
+public class TestClass
+{{
+  public static IEnumerable<object[]> GetSequences(IEnumerable<object> seq) =>
+    new List<object[]>();
+
+  [Theory]
+  [MemberData(nameof(GetSequences), new object[] {{ 1, 2 }})]
   public void Test(IEnumerable<int> seq)
   {{
     Assert.NotEmpty(seq);


### PR DESCRIPTION
This PR fixes a regression introduced by https://github.com/xunit/xunit/issues/2826. It tests to see if the argument to the MemberDataAttribute should be treated as a single argument rather than a params array.

@bradwilson FYI