### PR TITLE
Fix for https://github.com/xunit/xunit/issues/2873

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
@@ -1138,6 +1138,38 @@ public class TestClass {
 		}
 
 		[Fact]
+		public async void DoesNotFindWarning_WhenPassingTupleWithoutFieldNames()
+		{
+			var source = @"
+using Xunit;
+
+public class TestClass {
+	public static TheoryData<(int, int)> TestData = new TheoryData<(int, int)>();
+
+    [MemberData(nameof(TestData))]
+    public void TestMethod((int a, int b) x) { }
+}";
+
+			await Verify.VerifyAnalyzer(LanguageVersion.CSharp8, source);
+		}
+
+		[Fact]
+		public async void DoesNotFindWarning_WhenPassingTupleWithDifferentFieldNames()
+		{
+			var source = @"
+using Xunit;
+
+public class TestClass {
+	public static TheoryData<(int c, int d)> TestData = new TheoryData<(int, int)>();
+
+    [MemberData(nameof(TestData))]
+    public void TestMethod((int a, int b) x) { }
+}";
+
+			await Verify.VerifyAnalyzer(LanguageVersion.CSharp8, source);
+		}
+
+		[Fact]
 		public async void FindWarning_WithExtraValueNotCompatibleWithParamsArray()
 		{
 			var source = @"

--- a/src/xunit.analyzers/Utility/SymbolExtensions.cs
+++ b/src/xunit.analyzers/Utility/SymbolExtensions.cs
@@ -86,6 +86,14 @@ public static class SymbolExtensions
 						return IsAssignableFrom(targetEnumerableType, sourceEnumerableType);
 				}
 
+				// Special handling for tuples as tuples with differently named fields are still assignable
+				if (targetType.IsTupleType && sourceType.IsTupleType)
+				{
+					ITypeSymbol targetTupleType = ((INamedTypeSymbol)targetType).TupleUnderlyingType ?? targetType;
+					ITypeSymbol sourceTupleType = ((INamedTypeSymbol)sourceType).TupleUnderlyingType ?? sourceType;
+					return SymbolEqualityComparer.Default.Equals(sourceTupleType, targetTupleType);
+				}
+
 				if (targetType.TypeKind == TypeKind.Interface)
 					return sourceType.AllInterfaces.Any(i => IsAssignableFrom(targetType, i));
 


### PR DESCRIPTION
IsAssignableFrom logic does not account for the possibility that tuple type fields may be named differently. This change augments the logic to allow for the names to not be equal.