### PR TITLE
Create analyzer for non-serializable TheoryData type arguments (xunit/xunit#2866)

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializableTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializableTests.cs
@@ -350,7 +350,7 @@ public class PossiblySerializableUnsealedClass {{ }}";
 		}
 	}
 
-	public sealed class X1044_TheoryDataTypeArgumentsShouldBeSerializable : TheoryDataTypeArgumentsShouldBeSerializableTests
+	public sealed class X1044_AvoidUsingTheoryDataTypeArgumentsThatAreNotSerializable : TheoryDataTypeArgumentsShouldBeSerializableTests
 	{
 		const string Id = "xUnit1044";
 
@@ -431,7 +431,7 @@ public struct NonSerializableStruct {{ }}";
 		}
 	}
 
-	public sealed class X1045_TheoryDataTypeArgumentsShouldBeDefinitelySerializable : TheoryDataTypeArgumentsShouldBeSerializableTests
+	public sealed class X1045_AvoidUsingTheoryDataTypeArgumentsThatMightNotBeSerializable : TheoryDataTypeArgumentsShouldBeSerializableTests
 	{
 		const string Id = "xUnit1045";
 

--- a/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializableTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializableTests.cs
@@ -145,6 +145,20 @@ public class DataSource<T1, T2> : IEnumerable<object[]> {
 	[MemberData(nameof(TheoryDataMembers), "SerializableEnumeration")]
 	[MemberData(nameof(TheoryDataMembers), "SerializableEnumeration?")]
 	[MemberData(nameof(TheoryDataMembers), "Dictionary<string, List<string>>")]
+
+#if NET6_0_OR_GREATER && ROSLYN_4_4_OR_GREATER
+
+	[MemberData(nameof(TheoryDataMembers), "DateOnly")]
+	[MemberData(nameof(TheoryDataMembers), "DateOnly[]")]
+	[MemberData(nameof(TheoryDataMembers), "DateOnly?")]
+	[MemberData(nameof(TheoryDataMembers), "DateOnly?[]")]
+	[MemberData(nameof(TheoryDataMembers), "TimeOnly")]
+	[MemberData(nameof(TheoryDataMembers), "TimeOnly[]")]
+	[MemberData(nameof(TheoryDataMembers), "TimeOnly?")]
+	[MemberData(nameof(TheoryDataMembers), "TimeOnly?[]")]
+
+#endif
+
 	public async void GivenTheoryMethod_WithSerializableTheoryDataMember_DoesNotFindDiagnostic(
 		string member,
 		string attribute,
@@ -218,39 +232,6 @@ public struct SerializableStruct : ISerializableInterface {{
 }}";
 		}
 	}
-
-#if NET6_0_OR_GREATER && ROSLYN_4_4_OR_GREATER
-
-	[Theory]
-	[MemberData(nameof(TheoryDataMembers), "DateOnly")]
-	[MemberData(nameof(TheoryDataMembers), "DateOnly[]")]
-	[MemberData(nameof(TheoryDataMembers), "DateOnly?")]
-	[MemberData(nameof(TheoryDataMembers), "DateOnly?[]")]
-	[MemberData(nameof(TheoryDataMembers), "TimeOnly")]
-	[MemberData(nameof(TheoryDataMembers), "TimeOnly[]")]
-	[MemberData(nameof(TheoryDataMembers), "TimeOnly?")]
-	[MemberData(nameof(TheoryDataMembers), "TimeOnly?[]")]
-	public async void GivenTheoryMethod_WithDateOnlyOrTimeOnlyInTheoryDataMember_DoesNotFindDiagnostic(
-		string member,
-		string attribute,
-		string type)
-	{
-		var source = $@"
-using System;
-using Xunit;
-
-public class TestClass {{
-    {member}
-
-    [Theory]
-    [{attribute}]
-    public void TestMethod({type} parameter) {{ }}
-}}";
-
-		await Verify.VerifyAnalyzer(LanguageVersion.CSharp10, source);
-	}
-
-#endif
 
 	[Theory]
 	[MemberData(nameof(TheoryDataMembers), "object")]

--- a/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializableTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializableTests.cs
@@ -73,6 +73,33 @@ public class TestClass {
 		await Verify.VerifyAnalyzer(source);
 	}
 
+	[Fact]
+	public async void GivenTheoryMethod_WithoutTheoryDataAsDataSource_DoesNotFindDiagnostic()
+	{
+		var source = @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+public class TestClass {
+    public static IEnumerable<object[]> Property1 => Array.Empty<object[]>();
+    public static DataSource<IDisposable, Action> Property2 => new DataSource<IDisposable, Action>();
+
+    [Theory]
+    [MemberData(nameof(Property1))]
+    [MemberData(nameof(Property2))]
+    public void TestMethod(object a, object b) { }
+}
+
+public class DataSource<T1, T2> : IEnumerable<object[]> {
+    public IEnumerator<object[]> GetEnumerator() { yield break; }
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}";
+
+		await Verify.VerifyAnalyzer(source);
+	}
+
 	[Theory]
 	[MemberData(nameof(TheoryDataMembers), "string")]
 	[MemberData(nameof(TheoryDataMembers), "string[]")]

--- a/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializableTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializableTests.cs
@@ -3,9 +3,6 @@ using Verify = CSharpVerifier<Xunit.Analyzers.TheoryDataTypeArgumentsShouldBeSer
 
 public class TheoryDataTypeArgumentsShouldBeSerializableTests
 {
-	const string X1044 = "xUnit1044";
-	const string X1045 = "xUnit1045";
-
 	public static TheoryData<string, string, string, string> TheoryDataClass(
 		string type1,
 		string type2,
@@ -47,33 +44,35 @@ public class DerivedClass : BaseClass<{type1}, {type2}, object, Delegate> {{ }}"
 		};
 	}
 
-	[Fact]
-	public async void GivenMethodWithoutAttributes_DoesNotFindDiagnostic()
+	public sealed class NoDiagnostic : TheoryDataTypeArgumentsShouldBeSerializableTests
 	{
-		var source = @"
+		[Fact]
+		public async void GivenMethodWithoutAttributes_DoesNotFindDiagnostic()
+		{
+			var source = @"
 public class TestClass {
     public void TestMethod() { }
 }";
 
-		await Verify.VerifyAnalyzer(source);
-	}
+			await Verify.VerifyAnalyzer(source);
+		}
 
-	[Fact]
-	public async void GivenFactMethod_DoesNotFindDiagnostic()
-	{
-		var source = @"
+		[Fact]
+		public async void GivenFactMethod_DoesNotFindDiagnostic()
+		{
+			var source = @"
 public class TestClass {
     [Xunit.Fact]
     public void TestMethod() { }
 }";
 
-		await Verify.VerifyAnalyzer(source);
-	}
+			await Verify.VerifyAnalyzer(source);
+		}
 
-	[Fact]
-	public async void GivenTheoryMethod_WithoutTheoryDataAsDataSource_DoesNotFindDiagnostic()
-	{
-		var source = @"
+		[Fact]
+		public async void GivenTheoryMethod_WithoutTheoryDataAsDataSource_DoesNotFindDiagnostic()
+		{
+			var source = @"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -94,76 +93,76 @@ public class DataSource<T1, T2> : IEnumerable<object[]> {
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }";
 
-		await Verify.VerifyAnalyzer(source);
-	}
+			await Verify.VerifyAnalyzer(source);
+		}
 
-	[Theory]
-	[MemberData(nameof(TheoryDataMembers), "string")]
-	[MemberData(nameof(TheoryDataMembers), "string[]")]
-	[MemberData(nameof(TheoryDataMembers), "string[][]")]
-	[MemberData(nameof(TheoryDataMembers), "char")]
-	[MemberData(nameof(TheoryDataMembers), "char?")]
-	[MemberData(nameof(TheoryDataMembers), "byte")]
-	[MemberData(nameof(TheoryDataMembers), "byte?")]
-	[MemberData(nameof(TheoryDataMembers), "sbyte")]
-	[MemberData(nameof(TheoryDataMembers), "sbyte?")]
-	[MemberData(nameof(TheoryDataMembers), "short")]
-	[MemberData(nameof(TheoryDataMembers), "short?")]
-	[MemberData(nameof(TheoryDataMembers), "ushort")]
-	[MemberData(nameof(TheoryDataMembers), "ushort?")]
-	[MemberData(nameof(TheoryDataMembers), "int")]
-	[MemberData(nameof(TheoryDataMembers), "int[]")]
-	[MemberData(nameof(TheoryDataMembers), "int[][]")]
-	[MemberData(nameof(TheoryDataMembers), "int?")]
-	[MemberData(nameof(TheoryDataMembers), "int?[]")]
-	[MemberData(nameof(TheoryDataMembers), "int?[][]")]
-	[MemberData(nameof(TheoryDataMembers), "uint")]
-	[MemberData(nameof(TheoryDataMembers), "uint?")]
-	[MemberData(nameof(TheoryDataMembers), "long")]
-	[MemberData(nameof(TheoryDataMembers), "long?")]
-	[MemberData(nameof(TheoryDataMembers), "ulong")]
-	[MemberData(nameof(TheoryDataMembers), "ulong?")]
-	[MemberData(nameof(TheoryDataMembers), "float")]
-	[MemberData(nameof(TheoryDataMembers), "float?")]
-	[MemberData(nameof(TheoryDataMembers), "double")]
-	[MemberData(nameof(TheoryDataMembers), "double?")]
-	[MemberData(nameof(TheoryDataMembers), "decimal")]
-	[MemberData(nameof(TheoryDataMembers), "decimal?")]
-	[MemberData(nameof(TheoryDataMembers), "bool")]
-	[MemberData(nameof(TheoryDataMembers), "bool?")]
-	[MemberData(nameof(TheoryDataMembers), "DateTime")]
-	[MemberData(nameof(TheoryDataMembers), "DateTime?")]
-	[MemberData(nameof(TheoryDataMembers), "DateTimeOffset")]
-	[MemberData(nameof(TheoryDataMembers), "DateTimeOffset?")]
-	[MemberData(nameof(TheoryDataMembers), "TimeSpan")]
-	[MemberData(nameof(TheoryDataMembers), "TimeSpan?")]
-	[MemberData(nameof(TheoryDataMembers), "BigInteger")]
-	[MemberData(nameof(TheoryDataMembers), "BigInteger?")]
-	[MemberData(nameof(TheoryDataMembers), "Type")]
-	[MemberData(nameof(TheoryDataMembers), "Enum")]
-	[MemberData(nameof(TheoryDataMembers), "SerializableEnumeration")]
-	[MemberData(nameof(TheoryDataMembers), "SerializableEnumeration?")]
-	[MemberData(nameof(TheoryDataMembers), "Dictionary<string, List<string>>")]
+		[Theory]
+		[MemberData(nameof(TheoryDataMembers), "string")]
+		[MemberData(nameof(TheoryDataMembers), "string[]")]
+		[MemberData(nameof(TheoryDataMembers), "string[][]")]
+		[MemberData(nameof(TheoryDataMembers), "char")]
+		[MemberData(nameof(TheoryDataMembers), "char?")]
+		[MemberData(nameof(TheoryDataMembers), "byte")]
+		[MemberData(nameof(TheoryDataMembers), "byte?")]
+		[MemberData(nameof(TheoryDataMembers), "sbyte")]
+		[MemberData(nameof(TheoryDataMembers), "sbyte?")]
+		[MemberData(nameof(TheoryDataMembers), "short")]
+		[MemberData(nameof(TheoryDataMembers), "short?")]
+		[MemberData(nameof(TheoryDataMembers), "ushort")]
+		[MemberData(nameof(TheoryDataMembers), "ushort?")]
+		[MemberData(nameof(TheoryDataMembers), "int")]
+		[MemberData(nameof(TheoryDataMembers), "int[]")]
+		[MemberData(nameof(TheoryDataMembers), "int[][]")]
+		[MemberData(nameof(TheoryDataMembers), "int?")]
+		[MemberData(nameof(TheoryDataMembers), "int?[]")]
+		[MemberData(nameof(TheoryDataMembers), "int?[][]")]
+		[MemberData(nameof(TheoryDataMembers), "uint")]
+		[MemberData(nameof(TheoryDataMembers), "uint?")]
+		[MemberData(nameof(TheoryDataMembers), "long")]
+		[MemberData(nameof(TheoryDataMembers), "long?")]
+		[MemberData(nameof(TheoryDataMembers), "ulong")]
+		[MemberData(nameof(TheoryDataMembers), "ulong?")]
+		[MemberData(nameof(TheoryDataMembers), "float")]
+		[MemberData(nameof(TheoryDataMembers), "float?")]
+		[MemberData(nameof(TheoryDataMembers), "double")]
+		[MemberData(nameof(TheoryDataMembers), "double?")]
+		[MemberData(nameof(TheoryDataMembers), "decimal")]
+		[MemberData(nameof(TheoryDataMembers), "decimal?")]
+		[MemberData(nameof(TheoryDataMembers), "bool")]
+		[MemberData(nameof(TheoryDataMembers), "bool?")]
+		[MemberData(nameof(TheoryDataMembers), "DateTime")]
+		[MemberData(nameof(TheoryDataMembers), "DateTime?")]
+		[MemberData(nameof(TheoryDataMembers), "DateTimeOffset")]
+		[MemberData(nameof(TheoryDataMembers), "DateTimeOffset?")]
+		[MemberData(nameof(TheoryDataMembers), "TimeSpan")]
+		[MemberData(nameof(TheoryDataMembers), "TimeSpan?")]
+		[MemberData(nameof(TheoryDataMembers), "BigInteger")]
+		[MemberData(nameof(TheoryDataMembers), "BigInteger?")]
+		[MemberData(nameof(TheoryDataMembers), "Type")]
+		[MemberData(nameof(TheoryDataMembers), "Enum")]
+		[MemberData(nameof(TheoryDataMembers), "SerializableEnumeration")]
+		[MemberData(nameof(TheoryDataMembers), "SerializableEnumeration?")]
+		[MemberData(nameof(TheoryDataMembers), "Dictionary<string, List<string>>")]
 
 #if NET6_0_OR_GREATER && ROSLYN_4_4_OR_GREATER
 
