### PR TITLE
xUnit1030 should not trigger inside lambda

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/DoNotUseConfigureAwaitTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/DoNotUseConfigureAwaitTests.cs
@@ -185,6 +185,27 @@ public class TestClass {{
 
 			await Verify.VerifyAnalyzer(source, expected);
 		}
+
+		[Fact]
+		public async void False_DoesNotTriggerInNestedTask()
+		{
+			var source = @"
+using System.Threading.Tasks;
+using Xunit;
+
+public class TestClass {
+    [Fact]
+    public async Task TestMethod() {
+		var t = Task.Run(async () => {
+			await Task.Delay(1).ConfigureAwait(false);
+		});
+		
+		await t;
+    }
+}";
+
+			await Verify.VerifyAnalyzer(source);
+		}
 	}
 
 #if NETCOREAPP

--- a/src/xunit.analyzers.tests/Analyzers/X1000/DoNotUseConfigureAwaitTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/DoNotUseConfigureAwaitTests.cs
@@ -65,6 +65,28 @@ public class TestClass {
 
 		[Theory]
 		[MemberData(nameof(InvalidValues))]
+		public async void InvalidValue_InsideLambda_DoesNotTrigger(string argumentValue)
+		{
+			var source = @$"
+using System.Threading.Tasks;
+using Xunit;
+
+public class TestClass {{
+    [Fact]
+    public async Task TestMethod() {{
+        var booleanVar = true;
+        var t = Task.Run(async () => {{
+            await Task.Delay(1).ConfigureAwait({argumentValue});
+        }});
+        await t;
+    }}
+}}";
+
+			await Verify.VerifyAnalyzer(source);
+		}
+
+		[Theory]
+		[MemberData(nameof(InvalidValues))]
 		public async void InvalidValue_TaskWithAwait_Triggers(string argumentValue)
 		{
 			var source = @$"
@@ -185,27 +207,6 @@ public class TestClass {{
 
 			await Verify.VerifyAnalyzer(source, expected);
 		}
-
-		[Fact]
-		public async void False_DoesNotTriggerInNestedTask()
-		{
-			var source = @"
-using System.Threading.Tasks;
-using Xunit;
-
-public class TestClass {
-    [Fact]
-    public async Task TestMethod() {
-		var t = Task.Run(async () => {
-			await Task.Delay(1).ConfigureAwait(false);
-		});
-		
-		await t;
-    }
-}";
-
-			await Verify.VerifyAnalyzer(source);
-		}
 	}
 
 #if NETCOREAPP
@@ -260,7 +261,29 @@ public class TestClass {{
 
 		[Theory]
 		[MemberData(nameof(InvalidValues))]
-		public async void InvalidValue_TaskWithAwait_DoesNotTrigger(string enumValue)
+		public async void InvalidValue_InsideLambda_DoesNotTrigger(string argumentValue)
+		{
+			var source = @$"
+using System.Threading.Tasks;
+using Xunit;
+
+public class TestClass {{
+    [Fact]
+    public async Task TestMethod() {{
+        var enumVar = ConfigureAwaitOptions.ContinueOnCapturedContext;
+        var t = Task.Run(async () => {{
+            await Task.Delay(1).ConfigureAwait({argumentValue});
+        }});
+        await t;
+    }}
+}}";
+
+			await Verify.VerifyAnalyzer(source);
+		}
+
+		[Theory]
+		[MemberData(nameof(InvalidValues))]
+		public async void InvalidValue_TaskWithAwait_Triggers(string enumValue)
 		{
 			var source = $@"
 using System.Threading.Tasks;

--- a/src/xunit.analyzers/X1000/DoNotUseConfigureAwait.cs
+++ b/src/xunit.analyzers/X1000/DoNotUseConfigureAwait.cs
@@ -63,6 +63,11 @@ public class DoNotUseConfigureAwait : XunitDiagnosticAnalyzer
 			if (!invocation.IsInTestMethod(xunitContext))
 				return;
 
+			// Ignore anything inside a lambda expression
+			for (var current = context.Operation; current is not null; current = current.Parent)
+				if (current is IAnonymousFunctionOperation)
+					return;
+
 			// invocation should be two nodes: "(some other code).ConfigureAwait" and the arguments (like "(false)")
 			var invocationChildren = invocation.Syntax.ChildNodes().ToList();
 			if (invocationChildren.Count != 2)


### PR DESCRIPTION
In my project, I was forced to turn off the xUnit1030 analyzer because it does not take into account scenarios like the one in the test case. I figured that a PR is the easiest way to demonstrate my issue.

However, I'm not entirely sure if the `xUnit1030` analyzer is wrong here, or if I'm wrong and the test sample is incorrect. 

Could you comment on it @bradwilson, please?