### PR TITLE
Updates Microsoft.CodeAnalysis.CSharp version to latest

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="[4.2.0]" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="[4.8.0]" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/xunit.analyzers.fixes/X2000/BooleanAssertsShouldNotBeNegatedFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/BooleanAssertsShouldNotBeNegatedFixer.cs
@@ -41,7 +41,7 @@ public class BooleanAssertsShouldNotBeNegatedFixer : BatchedCodeFixProvider
 
 		context.RegisterCodeFix(
 			CodeAction.Create(
-				string.Format(CultureInfo.CurrentCulture, "Use Assert.{0}", replacement),
+				string.Format("Use Assert.{0}", replacement),
 				ct => UseSuggestedAssert(context.Document, invocation, replacement, ct),
 				Key_UseSuggestedAssert
 			),

--- a/src/xunit.analyzers.tests/Analyzers/X1000/TheoryMethodShouldUseAllParametersTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/TheoryMethodShouldUseAllParametersTests.cs
@@ -221,4 +221,24 @@ class TestClass {
 
 		await Verify.VerifyAnalyzer(source);
 	}
+
+	[Fact]
+	public async void DoesNotFindWarning_ForParameterReferenceInCollectionLiteral()
+	{
+		var source = @"
+using Xunit;
+public class TestClass
+{
+    [Theory]
+    [InlineData(""hello"")]
+    public void XUnit1026_False_Positive(string greeting)
+    {
+        string[] values = [greeting, ""world""];
+        string actual = string.Join(' ', values);
+        Assert.Equal(""hello world"", actual);
+    }
+}";
+
+		await Verify.VerifyAnalyzer(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp12, source);
+	}
 }


### PR DESCRIPTION
This PR resolves issue https://github.com/xunit/xunit/issues/2789 by updating the NuGet version of the code analysis tools to the latest, so that CSharp12 is included. The new version of the NuGet package supports Framework4.7.2 and .NetStandard2.0 so should not introduce any compatibility issues.

One small code change was required as using CultureInfo.CurrentCulture in the way used in that fixer is now listed as a "banned symbol" because the compiler settings will pick up the culture. Feel free to revert that part of the change to see the error if you'd like @bradwilson :-).