-	[MemberData(nameof(TheoryDataMembers), "DateOnly")]
-	[MemberData(nameof(TheoryDataMembers), "DateOnly[]")]
-	[MemberData(nameof(TheoryDataMembers), "DateOnly?")]
-	[MemberData(nameof(TheoryDataMembers), "DateOnly?[]")]
-	[MemberData(nameof(TheoryDataMembers), "TimeOnly")]
-	[MemberData(nameof(TheoryDataMembers), "TimeOnly[]")]
-	[MemberData(nameof(TheoryDataMembers), "TimeOnly?")]
-	[MemberData(nameof(TheoryDataMembers), "TimeOnly?[]")]
+		[MemberData(nameof(TheoryDataMembers), "DateOnly")]
+		[MemberData(nameof(TheoryDataMembers), "DateOnly[]")]
+		[MemberData(nameof(TheoryDataMembers), "DateOnly?")]
+		[MemberData(nameof(TheoryDataMembers), "DateOnly?[]")]
+		[MemberData(nameof(TheoryDataMembers), "TimeOnly")]
+		[MemberData(nameof(TheoryDataMembers), "TimeOnly[]")]
+		[MemberData(nameof(TheoryDataMembers), "TimeOnly?")]
+		[MemberData(nameof(TheoryDataMembers), "TimeOnly?[]")]
 
 #endif
 
-	public async void GivenTheoryMethod_WithSerializableTheoryDataMember_DoesNotFindDiagnostic(
-		string member,
-		string attribute,
-		string type)
-	{
-		var source = $@"
+		public async void GivenTheoryMethod_WithSerializableTheoryDataMember_DoesNotFindDiagnostic(
+			string member,
+			string attribute,
+			string type)
+		{
+			var source = $@"
 using System;
 using System.Collections.Generic;
 using System.Numerics;
@@ -179,34 +178,34 @@ public class TestClass {{
 
 public enum SerializableEnumeration {{ Zero }}";
 
-		await Verify.VerifyAnalyzer(source);
-	}
+			await Verify.VerifyAnalyzer(source);
+		}
 
-	[Theory]
-	[MemberData(nameof(TheoryDataMembers), "IXunitSerializable")]
-	[MemberData(nameof(TheoryDataMembers), "IXunitSerializable[]")]
-	[MemberData(nameof(TheoryDataMembers), "ISerializableInterface")]
-	[MemberData(nameof(TheoryDataMembers), "ISerializableInterface[]")]
-	[MemberData(nameof(TheoryDataMembers), "SerializableClass")]
-	[MemberData(nameof(TheoryDataMembers), "SerializableClass[]")]
-	[MemberData(nameof(TheoryDataMembers), "SerializableStruct")]
-	[MemberData(nameof(TheoryDataMembers), "SerializableStruct[]")]
-	[MemberData(nameof(TheoryDataMembers), "SerializableStruct?")]
-	[MemberData(nameof(TheoryDataMembers), "SerializableStruct?[]")]
-	public async void GivenTheoryMethod_WithIXunitSerializableTheoryDataMember_DoesNotFindDiagnostic(
-		string member,
-		string attribute,
-		string type)
-	{
-		var sourceV2 = GetSource(iXunitSerializableNamespace: "Xunit.Abstractions");
-		var sourceV3 = GetSource(iXunitSerializableNamespace: "Xunit.Sdk");
-
-		await Verify.VerifyAnalyzerV2(sourceV2);
-		await Verify.VerifyAnalyzerV3(sourceV3);
-
-		string GetSource(string iXunitSerializableNamespace)
+		[Theory]
+		[MemberData(nameof(TheoryDataMembers), "IXunitSerializable")]
+		[MemberData(nameof(TheoryDataMembers), "IXunitSerializable[]")]
+		[MemberData(nameof(TheoryDataMembers), "ISerializableInterface")]
+		[MemberData(nameof(TheoryDataMembers), "ISerializableInterface[]")]
+		[MemberData(nameof(TheoryDataMembers), "SerializableClass")]
+		[MemberData(nameof(TheoryDataMembers), "SerializableClass[]")]
+		[MemberData(nameof(TheoryDataMembers), "SerializableStruct")]
+		[MemberData(nameof(TheoryDataMembers), "SerializableStruct[]")]
+		[MemberData(nameof(TheoryDataMembers), "SerializableStruct?")]
+		[MemberData(nameof(TheoryDataMembers), "SerializableStruct?[]")]
+		public async void GivenTheoryMethod_WithIXunitSerializableTheoryDataMember_DoesNotFindDiagnostic(
+			string member,
+			string attribute,
+			string type)
 		{
-			return $@"
+			var sourceV2 = GetSource(iXunitSerializableNamespace: "Xunit.Abstractions");
+			var sourceV3 = GetSource(iXunitSerializableNamespace: "Xunit.Sdk");
+
+			await Verify.VerifyAnalyzerV2(sourceV2);
+			await Verify.VerifyAnalyzerV3(sourceV3);
+
+			string GetSource(string iXunitSerializableNamespace)
+			{
+				return $@"
 using Xunit;
 using {iXunitSerializableNamespace};
 
@@ -229,26 +228,42 @@ public struct SerializableStruct : ISerializableInterface {{
     public void Deserialize(IXunitSerializationInfo info) {{ }}
     public void Serialize(IXunitSerializationInfo info) {{ }}
 }}";
+			}
+		}
+
+		[Theory]
+		[MemberData(nameof(TheoryDataClass), "int", "double", "string")]
+		public async void GivenTheoryMethod_WithSerializableTheoryDataClass_DoesNotFindDiagnostic(
+			string source,
+			string _1,
+			string _2,
+			string _3)
+		{
+			await Verify.VerifyAnalyzer(source);
 		}
 	}
 
-	[Theory]
-	[MemberData(nameof(TheoryDataMembers), "Delegate")]
-	[MemberData(nameof(TheoryDataMembers), "Delegate[]")]
-	[MemberData(nameof(TheoryDataMembers), "Func<int>")]
-	[MemberData(nameof(TheoryDataMembers), "Func<int>[]")]
-	[MemberData(nameof(TheoryDataMembers), "NonSerializableSealedClass")]
-	[MemberData(nameof(TheoryDataMembers), "NonSerializableSealedClass[]")]
-	[MemberData(nameof(TheoryDataMembers), "NonSerializableStruct")]
-	[MemberData(nameof(TheoryDataMembers), "NonSerializableStruct[]")]
-	[MemberData(nameof(TheoryDataMembers), "NonSerializableStruct?")]
-	[MemberData(nameof(TheoryDataMembers), "NonSerializableStruct?[]")]
-	public async void GivenTheoryMethod_WithNonSerializableTheoryDataMember_FindsDiagnosticX1044(
-		string member,
-		string attribute,
-		string type)
+	public sealed class X1044_TheoryDataTypeArgumentsShouldBeSerializable : TheoryDataTypeArgumentsShouldBeSerializableTests
 	{
-		var source = $@"
+		const string Id = "xUnit1044";
+
+		[Theory]
+		[MemberData(nameof(TheoryDataMembers), "Delegate")]
+		[MemberData(nameof(TheoryDataMembers), "Delegate[]")]
+		[MemberData(nameof(TheoryDataMembers), "Func<int>")]
+		[MemberData(nameof(TheoryDataMembers), "Func<int>[]")]
+		[MemberData(nameof(TheoryDataMembers), "NonSerializableSealedClass")]
+		[MemberData(nameof(TheoryDataMembers), "NonSerializableSealedClass[]")]
+		[MemberData(nameof(TheoryDataMembers), "NonSerializableStruct")]
+		[MemberData(nameof(TheoryDataMembers), "NonSerializableStruct[]")]
+		[MemberData(nameof(TheoryDataMembers), "NonSerializableStruct?")]
+		[MemberData(nameof(TheoryDataMembers), "NonSerializableStruct?[]")]
+		public async void GivenTheoryMethod_WithNonSerializableTheoryDataMember_FindsDiagnostic(
+			string member,
+			string attribute,
+			string type)
+		{
+			var source = $@"
 using System;
 using System.Text;
 using Xunit;
@@ -265,38 +280,77 @@ public sealed class NonSerializableSealedClass {{ }}
 
 public struct NonSerializableStruct {{ }}";
 
-		var expected =
-			Verify
-				.Diagnostic(X1044)
-				.WithSpan(10, 6, 10, 6 + attribute.Length)
-				.WithArguments(type);
+			var expected =
+				Verify
+					.Diagnostic(Id)
+					.WithSpan(10, 6, 10, 6 + attribute.Length)
+					.WithArguments(type);
 
-		await Verify.VerifyAnalyzer(source, expected);
+			await Verify.VerifyAnalyzer(source, expected);
+		}
+
+		[Theory]
+		[MemberData(nameof(TheoryDataClass), "Action", "TimeZoneInfo", "TimeZoneInfo.TransitionTime")]
+		public async void GivenTheoryMethod_WithNonSerializableTheoryDataClass_FindsDiagnostic(
+			string source,
+			string type1,
+			string type2,
+			string type3)
+		{
+			var expectedForType1 =
+				Verify
+					.Diagnostic(Id)
+					.WithSpan(7, 6, 7, 37)
+					.WithArguments(type1);
+
+			var expectedForType2 =
+				Verify
+					.Diagnostic(Id)
+					.WithSpan(7, 6, 7, 37)
+					.WithArguments(type2);
+
+			var expectedForType3 =
+				Verify
+					.Diagnostic(Id)
+					.WithSpan(7, 6, 7, 37)
+					.WithArguments(type3);
+
+			await Verify.VerifyAnalyzer(
+				source,
+				expectedForType1,
+				expectedForType2,
+				expectedForType3
+			);
+		}
 	}
 
-	[Theory]
-	[MemberData(nameof(TheoryDataMembers), "object")]
-	[MemberData(nameof(TheoryDataMembers), "object[]")]
-	[MemberData(nameof(TheoryDataMembers), "Array")]
-	[MemberData(nameof(TheoryDataMembers), "Array[]")]
-	[MemberData(nameof(TheoryDataMembers), "ValueType")]
-	[MemberData(nameof(TheoryDataMembers), "ValueType[]")]
-	[MemberData(nameof(TheoryDataMembers), "IEnumerable")]
-	[MemberData(nameof(TheoryDataMembers), "IEnumerable[]")]
-	[MemberData(nameof(TheoryDataMembers), "IEnumerable<int>")]
-	[MemberData(nameof(TheoryDataMembers), "IEnumerable<int>[]")]
-	[MemberData(nameof(TheoryDataMembers), "Dictionary<int, string>")]
-	[MemberData(nameof(TheoryDataMembers), "Dictionary<int, string>[]")]
-	[MemberData(nameof(TheoryDataMembers), "IPossiblySerializableInterface")]
-	[MemberData(nameof(TheoryDataMembers), "IPossiblySerializableInterface[]")]
-	[MemberData(nameof(TheoryDataMembers), "PossiblySerializableUnsealedClass")]
-	[MemberData(nameof(TheoryDataMembers), "PossiblySerializableUnsealedClass[]")]
-	public async void GivenTheoryMethod_WithPossiblySerializableTheoryDataMember_FindsDiagnosticX1045(
-		string member,
-		string attribute,
-		string type)
+	public sealed class X1045_TheoryDataTypeArgumentsShouldBeDefinitelySerializable : TheoryDataTypeArgumentsShouldBeSerializableTests
 	{
-		var source = $@"
+		const string Id = "xUnit1045";
+
+		[Theory]
+		[MemberData(nameof(TheoryDataMembers), "object")]
+		[MemberData(nameof(TheoryDataMembers), "object[]")]
+		[MemberData(nameof(TheoryDataMembers), "Array")]
+		[MemberData(nameof(TheoryDataMembers), "Array[]")]
+		[MemberData(nameof(TheoryDataMembers), "ValueType")]
+		[MemberData(nameof(TheoryDataMembers), "ValueType[]")]
+		[MemberData(nameof(TheoryDataMembers), "IEnumerable")]
+		[MemberData(nameof(TheoryDataMembers), "IEnumerable[]")]
+		[MemberData(nameof(TheoryDataMembers), "IEnumerable<int>")]
+		[MemberData(nameof(TheoryDataMembers), "IEnumerable<int>[]")]
+		[MemberData(nameof(TheoryDataMembers), "Dictionary<int, string>")]
+		[MemberData(nameof(TheoryDataMembers), "Dictionary<int, string>[]")]
+		[MemberData(nameof(TheoryDataMembers), "IPossiblySerializableInterface")]
+		[MemberData(nameof(TheoryDataMembers), "IPossiblySerializableInterface[]")]
+		[MemberData(nameof(TheoryDataMembers), "PossiblySerializableUnsealedClass")]
+		[MemberData(nameof(TheoryDataMembers), "PossiblySerializableUnsealedClass[]")]
+		public async void GivenTheoryMethod_WithPossiblySerializableTheoryDataMember_FindsDiagnostic(
+			string member,
+			string attribute,
+			string type)
+		{
+			var source = $@"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -314,91 +368,47 @@ public interface IPossiblySerializableInterface {{ }}
 
 public class PossiblySerializableUnsealedClass {{ }}";
 
-		var expected =
-			Verify
-				.Diagnostic(X1045)
-				.WithSpan(11, 6, 11, 6 + attribute.Length)
-				.WithArguments(type);
+			var expected =
+				Verify
+					.Diagnostic(Id)
+					.WithSpan(11, 6, 11, 6 + attribute.Length)
+					.WithArguments(type);
 
-		await Verify.VerifyAnalyzer(source, expected);
-	}
+			await Verify.VerifyAnalyzer(source, expected);
+		}
 
-	[Theory]
-	[MemberData(nameof(TheoryDataClass), "int", "double", "string")]
-	public async void GivenTheoryMethod_WithSerializableTheoryDataClass_DoesNotFindDiagnostic(
-		string source,
-		string _1,
-		string _2,
-		string _3)
-	{
-		await Verify.VerifyAnalyzer(source);
-	}
+		[Theory]
+		[MemberData(nameof(TheoryDataClass), "object[]", "Array", "IDisposable")]
+		public async void GivenTheoryMethod_WithPossiblySerializableTheoryDataClass_FindsDiagnostic(
+			string source,
+			string type1,
+			string type2,
+			string type3)
+		{
+			var expectedForType1 =
+				Verify
+					.Diagnostic(Id)
+					.WithSpan(7, 6, 7, 37)
+					.WithArguments(type1);
 
-	[Theory]
-	[MemberData(nameof(TheoryDataClass), "Action", "TimeZoneInfo", "TimeZoneInfo.TransitionTime")]
-	public async void GivenTheoryMethod_WithNonSerializableTheoryDataClass_FindsDiagnosticX1044(
-		string source,
-		string type1,
-		string type2,
-		string type3)
-	{
-		var expectedForType1 =
-			Verify
-				.Diagnostic(X1044)
-				.WithSpan(7, 6, 7, 37)
-				.WithArguments(type1);
+			var expectedForType2 =
+				Verify
+					.Diagnostic(Id)
+					.WithSpan(7, 6, 7, 37)
+					.WithArguments(type2);
 
-		var expectedForType2 =
-			Verify
-				.Diagnostic(X1044)
-				.WithSpan(7, 6, 7, 37)
-				.WithArguments(type2);
+			var expectedForType3 =
+				Verify
+					.Diagnostic(Id)
+					.WithSpan(7, 6, 7, 37)
+					.WithArguments(type3);
 
-		var expectedForType3 =
-			Verify
-				.Diagnostic(X1044)
-				.WithSpan(7, 6, 7, 37)
-				.WithArguments(type3);
-
-		await Verify.VerifyAnalyzer(
-			source,
-			expectedForType1,
-			expectedForType2,
-			expectedForType3
-		);
-	}
-
-	[Theory]
-	[MemberData(nameof(TheoryDataClass), "object[]", "Array", "IDisposable")]
-	public async void GivenTheoryMethod_WithPossiblySerializableTheoryDataClass_FindsDiagnosticX1045(
-		string source,
-		string type1,
-		string type2,
-		string type3)
-	{
-		var expectedForType1 =
-			Verify
-				.Diagnostic(X1045)
-				.WithSpan(7, 6, 7, 37)
-				.WithArguments(type1);
-
-		var expectedForType2 =
-			Verify
-				.Diagnostic(X1045)
-				.WithSpan(7, 6, 7, 37)
-				.WithArguments(type2);
-
-		var expectedForType3 =
-			Verify
-				.Diagnostic(X1045)
-				.WithSpan(7, 6, 7, 37)
-				.WithArguments(type3);
-
-		await Verify.VerifyAnalyzer(
-			source,
-			expectedForType1,
-			expectedForType2,
-			expectedForType3
-		);
+			await Verify.VerifyAnalyzer(
+				source,
+				expectedForType1,
+				expectedForType2,
+				expectedForType3
+			);
+		}
 	}
 }

--- a/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializableTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializableTests.cs
@@ -61,7 +61,7 @@ public class DerivedClass : BaseClass<{type1}, {type2}, object, Delegate> {{ }}"
 	public sealed class NoDiagnostic : TheoryDataTypeArgumentsShouldBeSerializableTests
 	{
 		[Fact]
-		public async void GivenMethodWithoutAttributes_DoesNotFindDiagnostic()
+		public async void GivenMethodWithoutAttributes_FindsNoDiagnostic()
 		{
 			var source = @"
 public class TestClass {
@@ -72,7 +72,7 @@ public class TestClass {
 		}
 
 		[Fact]
-		public async void GivenFactMethod_DoesNotFindDiagnostic()
+		public async void GivenFact_FindsNoDiagnostic()
 		{
 			var source = @"
 public class TestClass {
@@ -84,7 +84,7 @@ public class TestClass {
 		}
 
 		[Fact]
-		public async void GivenTheoryMethod_WithoutTheoryDataAsDataSource_DoesNotFindDiagnostic()
+		public async void GivenTheory_WithoutTheoryDataAsDataSource_FindsNoDiagnostic()
 		{
 			var source = @"
 using System;
@@ -171,7 +171,7 @@ public class DataSource<T1, T2> : IEnumerable<object[]> {
 
 #endif
 
-		public async void GivenTheoryMethod_WithSerializableTheoryDataMember_DoesNotFindDiagnostic(
+		public async void GivenTheory_WithSerializableTheoryDataMember_FindsNoDiagnostic(
 			string member,
 			string attribute,
 			string type)
@@ -206,7 +206,7 @@ public enum SerializableEnumeration {{ Zero }}";
 		[MemberData(nameof(TheoryDataMembers), "SerializableStruct[]")]
 		[MemberData(nameof(TheoryDataMembers), "SerializableStruct?")]
 		[MemberData(nameof(TheoryDataMembers), "SerializableStruct?[]")]
-		public async void GivenTheoryMethod_WithIXunitSerializableTheoryDataMember_DoesNotFindDiagnostic(
+		public async void GivenTheory_WithIXunitSerializableTheoryDataMember_FindsNoDiagnostic(
 			string member,
 			string attribute,
 			string type)
@@ -254,7 +254,7 @@ public struct SerializableStruct : ISerializableInterface {{
 		[MemberData(nameof(TheoryDataMembers), "object[]")]
 		[MemberData(nameof(TheoryDataMembers), "IPossiblySerializableInterface")]
 		[MemberData(nameof(TheoryDataMembers), "PossiblySerializableUnsealedClass")]
-		public async void GivenTheoryMethod_WithNonSerializableDataButDiscoveryEnumerationDisabledForTheory_DoesNotFindDiagnostic(
+		public async void GivenTheory_WithNonSerializableDataButDiscoveryEnumerationDisabledForTheory_FindsNoDiagnostic(
 			string member,
 			string attribute,
 			string type)
@@ -291,7 +291,7 @@ public class PossiblySerializableUnsealedClass {{ }}";
 		[MemberData(nameof(TheoryDataMembersWithDiscoveryEnumerationDisabled), "object[]")]
 		[MemberData(nameof(TheoryDataMembersWithDiscoveryEnumerationDisabled), "IPossiblySerializableInterface")]
 		[MemberData(nameof(TheoryDataMembersWithDiscoveryEnumerationDisabled), "PossiblySerializableUnsealedClass")]
-		public async void GivenTheoryMethod_WithNonSerializableDataButDiscoveryEnumerationDisabledForData_DoesNotFindDiagnostic(
+		public async void GivenTheory_WithNonSerializableDataButDiscoveryEnumerationDisabledForData_FindsNoDiagnostic(
 			string member,
 			string attribute,
 			string type)
@@ -321,7 +321,7 @@ public class PossiblySerializableUnsealedClass {{ }}";
 
 		[Theory]
 		[MemberData(nameof(TheoryDataClass), "int", "double", "string")]
-		public async void GivenTheoryMethod_WithSerializableTheoryDataClass_DoesNotFindDiagnostic(
+		public async void GivenTheory_WithSerializableTheoryDataClass_FindsNoDiagnostic(
 			string source,
 			string _1,
 			string _2,
@@ -346,7 +346,7 @@ public class PossiblySerializableUnsealedClass {{ }}";
 		[MemberData(nameof(TheoryDataMembers), "NonSerializableStruct[]")]
 		[MemberData(nameof(TheoryDataMembers), "NonSerializableStruct?")]
 		[MemberData(nameof(TheoryDataMembers), "NonSerializableStruct?[]")]
-		public async void GivenTheoryMethod_WithNonSerializableTheoryDataMember_FindsDiagnostic(
+		public async void GivenTheory_WithNonSerializableTheoryDataMember_FindsDiagnostic(
 			string member,
 			string attribute,
 			string type)
@@ -379,7 +379,7 @@ public struct NonSerializableStruct {{ }}";
 
 		[Theory]
 		[MemberData(nameof(TheoryDataClass), "Action", "TimeZoneInfo", "TimeZoneInfo.TransitionTime")]
-		public async void GivenTheoryMethod_WithNonSerializableTheoryDataClass_FindsDiagnostic(
+		public async void GivenTheory_WithNonSerializableTheoryDataClass_FindsDiagnostic(
 			string source,
 			string type1,
 			string type2,
@@ -433,7 +433,7 @@ public struct NonSerializableStruct {{ }}";
 		[MemberData(nameof(TheoryDataMembers), "IPossiblySerializableInterface[]")]
 		[MemberData(nameof(TheoryDataMembers), "PossiblySerializableUnsealedClass")]
 		[MemberData(nameof(TheoryDataMembers), "PossiblySerializableUnsealedClass[]")]
-		public async void GivenTheoryMethod_WithPossiblySerializableTheoryDataMember_FindsDiagnostic(
+		public async void GivenTheory_WithPossiblySerializableTheoryDataMember_FindsDiagnostic(
 			string member,
 			string attribute,
 			string type)
@@ -467,7 +467,7 @@ public class PossiblySerializableUnsealedClass {{ }}";
 
 		[Theory]
 		[MemberData(nameof(TheoryDataClass), "object[]", "Array", "IDisposable")]
-		public async void GivenTheoryMethod_WithPossiblySerializableTheoryDataClass_FindsDiagnostic(
+		public async void GivenTheory_WithPossiblySerializableTheoryDataClass_FindsDiagnostic(
 			string source,
 			string type1,
 			string type2,

--- a/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializableTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializableTests.cs
@@ -6,6 +6,13 @@ public class TheoryDataTypeArgumentsShouldBeSerializableTests
 	public static TheoryData<string, string, string, string> TheoryDataClass(
 		string type1,
 		string type2,
+		string type3) =>
+			TheoryDataClass(theoryAttribute: "Theory", type1, type2, type3);
+
+	public static TheoryData<string, string, string, string> TheoryDataClass(
+		string theoryAttribute,
+		string type1,
+		string type2,
 		string type3)
 	{
 		var source = $@"
@@ -13,7 +20,7 @@ using System;
 using Xunit;
 
 public class TestClass {{
-    [Theory]
+    [{theoryAttribute}]
     [ClassData(typeof(DerivedClass))]
     public void TestMethod({type1} a, {type2} b, {type3} c) {{ }}
 }}
@@ -254,7 +261,7 @@ public struct SerializableStruct : ISerializableInterface {{
 		[MemberData(nameof(TheoryDataMembers), "object[]")]
 		[MemberData(nameof(TheoryDataMembers), "IPossiblySerializableInterface")]
 		[MemberData(nameof(TheoryDataMembers), "PossiblySerializableUnsealedClass")]
-		public async void GivenTheory_WithNonSerializableDataButDiscoveryEnumerationDisabledForTheory_FindsNoDiagnostic(
+		public async void GivenTheory_WithNonSerializableTheoryDataMember_WithDiscoveryEnumerationDisabledForTheory_FindsNoDiagnostic(
 			string member,
 			string attribute,
 			string type)
@@ -291,7 +298,7 @@ public class PossiblySerializableUnsealedClass {{ }}";
 		[MemberData(nameof(TheoryDataMembersWithDiscoveryEnumerationDisabled), "object[]")]
 		[MemberData(nameof(TheoryDataMembersWithDiscoveryEnumerationDisabled), "IPossiblySerializableInterface")]
 		[MemberData(nameof(TheoryDataMembersWithDiscoveryEnumerationDisabled), "PossiblySerializableUnsealedClass")]
-		public async void GivenTheory_WithNonSerializableDataButDiscoveryEnumerationDisabledForData_FindsNoDiagnostic(
+		public async void GivenTheory_WithNonSerializableTheoryDataMember_WithDiscoveryEnumerationDisabledForMemberData_FindsNoDiagnostic(
 			string member,
 			string attribute,
 			string type)
@@ -328,6 +335,18 @@ public class PossiblySerializableUnsealedClass {{ }}";
 			string _3)
 		{
 			await Verify.VerifyAnalyzer(source);
+		}
+
+		[Theory]
+		[MemberData(nameof(TheoryDataClass), "Theory(DisableDiscoveryEnumeration = true)", "Action", "TimeZoneInfo", "TimeZoneInfo.TransitionTime")]
+		[MemberData(nameof(TheoryDataClass), "Theory(DisableDiscoveryEnumeration = true)", "object[]", "Array", "IDisposable")]
+		public async void GivenTheory_WithNonSerializableTheoryDataClass_WithDiscoveryEnumerationDisabled_FindsNoDiagnostic(
+			string source,
+			string _1,
+			string _2,
+			string _3)
+		{
+			await Verify.VerifyAnalyzerV3(source);
 		}
 	}
 

--- a/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializableTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializableTests.cs
@@ -36,16 +36,14 @@ public class DerivedClass : BaseClass<{type1}, {type2}, object, Delegate> {{ }}"
 	{
 		var @class = $@"public sealed class Class : TheoryData<{type}> {{ }}";
 		var field = $@"public static readonly TheoryData<{type}> Field = new TheoryData<{type}>() {{ }};";
-		var method = $@"public static TheoryData<{type}> Method() => new TheoryData<{type}>() {{ }};";
-		var parameterizedMethod = $@"public static TheoryData<{type}> Method(int a, string b) => new TheoryData<{type}>() {{ }};";
+		var method = $@"public static TheoryData<{type}> Method(int a, string b) => new TheoryData<{type}>() {{ }};";
 		var property = $@"public static TheoryData<{type}> Property => new TheoryData<{type}>() {{ }};";
 
 		return new TheoryData<string, string, string>
 		{
 			{ @class, "ClassData(typeof(Class))", type },
 			{ field, "MemberData(nameof(Field))", type },
-			{ method, "MemberData(nameof(Method))", type },
-			{ parameterizedMethod, @"MemberData(nameof(Method), 1, ""2"")", type },
+			{ method, @"MemberData(nameof(Method), 1, ""2"")", type },
 			{ property, "MemberData(nameof(Property))", type }
 		};
 	}

--- a/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializableTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializableTests.cs
@@ -1,0 +1,399 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+using Verify = CSharpVerifier<Xunit.Analyzers.TheoryDataTypeArgumentsShouldBeSerializable>;
+
+public class TheoryDataTypeArgumentsShouldBeSerializableTests
+{
+	const string IsNotSerializable = "is not serializable";
+	const string MightNotBeSerializable = "might not be serializable";
+
+	public static TheoryData<string, string, string, string> TheoryDataClass(
+		string type1,
+		string type2,
+		string type3)
+	{
+		var source = $@"
+using System;
+using Xunit;
+
+public class TestClass {{
+    [Theory]
+    [ClassData(typeof(DerivedClass))]
+    public void TestMethod({type1} a, {type2} b, {type3} c) {{ }}
+}}
+
+public class BaseClass<T1, T2, T3, T4> : TheoryData<T1, T2, {type3}> {{ }}
+
+public class DerivedClass : BaseClass<{type1}, {type2}, object, Delegate> {{ }}";
+
+		return new TheoryData<string, string, string, string>
+		{
+			{ source, type1, type2, type3 }
+		};
+	}
+
+	public static TheoryData<string, string, string> TheoryDataMembers(string type)
+	{
+		var @class = $@"public sealed class Class : TheoryData<{type}> {{ }}";
+		var field = $@"public static readonly TheoryData<{type}> Field = new TheoryData<{type}>() {{ }};";
+		var method = $@"public static TheoryData<{type}> Method() => new TheoryData<{type}>() {{ }};";
+		var parameterizedMethod = $@"public static TheoryData<{type}> Method(int a, string b) => new TheoryData<{type}>() {{ }};";
+		var property = $@"public static TheoryData<{type}> Property => new TheoryData<{type}>() {{ }};";
+
+		return new TheoryData<string, string, string>
+		{
+			{ @class, "ClassData(typeof(Class))", type },
+			{ field, "MemberData(nameof(Field))", type },
+			{ method, "MemberData(nameof(Method))", type },
+			{ parameterizedMethod, @"MemberData(nameof(Method), 1, ""2"")", type },
+			{ property, "MemberData(nameof(Property))", type }
+		};
+	}
+
+	[Fact]
+	public async void GivenMethodWithoutAttributes_DoesNotFindDiagnostic()
+	{
+		var source = @"
+public class TestClass {
+    public void TestMethod() { }
+}";
+
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Fact]
+	public async void GivenFactMethod_DoesNotFindDiagnostic()
+	{
+		var source = @"
+public class TestClass {
+    [Xunit.Fact]
+    public void TestMethod() { }
+}";
+
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Theory]
+	[MemberData(nameof(TheoryDataMembers), "string")]
+	[MemberData(nameof(TheoryDataMembers), "string[]")]
+	[MemberData(nameof(TheoryDataMembers), "string[][]")]
+	[MemberData(nameof(TheoryDataMembers), "char")]
+	[MemberData(nameof(TheoryDataMembers), "char?")]
+	[MemberData(nameof(TheoryDataMembers), "byte")]
+	[MemberData(nameof(TheoryDataMembers), "byte?")]
+	[MemberData(nameof(TheoryDataMembers), "sbyte")]
+	[MemberData(nameof(TheoryDataMembers), "sbyte?")]
+	[MemberData(nameof(TheoryDataMembers), "short")]
+	[MemberData(nameof(TheoryDataMembers), "short?")]
+	[MemberData(nameof(TheoryDataMembers), "ushort")]
+	[MemberData(nameof(TheoryDataMembers), "ushort?")]
+	[MemberData(nameof(TheoryDataMembers), "int")]
+	[MemberData(nameof(TheoryDataMembers), "int[]")]
+	[MemberData(nameof(TheoryDataMembers), "int[][]")]
+	[MemberData(nameof(TheoryDataMembers), "int?")]
+	[MemberData(nameof(TheoryDataMembers), "int?[]")]
+	[MemberData(nameof(TheoryDataMembers), "int?[][]")]
+	[MemberData(nameof(TheoryDataMembers), "uint")]
+	[MemberData(nameof(TheoryDataMembers), "uint?")]
+	[MemberData(nameof(TheoryDataMembers), "long")]
+	[MemberData(nameof(TheoryDataMembers), "long?")]
+	[MemberData(nameof(TheoryDataMembers), "ulong")]
+	[MemberData(nameof(TheoryDataMembers), "ulong?")]
+	[MemberData(nameof(TheoryDataMembers), "float")]
+	[MemberData(nameof(TheoryDataMembers), "float?")]
+	[MemberData(nameof(TheoryDataMembers), "double")]
+	[MemberData(nameof(TheoryDataMembers), "double?")]
+	[MemberData(nameof(TheoryDataMembers), "decimal")]
+	[MemberData(nameof(TheoryDataMembers), "decimal?")]
+	[MemberData(nameof(TheoryDataMembers), "bool")]
+	[MemberData(nameof(TheoryDataMembers), "bool?")]
+	[MemberData(nameof(TheoryDataMembers), "DateTime")]
+	[MemberData(nameof(TheoryDataMembers), "DateTime?")]
+	[MemberData(nameof(TheoryDataMembers), "DateTimeOffset")]
+	[MemberData(nameof(TheoryDataMembers), "DateTimeOffset?")]
+	[MemberData(nameof(TheoryDataMembers), "TimeSpan")]
+	[MemberData(nameof(TheoryDataMembers), "TimeSpan?")]
+	[MemberData(nameof(TheoryDataMembers), "BigInteger")]
+	[MemberData(nameof(TheoryDataMembers), "BigInteger?")]
+	[MemberData(nameof(TheoryDataMembers), "Type")]
+	[MemberData(nameof(TheoryDataMembers), "Enum")]
+	[MemberData(nameof(TheoryDataMembers), "SerializableEnumeration")]
+	[MemberData(nameof(TheoryDataMembers), "SerializableEnumeration?")]
+	[MemberData(nameof(TheoryDataMembers), "Dictionary<string, List<string>>")]
+	public async void GivenTheoryMethod_WithSerializableTheoryDataMember_DoesNotFindDiagnostic(
+		string member,
+		string attribute,
+		string type)
+	{
+		var source = $@"
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Xunit;
+
+public class TestClass {{
+    {member}
+
+    [Theory]
+    [{attribute}]
+    public void TestMethod({type} parameter) {{ }}
+}}
+
+public enum SerializableEnumeration {{ Zero }}";
+
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Theory]
+	[MemberData(nameof(TheoryDataMembers), "IXunitSerializable")]
+	[MemberData(nameof(TheoryDataMembers), "IXunitSerializable[]")]
+	[MemberData(nameof(TheoryDataMembers), "ISerializableInterface")]
+	[MemberData(nameof(TheoryDataMembers), "ISerializableInterface[]")]
+	[MemberData(nameof(TheoryDataMembers), "SerializableClass")]
+	[MemberData(nameof(TheoryDataMembers), "SerializableClass[]")]
+	[MemberData(nameof(TheoryDataMembers), "SerializableStruct")]
+	[MemberData(nameof(TheoryDataMembers), "SerializableStruct[]")]
+	[MemberData(nameof(TheoryDataMembers), "SerializableStruct?")]
+	[MemberData(nameof(TheoryDataMembers), "SerializableStruct?[]")]
+	public async void GivenTheoryMethod_WithIXunitSerializableTheoryDataMember_DoesNotFindDiagnostic(
+		string member,
+		string attribute,
+		string type)
+	{
+		var sourceV2 = GetSource(iXunitSerializableNamespace: "Xunit.Abstractions");
+		var sourceV3 = GetSource(iXunitSerializableNamespace: "Xunit.Sdk");
+
+		await Verify.VerifyAnalyzerV2(sourceV2);
+		await Verify.VerifyAnalyzerV3(sourceV3);
+
+		string GetSource(string iXunitSerializableNamespace)
+		{
+			return $@"
+using Xunit;
+using {iXunitSerializableNamespace};
+
+public class TestClass {{
+    {member}
+
+    [Theory]
+    [{attribute}]
+    public void TestMethod({type} parameter) {{ }}
+}}
+
+public interface ISerializableInterface : IXunitSerializable {{ }}
+
+public class SerializableClass : ISerializableInterface {{
+    public void Deserialize(IXunitSerializationInfo info) {{ }}
+    public void Serialize(IXunitSerializationInfo info) {{ }}
+}}
+
+public struct SerializableStruct : ISerializableInterface {{
+    public void Deserialize(IXunitSerializationInfo info) {{ }}
+    public void Serialize(IXunitSerializationInfo info) {{ }}
+}}";
+		}
+	}
+
+#if NET6_0_OR_GREATER && ROSLYN_4_4_OR_GREATER
+
+	[Theory]
+	[MemberData(nameof(TheoryDataMembers), "DateOnly")]
+	[MemberData(nameof(TheoryDataMembers), "DateOnly[]")]
+	[MemberData(nameof(TheoryDataMembers), "DateOnly?")]
+	[MemberData(nameof(TheoryDataMembers), "DateOnly?[]")]
+	[MemberData(nameof(TheoryDataMembers), "TimeOnly")]
+	[MemberData(nameof(TheoryDataMembers), "TimeOnly[]")]
+	[MemberData(nameof(TheoryDataMembers), "TimeOnly?")]
+	[MemberData(nameof(TheoryDataMembers), "TimeOnly?[]")]
+	public async void GivenTheoryMethod_WithDateOnlyOrTimeOnlyInTheoryDataMember_DoesNotFindDiagnostic(
+		string member,
+		string attribute,
+		string type)
+	{
+		var source = $@"
+using System;
+using Xunit;
+
+public class TestClass {{
+    {member}
+
+    [Theory]
+    [{attribute}]
+    public void TestMethod({type} parameter) {{ }}
+}}";
+
+		await Verify.VerifyAnalyzer(LanguageVersion.CSharp10, source);
+	}
+
+#endif
+
+	[Theory]
+	[MemberData(nameof(TheoryDataMembers), "object")]
+	[MemberData(nameof(TheoryDataMembers), "object[]")]
+	[MemberData(nameof(TheoryDataMembers), "Array")]
+	[MemberData(nameof(TheoryDataMembers), "Array[]")]
+	[MemberData(nameof(TheoryDataMembers), "ValueType")]
+	[MemberData(nameof(TheoryDataMembers), "ValueType[]")]
+	[MemberData(nameof(TheoryDataMembers), "IEnumerable")]
+	[MemberData(nameof(TheoryDataMembers), "IEnumerable[]")]
+	[MemberData(nameof(TheoryDataMembers), "IEnumerable<int>")]
+	[MemberData(nameof(TheoryDataMembers), "IEnumerable<int>[]")]
+	[MemberData(nameof(TheoryDataMembers), "Dictionary<int, string>")]
+	[MemberData(nameof(TheoryDataMembers), "Dictionary<int, string>[]")]
+	[MemberData(nameof(TheoryDataMembers), "IPossiblySerializableInterface")]
+	[MemberData(nameof(TheoryDataMembers), "IPossiblySerializableInterface[]")]
+	[MemberData(nameof(TheoryDataMembers), "PossiblySerializableUnsealedClass")]
+	[MemberData(nameof(TheoryDataMembers), "PossiblySerializableUnsealedClass[]")]
+	public async void GivenTheoryMethod_WithPossiblySerializableTheoryDataMember_FindsWeakDiagnostic(
+		string member,
+		string attribute,
+		string type)
+	{
+		var source = $@"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+public class TestClass {{
+    {member}
+
+    [Theory]
+    [{attribute}]
+    public void TestMethod({type} parameter) {{ }}
+}}
+
+public interface IPossiblySerializableInterface {{ }}
+
+public class PossiblySerializableUnsealedClass {{ }}";
+
+		var expected =
+			Verify
+				.Diagnostic()
+				.WithSpan(11, 6, 11, 6 + attribute.Length)
+				.WithArguments(type, MightNotBeSerializable);
+
+		await Verify.VerifyAnalyzer(source, expected);
+	}
+
+	[Theory]
+	[MemberData(nameof(TheoryDataMembers), "Delegate")]
+	[MemberData(nameof(TheoryDataMembers), "Delegate[]")]
+	[MemberData(nameof(TheoryDataMembers), "Func<int>")]
+	[MemberData(nameof(TheoryDataMembers), "Func<int>[]")]
+	[MemberData(nameof(TheoryDataMembers), "NonSerializableSealedClass")]
+	[MemberData(nameof(TheoryDataMembers), "NonSerializableSealedClass[]")]
+	[MemberData(nameof(TheoryDataMembers), "NonSerializableStruct")]
+	[MemberData(nameof(TheoryDataMembers), "NonSerializableStruct[]")]
+	[MemberData(nameof(TheoryDataMembers), "NonSerializableStruct?")]
+	[MemberData(nameof(TheoryDataMembers), "NonSerializableStruct?[]")]
+	public async void GivenTheoryMethod_WithNonSerializableTheoryDataMember_FindsStrongDiagnostic(
+		string member,
+		string attribute,
+		string type)
+	{
+		var source = $@"
+using System;
+using System.Text;
+using Xunit;
+
+public class TestClass {{
+    {member}
+
+    [Theory]
+    [{attribute}]
+    public void TestMethod({type} parameter) {{ }}
+}}
+
+public sealed class NonSerializableSealedClass {{ }}
+
+public struct NonSerializableStruct {{ }}";
+
+		var expected =
+			Verify
+				.Diagnostic()
+				.WithSpan(10, 6, 10, 6 + attribute.Length)
+				.WithArguments(type, IsNotSerializable);
+
+		await Verify.VerifyAnalyzer(source, expected);
+	}
+
+	[Theory]
+	[MemberData(nameof(TheoryDataClass), "int", "double", "string")]
+	public async void GivenTheoryMethod_WithSerializableTheoryDataClass_DoesNotFindDiagnostic(
+		string source,
+		string _1,
+		string _2,
+		string _3)
+	{
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Theory]
+	[MemberData(nameof(TheoryDataClass), "object[]", "Array", "IDisposable")]
+	public async void GivenTheoryMethod_WithPossiblySerializableTheoryDataClass_FindsWeakDiagnostic(
+		string source,
+		string type1,
+		string type2,
+		string type3)
+	{
+		var expectedForType1 =
+			Verify
+				.Diagnostic()
+				.WithSpan(7, 6, 7, 37)
+				.WithArguments(type1, MightNotBeSerializable);
+
+		var expectedForType2 =
+			Verify
+				.Diagnostic()
+				.WithSpan(7, 6, 7, 37)
+				.WithArguments(type2, MightNotBeSerializable);
+
+		var expectedForType3 =
+			Verify
+				.Diagnostic()
+				.WithSpan(7, 6, 7, 37)
+				.WithArguments(type3, MightNotBeSerializable);
+
+		await Verify.VerifyAnalyzer(
+			source,
+			expectedForType1,
+			expectedForType2,
+			expectedForType3
+		);
+	}
+
+	[Theory]
+	[MemberData(nameof(TheoryDataClass), "Action", "TimeZoneInfo", "TimeZoneInfo.TransitionTime")]
+	public async void GivenTheoryMethod_WithNonSerializableTheoryDataClass_FindsStrongDiagnostic(
+		string source,
+		string type1,
+		string type2,
+		string type3)
+	{
+		var expectedForType1 =
+			Verify
+				.Diagnostic()
+				.WithSpan(7, 6, 7, 37)
+				.WithArguments(type1, IsNotSerializable);
+
+		var expectedForType2 =
+			Verify
+				.Diagnostic()
+				.WithSpan(7, 6, 7, 37)
+				.WithArguments(type2, IsNotSerializable);
+
+		var expectedForType3 =
+			Verify
+				.Diagnostic()
+				.WithSpan(7, 6, 7, 37)
+				.WithArguments(type3, IsNotSerializable);
+
+		await Verify.VerifyAnalyzer(
+			source,
+			expectedForType1,
+			expectedForType2,
+			expectedForType3
+		);
+	}
+}

--- a/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
@@ -402,19 +402,19 @@ public static partial class Descriptors
 			"Constructor '{0}' must be public to be used on a test method."
 		);
 
-	public static DiagnosticDescriptor X1044_TheoryDataTypeArgumentsShouldBeSerializable { get; } =
+	public static DiagnosticDescriptor X1044_AvoidUsingTheoryDataTypeArgumentsThatAreNotSerializable { get; } =
 		Diagnostic(
 			"xUnit1044",
-			"TheoryData type arguments should be serializable",
+			"Avoid using TheoryData type arguments that are not serializable",
 			Usage,
 			Info,
 			"The type argument {0} is not serializable, which will cause Test Explorer to not enumerate individual data rows. Consider using a type that is known to be serializable."
 		);
 
-	public static DiagnosticDescriptor X1045_TheoryDataTypeArgumentsShouldBeDefinitelySerializable { get; } =
+	public static DiagnosticDescriptor X1045_AvoidUsingTheoryDataTypeArgumentsThatMightNotBeSerializable { get; } =
 		Diagnostic(
 			"xUnit1045",
-			"TheoryData type arguments should be definitely serializable",
+			"Avoid using TheoryData type arguments that might not be serializable",
 			Usage,
 			Info,
 			"The type argument {0} might not be serializable, which may cause Test Explorer to not enumerate individual data rows. Consider using a type that is known to be serializable."

--- a/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
@@ -402,7 +402,14 @@ public static partial class Descriptors
 			"Constructor '{0}' must be public to be used on a test method."
 		);
 
-	// Placeholder for rule X1044
+	public static DiagnosticDescriptor X1044_TheoryDataTypeArgumentsShouldBeSerializable { get; } =
+		Diagnostic(
+			"xUnit1044",
+			"TheoryData type arguments should be serializable",
+			Usage,
+			Info,
+			"The type argument {0} {1}. Consider using a type that is known to be serializable."
+		);
 
 	// Placeholder for rule X1045
 

--- a/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
@@ -408,10 +408,17 @@ public static partial class Descriptors
 			"TheoryData type arguments should be serializable",
 			Usage,
 			Info,
-			"The type argument {0} {1}. Consider using a type that is known to be serializable."
+			"The type argument {0} is not serializable, which will cause Test Explorer to not enumerate individual data rows. Consider using a type that is known to be serializable."
 		);
 
-	// Placeholder for rule X1045
+	public static DiagnosticDescriptor X1045_TheoryDataTypeArgumentsShouldBeDefinitelySerializable { get; } =
+		Diagnostic(
+			"xUnit1045",
+			"TheoryData type arguments should be definitely serializable",
+			Usage,
+			Info,
+			"The type argument {0} might not be serializable, which may cause Test Explorer to not enumerate individual data rows. Consider using a type that is known to be serializable."
+		);
 
 	// Placeholder for rule X1046
 

--- a/src/xunit.analyzers/Utility/SymbolExtensions.cs
+++ b/src/xunit.analyzers/Utility/SymbolExtensions.cs
@@ -112,4 +112,17 @@ public static class SymbolExtensions
 				Guard.ArgumentNotNull(attribute).AttributeClass,
 				exactMatch
 			);
+
+	public static ITypeSymbol UnwrapNullable(this ITypeSymbol type)
+	{
+		Guard.ArgumentNotNull(type);
+
+		if (type is not INamedTypeSymbol namedType)
+			return type;
+
+		if (namedType.IsGenericType && namedType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+			return namedType.TypeArguments[0];
+
+		return type;
+	}
 }

--- a/src/xunit.analyzers/Utility/SymbolExtensions.cs
+++ b/src/xunit.analyzers/Utility/SymbolExtensions.cs
@@ -11,7 +11,7 @@ public static class SymbolExtensions
 		this ImmutableArray<AttributeData> attributes,
 		INamedTypeSymbol attributeType,
 		bool exactMatch = false) =>
-			attributes.Any(a => Guard.ArgumentNotNull(attributeType).IsAssignableFrom(a.AttributeClass, exactMatch));
+			attributes.Any(a => a.IsInstanceOf(attributeType, exactMatch));
 
 	/// <summary>
 	/// If the passed <paramref name="typeSymbol"/> is <see cref="IEnumerable{T}"/>, then returns
@@ -103,4 +103,13 @@ public static class SymbolExtensions
 
 		return false;
 	}
+
+	public static bool IsInstanceOf(
+		this AttributeData attribute,
+		INamedTypeSymbol attributeType,
+		bool exactMatch = false) =>
+			Guard.ArgumentNotNull(attributeType).IsAssignableFrom(
+				Guard.ArgumentNotNull(attribute).AttributeClass,
+				exactMatch
+			);
 }

--- a/src/xunit.analyzers/Utility/TypeSymbolFactory.cs
+++ b/src/xunit.analyzers/Utility/TypeSymbolFactory.cs
@@ -174,9 +174,6 @@ public static class TypeSymbolFactory
 	public static INamedTypeSymbol? ITheoryDataRow(Compilation compilation) =>
 		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName("Xunit.ITheoryDataRow");
 
-	public static INamedTypeSymbol? TheoryDataN(Compilation compilation, int n) =>
-		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName("Xunit.TheoryData`" + n.ToString(CultureInfo.InvariantCulture));
-
 	public static INamedTypeSymbol? ITypeInfo_V2(Compilation compilation) =>
 		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName("Xunit.Abstractions.ITypeInfo");
 
@@ -221,6 +218,11 @@ public static class TypeSymbolFactory
 
 	public static INamedTypeSymbol? TheoryAttribute(Compilation compilation) =>
 		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName(Constants.Types.Xunit.TheoryAttribute);
+
+	public static INamedTypeSymbol? TheoryDataN(
+		Compilation compilation,
+		int n) =>
+			Guard.ArgumentNotNull(compilation).GetTypeByMetadataName("Xunit.TheoryData`" + n.ToString(CultureInfo.InvariantCulture));
 
 	static int ValidateArity(
 		int arity,

--- a/src/xunit.analyzers/Utility/TypeSymbolFactory.cs
+++ b/src/xunit.analyzers/Utility/TypeSymbolFactory.cs
@@ -23,6 +23,9 @@ public static class TypeSymbolFactory
 	public static INamedTypeSymbol? Assert(Compilation compilation) =>
 		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName("Xunit.Assert");
 
+	public static INamedTypeSymbol? BigInteger(Compilation compilation) =>
+		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName("System.Numerics.BigInteger");
+
 	public static INamedTypeSymbol? ClassDataAttribute(Compilation compilation) =>
 		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName("Xunit.ClassDataAttribute");
 
@@ -40,6 +43,15 @@ public static class TypeSymbolFactory
 
 	public static INamedTypeSymbol? DataAttribute(Compilation compilation) =>
 		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName(Constants.Types.Xunit.Sdk.DataAttribute);
+
+	public static INamedTypeSymbol? DateOnly(Compilation compilation) =>
+		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName("System.DateOnly");
+
+	public static INamedTypeSymbol? DateTimeOffset(Compilation compilation) =>
+		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName("System.DateTimeOffset");
+
+	public static INamedTypeSymbol? DictionaryofTKeyTValue(Compilation compilation) =>
+		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName("System.Collections.Generic.Dictionary`2");
 
 	public static INamedTypeSymbol? FactAttribute(Compilation compilation) =>
 		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName(Constants.Types.Xunit.FactAttribute);
@@ -180,6 +192,12 @@ public static class TypeSymbolFactory
 	public static INamedTypeSymbol? IXunitSerializable_V2(Compilation compilation) =>
 		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName("Xunit.Abstractions.IXunitSerializable");
 
+	public static INamedTypeSymbol? IXunitSerializable_V3(Compilation compilation) =>
+		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName("Xunit.Sdk.IXunitSerializable");
+
+	public static INamedTypeSymbol? ListOfT(Compilation compilation) =>
+		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName("System.Collections.Generic.List`1");
+
 	public static INamedTypeSymbol? LongLivedMarshalByRefObject_ExecutionV2(Compilation compilation) =>
 		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName(Constants.Types.Xunit.LongLivedMarshalByRefObject);
 
@@ -219,10 +237,22 @@ public static class TypeSymbolFactory
 	public static INamedTypeSymbol? TheoryAttribute(Compilation compilation) =>
 		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName(Constants.Types.Xunit.TheoryAttribute);
 
+	public static INamedTypeSymbol? TheoryData(Compilation compilation) =>
+		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName("Xunit.TheoryData");
+
 	public static INamedTypeSymbol? TheoryDataN(
 		Compilation compilation,
 		int n) =>
 			Guard.ArgumentNotNull(compilation).GetTypeByMetadataName("Xunit.TheoryData`" + n.ToString(CultureInfo.InvariantCulture));
+
+	public static INamedTypeSymbol? TimeOnly(Compilation compilation) =>
+		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName("System.TimeOnly");
+
+	public static INamedTypeSymbol? TimeSpan(Compilation compilation) =>
+		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName("System.TimeSpan");
+
+	public static INamedTypeSymbol? Type(Compilation compilation) =>
+		Guard.ArgumentNotNull(compilation).GetTypeByMetadataName("System.Type");
 
 	static int ValidateArity(
 		int arity,

--- a/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
+++ b/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
@@ -1,0 +1,567 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Xunit.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyzer
+{
+	const string IsNotSerializable = "is not serializable";
+	const string MightNotBeSerializable = "might not be serializable";
+
+	public TheoryDataTypeArgumentsShouldBeSerializable() :
+		base(Descriptors.X1044_TheoryDataTypeArgumentsShouldBeSerializable)
+	{ }
+
+	public override void AnalyzeCompilation(
+		CompilationStartAnalysisContext context,
+		XunitContext xunitContext)
+	{
+		Guard.ArgumentNotNull(context);
+		Guard.ArgumentNotNull(xunitContext);
+
+		if (TypeSymbols.Create(context.Compilation, xunitContext) is not TypeSymbols typeSymbols)
+			return;
+
+		var finder = new TheoryDataTypeArgumentFinder(typeSymbols);
+		var analyzer = new SerializabilityAnalyzer(typeSymbols);
+
+		context.RegisterSyntaxNodeAction(context =>
+		{
+			var semanticModel = context.SemanticModel;
+			var cancellationToken = context.CancellationToken;
+
+			if (context.Node is not MethodDeclarationSyntax methodSyntax)
+				return;
+			if (semanticModel.GetDeclaredSymbol(methodSyntax, cancellationToken) is not IMethodSymbol method)
+				return;
+			if (method.ContainingType is not INamedTypeSymbol testClass)
+				return;
+			if (!method.GetAttributes().ContainsAttributeType(typeSymbols.TheoryAttribute))
+				return;
+
+			var dataAttributes =
+				methodSyntax
+					.AttributeLists
+					.SelectMany(list => list.Attributes)
+					.Zip(method.GetAttributes(), (attributeSyntax, attribute) => (attributeSyntax, attribute))
+					.Where((tuple) => tuple.attribute.IsInstanceOf(typeSymbols.DataAttribute));
+
+			foreach ((var dataAttributeSyntax, var dataAttribute) in dataAttributes)
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+
+				var types = finder.FindTypeArguments(dataAttribute, testClass);
+
+				foreach (var type in types)
+				{
+					if (analyzer.TypeShouldBeIgnored(type))
+						continue;
+
+					var serializability = analyzer.AnalayzeSerializability(type);
+
+					if (serializability != Serializability.AlwaysSerializable)
+						context.ReportDiagnostic(
+							Diagnostic.Create(
+								Descriptors.X1044_TheoryDataTypeArgumentsShouldBeSerializable,
+								dataAttributeSyntax.GetLocation(),
+								type.ToMinimalDisplayString(semanticModel, dataAttributeSyntax.SpanStart),
+								serializability == Serializability.NeverSerializable
+									? IsNotSerializable
+									: MightNotBeSerializable
+							)
+						);
+				}
+			}
+		}, SyntaxKind.MethodDeclaration);
+	}
+
+	enum Serializability
+	{
+		NeverSerializable,
+		PossiblySerializable,
+		AlwaysSerializable
+	}
+
+	sealed class SerializabilityAnalyzer
+	{
+		readonly TypeSymbols typeSymbols;
+
+		public SerializabilityAnalyzer(TypeSymbols typeSymbols) =>
+			this.typeSymbols = typeSymbols;
+
+		/// <summary>
+		/// Analyze the given type to determine whether it is always, possibly, or never serializable.
+		/// </summary>
+		/// <remarks>
+		/// The logic in this method corresponds to the logic in SerializationHelper.IsSerializable
+		/// and SerializationHelper.Serialize.
+		/// </remarks>
+		public Serializability AnalayzeSerializability(ITypeSymbol type)
+		{
+			type = type.UnwrapNullable();
+
+			if (GetTypeKindSerializability(type.TypeKind) == Serializability.NeverSerializable)
+				return Serializability.NeverSerializable;
+
+			if (type.TypeKind == TypeKind.Array && type is IArrayTypeSymbol arrayType)
+				return AnalayzeSerializability(arrayType.ElementType);
+
+			if (typeSymbols.Type.IsAssignableFrom(type))
+				return Serializability.AlwaysSerializable;
+
+			if (type.Equals(typeSymbols.TraitDictionary, SymbolEqualityComparer.Default))
+				return Serializability.AlwaysSerializable;
+
+			if (typeSymbols.IXunitSerializable.IsAssignableFrom(type))
+				return Serializability.AlwaysSerializable;
+
+			if (type.SpecialType != SpecialType.None)
+				return GetSpecialTypeSerializability(type.SpecialType);
+
+			if (type.Equals(typeSymbols.BigInteger, SymbolEqualityComparer.Default)
+				|| type.Equals(typeSymbols.DateTimeOffset, SymbolEqualityComparer.Default)
+				|| type.Equals(typeSymbols.TimeSpan, SymbolEqualityComparer.Default)
+				|| type.Equals(typeSymbols.DateOnly, SymbolEqualityComparer.Default)
+				|| type.Equals(typeSymbols.TimeOnly, SymbolEqualityComparer.Default))
+				return Serializability.AlwaysSerializable;
+
+			if (type.TypeKind == TypeKind.Class && !type.IsSealed)
+				return Serializability.PossiblySerializable;
+
+			if (type.TypeKind == TypeKind.Interface)
+				return Serializability.PossiblySerializable;
+
+			if (type.TypeKind == TypeKind.Enum)
+				return Serializability.PossiblySerializable;
+
+			return Serializability.NeverSerializable;
+		}
+
+		static Serializability GetSpecialTypeSerializability(SpecialType type) =>
+			type switch
+			{
+				SpecialType.System_String
+					or SpecialType.System_Char
+					or SpecialType.System_Byte
+					or SpecialType.System_SByte
+					or SpecialType.System_Int16
+					or SpecialType.System_UInt16
+					or SpecialType.System_Int32
+					or SpecialType.System_UInt32
+					or SpecialType.System_Int64
+					or SpecialType.System_UInt64
+					or SpecialType.System_Single
+					or SpecialType.System_Double
+					or SpecialType.System_Decimal
+					or SpecialType.System_Boolean
+					or SpecialType.System_DateTime => Serializability.AlwaysSerializable,
+
+				SpecialType.None
+					or SpecialType.System_Object
+					or SpecialType.System_Array
+					or SpecialType.System_Enum
+					or SpecialType.System_ValueType
+					or SpecialType.System_Nullable_T
+					or SpecialType.System_Collections_IEnumerable
+					or SpecialType.System_IDisposable => Serializability.PossiblySerializable,
+
+				_ => Serializability.NeverSerializable
+			};
+
+		static Serializability GetTypeKindSerializability(TypeKind kind) =>
+			kind switch
+			{
+				TypeKind.Array
+					or TypeKind.Class
+					or TypeKind.Enum
+					or TypeKind.Interface
+					or TypeKind.Struct => Serializability.PossiblySerializable,
+
+				_ => Serializability.NeverSerializable
+			};
+
+		static bool TypeKindShouldBeIgnored(TypeKind kind) =>
+			kind switch
+			{
+				TypeKind.Unknown
+					or TypeKind.Enum
+					or TypeKind.Error
+					or TypeKind.Module
+					or TypeKind.TypeParameter
+					or TypeKind.Submission => true,
+
+				_ => false
+			};
+
+		/// <summary>
+		/// Determine whether the given type should be ignored when analyzing serializability.
+		/// Types are ignored by type kind (and special type for <see cref="SpecialType.System_Enum"/>).
+		/// Arrays and generic types are ignored if they are composed of ignored types, recursively.
+		/// </summary>
+		/// <remarks>
+		/// Enumerations are serializable if and only if they are from a local assembly and not from
+		/// the Global Assembly Cache. However, static analysis cannot determine whether a type is from
+		/// a local assembly or the GAC, because this requires trying to load the assembly by name
+		/// using reflection, which is banned in analyzers. Therefore, <see cref="TypeKind.Enum"/> and
+		/// <see cref="SpecialType.System_Enum"/> are ignored, in order to prevent a diagnostic from
+		/// being always found for all enumeration types.
+		/// </remarks>
+		public bool TypeShouldBeIgnored(ITypeSymbol type)
+		{
+			if (TypeKindShouldBeIgnored(type.TypeKind) || type.SpecialType == SpecialType.System_Enum)
+				return true;
+
+			if (type is IArrayTypeSymbol arrayType)
+				return TypeShouldBeIgnored(arrayType.ElementType);
+
+			if (type is INamedTypeSymbol namedType && namedType.IsGenericType)
+				return namedType.TypeArguments.Where(TypeShouldBeIgnored).Any();
+
+			return false;
+		}
+	}
+
+	sealed class TheoryDataTypeArgumentFinder
+	{
+		const string MemberType = nameof(MemberType);
+
+		readonly TypeSymbols typeSymbols;
+
+		public TheoryDataTypeArgumentFinder(TypeSymbols typeSymbols) =>
+			this.typeSymbols = typeSymbols;
+
+		/// <summary>
+		/// Find all TheoryData type arguments for a data source referenced by the given data attribute
+		/// in the given test class, if applicable. If the data source's type is not compatible with
+		/// a generic TheoryData class, such as if it is a member with the type <see cref="IEnumerable{T}"/>
+		/// of <see cref="object"/>[], then no type arguments will be found.
+		/// </summary>
+		public IEnumerable<ITypeSymbol> FindTypeArguments(
+			AttributeData dataAttribute,
+			INamedTypeSymbol testClass) =>
+				GetDataSourceType(dataAttribute, testClass) is INamedTypeSymbol type
+					? GetTheoryDataTypeArguments(type)
+					: [];
+
+		static IMethodSymbol? GetCompatibleMethod(
+			ITypeSymbol type,
+			string name,
+			ImmutableArray<TypedConstant> arguments)
+		{
+			foreach (var currentType in GetTypesForMemberResolution(type, includeInterfaces: true))
+			{
+				var methods =
+					currentType
+						.GetMembers(name)
+						.Where(member => member.DeclaredAccessibility == Accessibility.Public)
+						.Select(member => member as IMethodSymbol)
+						.WhereNotNull()
+						.Where(method => ParameterTypesAreCompatible(method.Parameters, arguments))
+						.ToArray();
+
+				if (methods.Length == 0)
+					continue;
+
+				if (methods.Length == 1)
+					return methods[0];
+
+				return methods.Where(method => method.Parameters.Length == arguments.Length).FirstOrDefault();
+			}
+
+			return null;
+		}
+
+		INamedTypeSymbol? GetDataSourceType(
+			AttributeData dataAttribute,
+			INamedTypeSymbol testClass)
+		{
+			if (dataAttribute.IsInstanceOf(typeSymbols.ClassDataAttribute))
+				return dataAttribute.ConstructorArguments.FirstOrDefault().Value as INamedTypeSymbol;
+
+			if (dataAttribute.IsInstanceOf(typeSymbols.MemberDataAttribute))
+				return GetMemberType(dataAttribute, testClass) as INamedTypeSymbol;
+
+			return null;
+		}
+
+		/// <remarks>
+		/// The logic in this method corresponds to the logic in MemberDataAttributeBase.GetFieldAccessor.
+		/// </remarks>
+		static IFieldSymbol? GetField(
+			ITypeSymbol type,
+			string name)
+		{
+			var field = GetPublicMember<IFieldSymbol>(type, name, includeInterfaces: false);
+
+			if (field is not null && field.IsStatic)
+				return field;
+
+			return null;
+		}
+
+		static ITypeSymbol? GetMemberContainingType(AttributeData memberDataAttribute) =>
+			memberDataAttribute
+				.NamedArguments
+				.Where(namedArgument => namedArgument.Key == MemberType)
+				.Select(namedArgument => namedArgument.Value.Type)
+				.WhereNotNull()
+				.FirstOrDefault();
+
+		/// <remarks>
+		/// The logic in this method corresponds to the logic in MemberDataAttributeBase.GetData.
+		/// </remarks>
+		static ITypeSymbol? GetMemberType(
+			AttributeData memberDataAttribute,
+			INamedTypeSymbol testClass)
+		{
+			var name = memberDataAttribute.ConstructorArguments.FirstOrDefault();
+
+			if (name.Value is string memberName)
+			{
+				var containingType = GetMemberContainingType(memberDataAttribute) ?? testClass;
+
+				var member =
+					GetProperty(containingType, memberName)
+						?? GetField(containingType, memberName)
+						?? GetMethod(containingType, memberName, memberDataAttribute) as ISymbol;
+
+				return GetMemberType(member);
+			}
+
+			return null;
+		}
+
+		static ITypeSymbol? GetMemberType(ISymbol? member) =>
+			member switch
+			{
+				IPropertySymbol property => property.Type,
+				IFieldSymbol field => field.Type,
+				IMethodSymbol method when !method.ReturnsVoid => method.ReturnType,
+				_ => null,
+			};
+
+		/// <remarks>
+		/// The logic in this method corresponds to the logic in MemberDataAttributeBase.GetMethodAccessor.
+		/// </remarks>
+		static IMethodSymbol? GetMethod(
+			ITypeSymbol type,
+			string name,
+			AttributeData memberDataAttribute)
+		{
+			var arguments = memberDataAttribute.ConstructorArguments[1].Values;
+			var method = GetCompatibleMethod(type, name, arguments);
+
+			if (method is not null && method.IsStatic)
+				return method;
+
+			return null;
+		}
+
+		/// <remarks>
+		/// The logic in this method corresponds to the logic in MemberDataAttributeBase.GetPropertyAccessor.
+		/// </remarks>
+		static IPropertySymbol? GetProperty(
+			ITypeSymbol type,
+			string name)
+		{
+			var property = GetPublicMember<IPropertySymbol>(type, name, includeInterfaces: true);
+
+			if (property is not null && property.GetMethod is not null && property.GetMethod.IsStatic)
+				return property;
+
+			return null;
+		}
+
+		static TSymbol? GetPublicMember<TSymbol>(
+			ITypeSymbol type,
+			string name,
+			bool includeInterfaces)
+			where TSymbol : class, ISymbol
+		{
+			foreach (var currentType in GetTypesForMemberResolution(type, includeInterfaces))
+			{
+				var member =
+					currentType
+						.GetMembers(name)
+						.Where(member => member.DeclaredAccessibility == Accessibility.Public)
+						.Select(member => member as TSymbol)
+						.WhereNotNull()
+						.FirstOrDefault();
+
+				if (member is not null)
+					return member;
+			}
+
+			return null;
+		}
+
+		IEnumerable<ITypeSymbol> GetTheoryDataTypeArguments(INamedTypeSymbol type)
+		{
+			if (type.TypeKind != TypeKind.Class || type.SpecialType != SpecialType.None)
+				return [];
+
+			if (typeSymbols.TheoryData(arity: 0) is not INamedTypeSymbol baseTheoryDataType)
+				return [];
+
+			for (var currentType = type; currentType is not null; currentType = currentType.BaseType)
+			{
+				if (baseTheoryDataType.Equals(currentType.BaseType, SymbolEqualityComparer.Default))
+				{
+					var theoryDataType = typeSymbols.TheoryData(currentType.Arity);
+					if (currentType.ConstructedFrom.Equals(theoryDataType, SymbolEqualityComparer.Default))
+						return currentType.TypeArguments;
+				}
+			}
+
+			return [];
+		}
+
+		/// <remarks>
+		/// The logic in this method corresponds to the logic in MemberDataAttributeBase.GetTypesForMemberResolution.
+		/// </remarks>
+		static IEnumerable<ITypeSymbol> GetTypesForMemberResolution(
+			ITypeSymbol type,
+			bool includeInterfaces)
+		{
+			for (var currentType = type; currentType is not null; currentType = currentType.BaseType)
+				yield return currentType;
+
+			if (includeInterfaces)
+				foreach (var @interface in type.AllInterfaces)
+					yield return @interface;
+		}
+
+		/// <remarks>
+		/// The logic in this method corresponds to the logic in MemberDataAttributeBase.ParameterTypesCompatible.
+		/// </remarks>
+		static bool ParameterTypesAreCompatible(
+			ImmutableArray<IParameterSymbol> parameters,
+			ImmutableArray<TypedConstant> arguments)
+		{
+			if (parameters.Length < arguments.Length)
+				return false;
+
+			var i = 0;
+			for (; i < arguments.Length; i++)
+				if (arguments[i].Type is ITypeSymbol argumentType && !parameters[i].Type.IsAssignableFrom(argumentType))
+					return false;
+
+			for (; i < parameters.Length; i++)
+				if (!parameters[i].IsOptional)
+					return false;
+
+			return true;
+		}
+	}
+
+	sealed class TypeSymbols
+	{
+		readonly Lazy<INamedTypeSymbol?> bigInteger;
+		readonly Compilation compilation;
+		readonly Lazy<INamedTypeSymbol?> dateOnly;
+		readonly Lazy<INamedTypeSymbol?> dateTimeOffset;
+		readonly Lazy<INamedTypeSymbol?> iXunitSerializable;
+		readonly Dictionary<int, INamedTypeSymbol?> theoryDataTypes;
+		readonly Lazy<INamedTypeSymbol?> timeOnly;
+		readonly Lazy<INamedTypeSymbol?> timeSpan;
+		readonly Lazy<INamedTypeSymbol?> traitDictionary;
+		readonly Lazy<INamedTypeSymbol?> type;
+
+		TypeSymbols(
+			Compilation compilation,
+			XunitContext xunitContext,
+			INamedTypeSymbol classDataAttribute,
+			INamedTypeSymbol dataAttribute,
+			INamedTypeSymbol memberDataAttribute,
+			INamedTypeSymbol theoryAttribute)
+		{
+			this.compilation = compilation;
+
+			bigInteger = new(() => TypeSymbolFactory.BigInteger(compilation));
+			dateOnly = new(() => TypeSymbolFactory.DateOnly(compilation));
+			dateTimeOffset = new(() => TypeSymbolFactory.DateTimeOffset(compilation));
+			iXunitSerializable = new(() =>
+				TypeSymbolFactory.IXunitSerializable_V3(compilation)
+					?? xunitContext.V2Abstractions?.IXunitSerializableType
+			);
+			type = new(() => TypeSymbolFactory.Type(compilation));
+			theoryDataTypes = [];
+			timeOnly = new(() => TypeSymbolFactory.TimeOnly(compilation));
+			timeSpan = new(() => TypeSymbolFactory.TimeSpan(compilation));
+			traitDictionary = new(() => GetTraitDictionary(compilation));
+
+			ClassDataAttribute = classDataAttribute;
+			DataAttribute = dataAttribute;
+			MemberDataAttribute = memberDataAttribute;
+			TheoryAttribute = theoryAttribute;
+		}
+
+		public INamedTypeSymbol? BigInteger => bigInteger.Value;
+		public INamedTypeSymbol ClassDataAttribute { get; }
+		public INamedTypeSymbol DataAttribute { get; }
+		public INamedTypeSymbol? DateOnly => dateOnly.Value;
+		public INamedTypeSymbol? DateTimeOffset => dateTimeOffset.Value;
+		public INamedTypeSymbol? IXunitSerializable => iXunitSerializable.Value;
+		public INamedTypeSymbol MemberDataAttribute { get; }
+		public INamedTypeSymbol TheoryAttribute { get; }
+		public INamedTypeSymbol? TimeOnly => timeOnly.Value;
+		public INamedTypeSymbol? TimeSpan => timeSpan.Value;
+		public INamedTypeSymbol? TraitDictionary => traitDictionary.Value;
+		public INamedTypeSymbol? Type => type.Value;
+
+		public static TypeSymbols? Create(
+			Compilation compilation,
+			XunitContext xunitContext)
+		{
+			if (xunitContext.Core.TheoryAttributeType is not INamedTypeSymbol theoryAttribute)
+				return null;
+			if (xunitContext.Core.DataAttributeType is not INamedTypeSymbol dataAttribute)
+				return null;
+			if (xunitContext.Core.ClassDataAttributeType is not INamedTypeSymbol classDataAttribute)
+				return null;
+			if (xunitContext.Core.MemberDataAttributeType is not INamedTypeSymbol memberDataAttribute)
+				return null;
+
+			return new TypeSymbols(
+				compilation,
+				xunitContext,
+				classDataAttribute,
+				dataAttribute,
+				memberDataAttribute,
+				theoryAttribute);
+		}
+
+		static INamedTypeSymbol? GetTraitDictionary(Compilation compilation)
+		{
+			if (TypeSymbolFactory.DictionaryofTKeyTValue(compilation) is not INamedTypeSymbol dictionaryType)
+				return null;
+
+			if (TypeSymbolFactory.ListOfT(compilation) is not INamedTypeSymbol listType)
+				return null;
+
+			var stringType = compilation.GetSpecialType(SpecialType.System_String);
+			var listOfStringType = listType.Construct(stringType);
+			return dictionaryType.Construct(stringType, listOfStringType);
+		}
+
+		public INamedTypeSymbol? TheoryData(int arity)
+		{
+			if (!theoryDataTypes.ContainsKey(arity))
+			{
+				if (arity == 0)
+					theoryDataTypes[arity] = TypeSymbolFactory.TheoryData(compilation);
+				else
+					theoryDataTypes[arity] = TypeSymbolFactory.TheoryDataN(compilation, arity);
+			}
+
+			return theoryDataTypes[arity];
+		}
+	}
+}

--- a/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
+++ b/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
@@ -45,6 +45,8 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 				return;
 			if (!method.GetAttributes().ContainsAttributeType(typeSymbols.TheoryAttribute))
 				return;
+			if (DiscoveryEnumerationIsDisabled(method, typeSymbols))
+				return;
 
 			var dataAttributes =
 				methodSyntax
@@ -80,6 +82,17 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 			}
 		}, SyntaxKind.MethodDeclaration);
 	}
+
+	static bool AttributeIsTheoryOrDataAttribute(AttributeData attribute, TypeSymbols typeSymbols) =>
+		attribute.IsInstanceOf(typeSymbols.TheoryAttribute) || attribute.IsInstanceOf(typeSymbols.DataAttribute);
+
+	static bool DiscoveryEnumerationIsDisabled(IMethodSymbol method, TypeSymbols typeSymbols) =>
+		method
+			.GetAttributes()
+			.Where(attribute => AttributeIsTheoryOrDataAttribute(attribute, typeSymbols))
+			.SelectMany(attribute => attribute.NamedArguments)
+			.Where(argument => argument.Key == "DisableDiscoveryEnumeration" && argument.Value.Value is true)
+			.Any();
 
 	enum Serializability
 	{

--- a/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
+++ b/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
@@ -14,8 +14,8 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 {
 	public TheoryDataTypeArgumentsShouldBeSerializable() :
 		base(
-			Descriptors.X1044_TheoryDataTypeArgumentsShouldBeSerializable,
-			Descriptors.X1045_TheoryDataTypeArgumentsShouldBeDefinitelySerializable
+			Descriptors.X1044_AvoidUsingTheoryDataTypeArgumentsThatAreNotSerializable,
+			Descriptors.X1045_AvoidUsingTheoryDataTypeArgumentsThatMightNotBeSerializable
 		)
 	{ }
 
@@ -72,8 +72,8 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 						context.ReportDiagnostic(
 							Diagnostic.Create(
 								serializability == Serializability.NeverSerializable
-									? Descriptors.X1044_TheoryDataTypeArgumentsShouldBeSerializable
-									: Descriptors.X1045_TheoryDataTypeArgumentsShouldBeDefinitelySerializable,
+									? Descriptors.X1044_AvoidUsingTheoryDataTypeArgumentsThatAreNotSerializable
+									: Descriptors.X1045_AvoidUsingTheoryDataTypeArgumentsThatMightNotBeSerializable,
 								dataAttributeSyntax.GetLocation(),
 								type.ToMinimalDisplayString(semanticModel, dataAttributeSyntax.SpanStart)
 							)
@@ -546,7 +546,8 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 				classDataAttribute,
 				dataAttribute,
 				memberDataAttribute,
-				theoryAttribute);
+				theoryAttribute
+			);
 		}
 
 		static INamedTypeSymbol? GetTraitDictionary(Compilation compilation)

--- a/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
+++ b/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
@@ -218,11 +218,10 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 		/// Arrays and generic types are ignored if they are composed of ignored types, recursively.
 		/// </summary>
 		/// <remarks>
-		/// Enumerations are serializable if and only if they are from a local assembly and not from
-		/// the Global Assembly Cache. However, static analysis cannot determine whether a type is from
-		/// a local assembly or the GAC, because this requires trying to load the assembly by name
-		/// using reflection, which is banned in analyzers. Therefore, <see cref="TypeKind.Enum"/> and
-		/// <see cref="SpecialType.System_Enum"/> are ignored, in order to prevent a diagnostic from
+		/// Enumerations are serializable if and only if they are not from the Global Assembly Cache,
+		/// which exists in .NET Framework only. However, static analysis cannot reliably determine
+		/// whether a type is from a local assembly or the GAC. Therefore, <see cref="TypeKind.Enum"/>
+		/// and <see cref="SpecialType.System_Enum"/> are ignored, in order to prevent a diagnostic from
 		/// being always found for all enumeration types.
 		/// </remarks>
 		public bool TypeShouldBeIgnored(ITypeSymbol type)

--- a/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
+++ b/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
@@ -281,10 +281,10 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 			AttributeData dataAttribute,
 			INamedTypeSymbol testClass)
 		{
-			if (dataAttribute.IsInstanceOf(typeSymbols.ClassDataAttribute))
+			if (dataAttribute.IsInstanceOf(typeSymbols.ClassDataAttribute, exactMatch: true))
 				return dataAttribute.ConstructorArguments.FirstOrDefault().Value as INamedTypeSymbol;
 
-			if (dataAttribute.IsInstanceOf(typeSymbols.MemberDataAttribute))
+			if (dataAttribute.IsInstanceOf(typeSymbols.MemberDataAttribute, exactMatch: true))
 				return GetMemberType(dataAttribute, testClass) as INamedTypeSymbol;
 
 			return null;

--- a/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
+++ b/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
@@ -12,11 +12,11 @@ namespace Xunit.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyzer
 {
-	const string IsNotSerializable = "is not serializable";
-	const string MightNotBeSerializable = "might not be serializable";
-
 	public TheoryDataTypeArgumentsShouldBeSerializable() :
-		base(Descriptors.X1044_TheoryDataTypeArgumentsShouldBeSerializable)
+		base(
+			Descriptors.X1044_TheoryDataTypeArgumentsShouldBeSerializable,
+			Descriptors.X1045_TheoryDataTypeArgumentsShouldBeDefinitelySerializable
+		)
 	{ }
 
 	public override void AnalyzeCompilation(
@@ -69,12 +69,11 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 					if (serializability != Serializability.AlwaysSerializable)
 						context.ReportDiagnostic(
 							Diagnostic.Create(
-								Descriptors.X1044_TheoryDataTypeArgumentsShouldBeSerializable,
-								dataAttributeSyntax.GetLocation(),
-								type.ToMinimalDisplayString(semanticModel, dataAttributeSyntax.SpanStart),
 								serializability == Serializability.NeverSerializable
-									? IsNotSerializable
-									: MightNotBeSerializable
+									? Descriptors.X1044_TheoryDataTypeArgumentsShouldBeSerializable
+									: Descriptors.X1045_TheoryDataTypeArgumentsShouldBeDefinitelySerializable,
+								dataAttributeSyntax.GetLocation(),
+								type.ToMinimalDisplayString(semanticModel, dataAttributeSyntax.SpanStart)
 							)
 						);
 				}


### PR DESCRIPTION
Suggested initial version of a solution for issue [xunit/xunit#2866](https://github.com/xunit/xunit/issues/2866).

Includes analyzer for proposed new rule xUnit1044: TheoryData type arguments should be serializable.

Please let me know if you have any feedback.

# Solution

## `Serializability` enumeration

- `NeverSerializable`
- `PossiblySerializable`
- `AlwaysSerializable`

## `TheoryDataTypeArgumentFinder` class

- Finds all `TheoryData<>` type arguments for a data source referenced by a given `[ClassData]` or `[MemberData]` attribute in a given test class, if applicable
- If the data source's type is not compatible with a `TheoryData<>` class (such as if it is a member with the type `IEnumerable<object[]>`), then no type arguments will be found
- If the data source's type derives from a `TheoryData<>` base class, then the type arguments for the base class will be found 

## `SerializabilityAnalyzer` class

- Analyzes a given type to determine whether it is always, possibly, or never serializable
- The static analysis of a type's serializability closely corresponds to the logic found in `SerializationHelper` and `MemberDataAttributeBase` from the `xunit` repository
- See discussion in issue [xunit/xunit#2866](https://github.com/xunit/xunit/issues/2866)

## `TypeSymbols` class

- Lazy caching wrapper around `TypeSymbolFactory` (plus the `Compilation` and `XunitContext`), for reusing already generated type symbols

## `TheoryDataTypeArgumentsShouldBeSerializable` analyzer

- Analyzes `MethodDeclarationSyntax` nodes with a `[Theory]` attribute
- For each `[ClassData]` or `[MemberData]` attribute: Uses `TheoryDataTypeArgumentFinder` to find all `TheoryData<>` type arguments for the referenced class or member, if applicable
- For each type argument found: Uses `SerializabilityAnalyzer` to check whether the type is serializable (unless the type should be ignored)
- For each never serializable type argument: Reports an xUnit1044 diagnostic for the data attribute syntax node, with a strongly phrased message: `The type argument {0} is not serializable. Consider using a type that is known to be serializable.`
- For each possibly serializable type argument: Reports an xUnit1044 diagnostic for the data attribute syntax node, with a weakly phrased message: `The type argument {0} might not be serializable. Consider using a type that is known to be serializable.`

# Key points

## Diagnostic severity

- The diagnostic currently has `Info` severity. Would `Warning` be more appropriate?
- Currently, using `Warning` would break the build because an existing test class, `SetEqualityAnalyzerTests`, uses a tuple type argument for a `MatrixTheoryData` data source, and warnings are treated as errors
- A solution would be to skip analyzing data sources associated with `DisableDiscoveryEnumeration = true`, but that has not been implemented yet (see discussion in issue [xunit/xunit#2866](https://github.com/xunit/xunit/issues/2866))

## Statically analyzing serializability of enumerations

- See discussion in issue [xunit/xunit#2866](https://github.com/xunit/xunit/issues/2866)
- Any given enumeration type is either always serializable (from a local assembly) or never serializable (from the GAC)
- As far as I can tell, static analysis cannot determine whether an enumeration type is from a local assembly or from the GAC
- As a result, all enumeration types are treated as possibly serializable
- However, the analyzer ignores them, in order to prevent a diagnostic from being found for every single enumeration type

## IXunitSerializable type symbol

- `IXunitSerializable` is in namespace `Xunit.Abstractions` in xUnit version 2, but in `Xunit.Sdk` in version 3
- The version 2 type symbol is accessible via a lazy cache in `xunitContext.V2Abstractions?.IXunitSerializableType` (as well as directly via `TypeSymbolFactory`)
- There does not seem to be any corresponding property in any of the version 3 contexts. Would it make sense to add one somewhere in the contexts? Ideally there would be a common interface, implemented for each version, that provided the type symbol for the current version
- I added the `TypeSymbolFactory.IXunitSerializable_V3` factory method for the version 3 type symbol
- My `TypeSymbols` class currently uses the following logic to access the appropriate type symbol: `TypeSymbolFactory.IXunitSerializable_V3(compilation) ?? xunitContext.V2Abstractions?.IXunitSerializableType`