### PR TITLE
Create analyzer/fixer for Assert.Empty

### DIFF
--- a/src/xunit.analyzers.fixes/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Text;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis;
+using Xunit.Analyzers.Fixes;
+using System.Threading.Tasks;
+using Xunit.Analyzers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+internal class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck : BatchedCodeFixProvider
+{
+	public const string Key_UseAlternateAssert = "xUnit2017_UseAlternateAssert";
+
+	public AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck() :
+		base(Descriptors.X2029_AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.Id)
+	{ }
+
+	public override Task RegisterCodeFixesAsync(CodeFixContext context)
+	{
+		throw new NotImplementedException();
+	}
+}

--- a/src/xunit.analyzers.fixes/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
@@ -7,6 +7,13 @@ using Microsoft.CodeAnalysis;
 using Xunit.Analyzers.Fixes;
 using System.Threading.Tasks;
 using Xunit.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CodeActions;
+using System.Threading;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Operations;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -21,7 +28,58 @@ public class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckFixer : B
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{
-		await Task.Yield();
-		return;
+		var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+		if (root is null)
+			return;
+
+		var invocation = root.FindNode(context.Span).FirstAncestorOrSelf<InvocationExpressionSyntax>();
+		if (invocation is null)
+			return;
+
+		context.RegisterCodeFix(
+			XunitCodeAction.Create(c => UseCheck(context.Document, invocation, c),
+			Key_UseAlternateAssert,
+			"Use DoesNotContain"
+			),
+			context.Diagnostics
+		);
+	}
+
+	static async Task<Document> UseCheck(
+		Document document,
+		InvocationExpressionSyntax invocation,
+		CancellationToken cancellationToken)
+	{
+		var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+		var arguments = invocation.ArgumentList.Arguments;
+		if (arguments.Count == 1 && arguments[0].Expression is InvocationExpressionSyntax innerInvocationSyntax)
+		{
+			if (invocation.Expression is MemberAccessExpressionSyntax outerMemberAccess && innerInvocationSyntax.Expression is MemberAccessExpressionSyntax memberAccess)
+			{
+				if (innerInvocationSyntax.ArgumentList.Arguments[0].Expression is ExpressionSyntax innerArgument)
+				{
+					editor.ReplaceNode(invocation,
+						invocation
+						.WithArgumentList(
+							ArgumentList(
+								SeparatedList(new[] {
+											Argument(memberAccess.Expression),
+											Argument(innerArgument) }
+								)
+							)
+						)
+						.WithExpression(
+							outerMemberAccess.WithName(
+								IdentifierName(Constants.Asserts.DoesNotContain)
+							)
+						)
+					);
+
+				}
+			}
+		}
+
+		return editor.GetChangedDocument();
 	}
 }

--- a/src/xunit.analyzers.fixes/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
@@ -8,6 +8,8 @@ using Xunit.Analyzers.Fixes;
 using System.Threading.Tasks;
 using Xunit.Analyzers;
 
+namespace Xunit.Analyzers.Fixes;
+
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 internal class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck : BatchedCodeFixProvider
 {

--- a/src/xunit.analyzers.fixes/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
@@ -11,16 +11,17 @@ using Xunit.Analyzers;
 namespace Xunit.Analyzers.Fixes;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
-public class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck : BatchedCodeFixProvider
+public class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckFixer : BatchedCodeFixProvider
 {
 	public const string Key_UseAlternateAssert = "xUnit2017_UseAlternateAssert";
 
-	public AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck() :
+	public AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckFixer() :
 		base(Descriptors.X2029_AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.Id)
 	{ }
 
-	public override Task RegisterCodeFixesAsync(CodeFixContext context)
+	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{
-		throw new NotImplementedException();
+		await Task.Yield();
+		return;
 	}
 }

--- a/src/xunit.analyzers.fixes/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
@@ -1,19 +1,12 @@
-using System;
-using System.Collections.Generic;
 using System.Composition;
-using System.Text;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis;
-using Xunit.Analyzers.Fixes;
 using System.Threading.Tasks;
-using Xunit.Analyzers;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CodeActions;
 using System.Threading;
 using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Operations;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
-using Microsoft.CodeAnalysis.CSharp;
 
 namespace Xunit.Analyzers.Fixes;
 

--- a/src/xunit.analyzers.fixes/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
@@ -11,7 +11,7 @@ using Xunit.Analyzers;
 namespace Xunit.Analyzers.Fixes;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
-internal class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck : BatchedCodeFixProvider
+public class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck : BatchedCodeFixProvider
 {
 	public const string Key_UseAlternateAssert = "xUnit2017_UseAlternateAssert";
 

--- a/src/xunit.analyzers.fixes/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckFixer.cs
@@ -1,10 +1,10 @@
 using System.Composition;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CodeActions;
 using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
@@ -13,7 +13,7 @@ namespace Xunit.Analyzers.Fixes;
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckFixer : BatchedCodeFixProvider
 {
-	public const string Key_UseAlternateAssert = "xUnit2017_UseAlternateAssert";
+	public const string Key_UseAlternateAssert = "xUnit2029_UseAlternateAssert";
 
 	public AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckFixer() :
 		base(Descriptors.X2029_AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.Id)
@@ -30,9 +30,10 @@ public class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckFixer : B
 			return;
 
 		context.RegisterCodeFix(
-			XunitCodeAction.Create(c => UseCheck(context.Document, invocation, c),
-			Key_UseAlternateAssert,
-			"Use DoesNotContain"
+			XunitCodeAction.Create(
+				c => UseCheck(context.Document, invocation, c),
+				Key_UseAlternateAssert,
+				"Use DoesNotContain"
 			),
 			context.Diagnostics
 		);
@@ -47,31 +48,14 @@ public class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckFixer : B
 
 		var arguments = invocation.ArgumentList.Arguments;
 		if (arguments.Count == 1 && arguments[0].Expression is InvocationExpressionSyntax innerInvocationSyntax)
-		{
 			if (invocation.Expression is MemberAccessExpressionSyntax outerMemberAccess && innerInvocationSyntax.Expression is MemberAccessExpressionSyntax memberAccess)
-			{
 				if (innerInvocationSyntax.ArgumentList.Arguments[0].Expression is ExpressionSyntax innerArgument)
-				{
-					editor.ReplaceNode(invocation,
+					editor.ReplaceNode(
+						invocation,
 						invocation
-						.WithArgumentList(
-							ArgumentList(
-								SeparatedList(new[] {
-											Argument(memberAccess.Expression),
-											Argument(innerArgument) }
-								)
-							)
-						)
-						.WithExpression(
-							outerMemberAccess.WithName(
-								IdentifierName(Constants.Asserts.DoesNotContain)
-							)
-						)
+							.WithArgumentList(ArgumentList(SeparatedList([Argument(memberAccess.Expression), Argument(innerArgument)])))
+							.WithExpression(outerMemberAccess.WithName(IdentifierName(Constants.Asserts.DoesNotContain)))
 					);
-
-				}
-			}
-		}
 
 		return editor.GetChangedDocument();
 	}

--- a/src/xunit.analyzers.tests/Analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckTests.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using Verify = CSharpVerifier<Xunit.Analyzers.AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck>;
 

--- a/src/xunit.analyzers.tests/Analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckTests.cs
@@ -3,8 +3,146 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Verify = CSharpVerifier<Xunit.Analyzers.AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck>
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Verify = CSharpVerifier<Xunit.Analyzers.AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck>;
 
-internal class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckTests
+
+
+public class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckTests
 {
+	public static TheoryData<string> GetEnumerables(string typeName)
+	{
+		return new TheoryData<string>()
+		{
+			$"new System.Collections.Generic.List<{typeName}>()",
+			$"new System.Collections.Generic.HashSet<{typeName}>()",
+			$"new System.Collections.ObjectModel.Collection<{typeName}>()",
+			$"new {typeName}[0]",
+			$"System.Linq.Enumerable.Empty<{typeName}>()"
+		};
+	}
+
+	public static TheoryData<string> GetSampleStrings()
+	{
+		return new TheoryData<string>()
+		{
+			String.Empty,
+			"123",
+			"abc\n\t\\\""
+		};
+	}
+
+	[Theory]
+	[MemberData(nameof(GetEnumerables), "int")]
+	public async Task FindsWarningForIntEnumerableDoesNotContainCheckWithEmpty(string collection)
+	{
+		var source = $@"
+using System.Linq;
+class TestClass
+{{
+    void TestMethod()
+    {{
+        [|Xunit.Assert.Empty({collection}.Where(f => f > 0))|];
+    }}
+}}";
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Theory]
+	[MemberData(nameof(GetEnumerables), "string")]
+	public async Task FindsWarningForStringEnumerableDoesNotContainCheckWithEmpty(string collection)
+	{
+		var source = $@"
+using System.Linq;
+class TestClass
+{{
+    void TestMethod()
+    {{
+        [|Xunit.Assert.Empty({collection}.Where(f => f.Length > 0))|];
+    }}
+}}";
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Theory]
+	[MemberData(nameof(GetSampleStrings))]
+	public async Task FindsWarningForStringDoesNotContainCheckWithEmpty(string sampleString)
+	{
+		var source = $@"
+using System.Linq;
+class TestClass
+{{
+    void TestMethod()
+    {{
+        [|Xunit.Assert.Empty({sampleString}.Where(f => f > 0))|];
+    }}
+}}";
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Theory]
+	[MemberData(nameof(GetEnumerables), "int")]
+	public async Task DoesNotFindWarningForIntEnumerableDoesNotContainCheckWithEmptyWithIndex(string collection)
+	{
+		var source = $@"
+using System.Linq;
+class TestClass
+{{
+    void TestMethod()
+    {{
+        Xunit.Assert.Empty({collection}.Where((f, i) => f > 0 && i > 0));
+    }}
+}}";
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Theory]
+	[MemberData(nameof(GetEnumerables), "string")]
+	public async Task DoesNotFindWarningForStringEnumerableDoesNotContainCheckWithEmptyWithIndex(string collection)
+	{
+		var source = $@"
+using System.Linq;
+class TestClass
+{{
+    void TestMethod()
+    {{
+        Xunit.Assert.Empty({collection}.Where((f, i) => f.Length > 0 && i > 0));
+    }}
+}}";
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Theory]
+	[MemberData(nameof(GetEnumerables), "int")]
+	[MemberData(nameof(GetEnumerables), "string")]
+	public async Task DoesNotFindWarningForEnumerableEmptyCheckWithoutLinq(string collection)
+	{
+		var source = $@"
+class TestClass
+{{
+    void TestMethod()
+    {{
+        Xunit.Assert.Empty({collection});
+    }}
+}}";
+		await Verify.VerifyAnalyzer(source);
+	}
+
+    [Theory]
+    [MemberData(nameof(GetEnumerables), "int")]
+    [MemberData(nameof(GetEnumerables), "string")]
+    public async Task DoesNotFindWarningForEnumurableEmptyCheckWithChainedLinq(string collection)
+    {
+        var source = $@"
+using System.Linq;
+class TestClass
+{{
+    void TestMethod()
+    {{
+        Xunit.Assert.Empty({collection}.Where(f => f.ToString().Length > 0).Select(f => f));
+    }}
+}}";
+        await Verify.VerifyAnalyzer(source);
+    }
 }

--- a/src/xunit.analyzers.tests/Analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckTests.cs
@@ -29,7 +29,7 @@ public class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckTests
 		{
 			String.Empty,
 			"123",
-			"abc\n\t\\\""
+			@"abc\n\t\\\"""
 		};
 	}
 
@@ -75,7 +75,7 @@ class TestClass
 {{
     void TestMethod()
     {{
-        [|Xunit.Assert.Empty({sampleString}.Where(f => f > 0))|];
+        [|Xunit.Assert.Empty(""{sampleString}"".Where(f => f > 0))|];
     }}
 }}";
 		await Verify.VerifyAnalyzer(source);

--- a/src/xunit.analyzers.tests/Analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckTests.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verify = CSharpVerifier<Xunit.Analyzers.AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck>
+
+internal class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckTests
+{
+}

--- a/src/xunit.analyzers.tests/Analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckTests.cs
@@ -1,118 +1,27 @@
-using System;
 using System.Threading.Tasks;
 using Xunit;
 using Verify = CSharpVerifier<Xunit.Analyzers.AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck>;
 
-
-
 public class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckTests
 {
-	public static TheoryData<string> GetEnumerables(string typeName)
-	{
-		return new TheoryData<string>()
-		{
-			$"new System.Collections.Generic.List<{typeName}>()",
-			$"new System.Collections.Generic.HashSet<{typeName}>()",
-			$"new System.Collections.ObjectModel.Collection<{typeName}>()",
-			$"new {typeName}[0]",
-			$"System.Linq.Enumerable.Empty<{typeName}>()"
-		};
-	}
-
-	public static TheoryData<string> GetSampleStrings()
-	{
-		return new TheoryData<string>()
-		{
-			String.Empty,
-			"123",
-			@"abc\n\t\\\"""
-		};
-	}
+	public static TheoryData<string, string> GetEnumerables(
+		string typeName,
+		string comparison) =>
+			new()
+			{
+				{ $"new System.Collections.Generic.List<{typeName}>()", comparison },
+				{ $"new System.Collections.Generic.HashSet<{typeName}>()", comparison },
+				{ $"new System.Collections.ObjectModel.Collection<{typeName}>()", comparison },
+				{ $"new {typeName}[0]", comparison },
+				{ $"System.Linq.Enumerable.Empty<{typeName}>()", comparison },
+			};
 
 	[Theory]
-	[MemberData(nameof(GetEnumerables), "int")]
-	public async Task FindsWarningForIntEnumerableDoesNotContainCheckWithEmpty(string collection)
-	{
-		var source = $@"
-using System.Linq;
-class TestClass
-{{
-    void TestMethod()
-    {{
-        [|Xunit.Assert.Empty({collection}.Where(f => f > 0))|];
-    }}
-}}";
-		await Verify.VerifyAnalyzer(source);
-	}
-
-	[Theory]
-	[MemberData(nameof(GetEnumerables), "string")]
-	public async Task FindsWarningForStringEnumerableDoesNotContainCheckWithEmpty(string collection)
-	{
-		var source = $@"
-using System.Linq;
-class TestClass
-{{
-    void TestMethod()
-    {{
-        [|Xunit.Assert.Empty({collection}.Where(f => f.Length > 0))|];
-    }}
-}}";
-		await Verify.VerifyAnalyzer(source);
-	}
-
-	[Theory]
-	[MemberData(nameof(GetSampleStrings))]
-	public async Task FindsWarningForStringDoesNotContainCheckWithEmpty(string sampleString)
-	{
-		var source = $@"
-using System.Linq;
-class TestClass
-{{
-    void TestMethod()
-    {{
-        [|Xunit.Assert.Empty(""{sampleString}"".Where(f => f > 0))|];
-    }}
-}}";
-		await Verify.VerifyAnalyzer(source);
-	}
-
-	[Theory]
-	[MemberData(nameof(GetEnumerables), "int")]
-	public async Task DoesNotFindWarningForIntEnumerableDoesNotContainCheckWithEmptyWithIndex(string collection)
-	{
-		var source = $@"
-using System.Linq;
-class TestClass
-{{
-    void TestMethod()
-    {{
-        Xunit.Assert.Empty({collection}.Where((f, i) => f > 0 && i > 0));
-    }}
-}}";
-		await Verify.VerifyAnalyzer(source);
-	}
-
-	[Theory]
-	[MemberData(nameof(GetEnumerables), "string")]
-	public async Task DoesNotFindWarningForStringEnumerableDoesNotContainCheckWithEmptyWithIndex(string collection)
-	{
-		var source = $@"
-using System.Linq;
-class TestClass
-{{
-    void TestMethod()
-    {{
-        Xunit.Assert.Empty({collection}.Where((f, i) => f.Length > 0 && i > 0));
-    }}
-}}";
-		await Verify.VerifyAnalyzer(source);
-	}
-
-	[Theory]
-	[MemberData(nameof(GetEnumerables), "int")]
-	[MemberData(nameof(GetEnumerables), "string")]
-	public async Task DoesNotFindWarningForEnumerableEmptyCheckWithoutLinq(string collection)
+	[MemberData(nameof(GetEnumerables), "int", "")]
+	[MemberData(nameof(GetEnumerables), "string", "")]
+	public async Task Containers_WithoutWhereClause_DoesNotTrigger(
+		string collection,
+		string _)
 	{
 		var source = $@"
 class TestClass
@@ -125,20 +34,80 @@ class TestClass
 		await Verify.VerifyAnalyzer(source);
 	}
 
-    [Theory]
-    [MemberData(nameof(GetEnumerables), "int")]
-    [MemberData(nameof(GetEnumerables), "string")]
-    public async Task DoesNotFindWarningForEnumurableEmptyCheckWithChainedLinq(string collection)
-    {
-        var source = $@"
+	[Theory]
+	[MemberData(nameof(GetEnumerables), "int", "f > 0")]
+	[MemberData(nameof(GetEnumerables), "string", "f.Length > 0")]
+	public async Task Containers_WithWhereClause_Triggers(
+		string collection,
+		string comparison)
+	{
+		var source = $@"
 using System.Linq;
 class TestClass
 {{
     void TestMethod()
     {{
-        Xunit.Assert.Empty({collection}.Where(f => f.ToString().Length > 0).Select(f => f));
+        [|Xunit.Assert.Empty({collection}.Where(f => {comparison}))|];
     }}
 }}";
-        await Verify.VerifyAnalyzer(source);
-    }
+
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Theory]
+	[MemberData(nameof(GetEnumerables), "int", "f > 0")]
+	[MemberData(nameof(GetEnumerables), "string", "f.Length > 0")]
+	public async Task Containers_WithWhereClauseWithIndex_DoesNotTrigger(
+		string collection,
+		string comparison)
+	{
+		var source = $@"
+using System.Linq;
+class TestClass
+{{
+    void TestMethod()
+    {{
+        Xunit.Assert.Empty({collection}.Where((f, i) => {comparison} && i > 0));
+    }}
+}}";
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Theory]
+	[MemberData(nameof(GetEnumerables), "int", "f > 0")]
+	[MemberData(nameof(GetEnumerables), "string", "f.Length > 0")]
+	public async Task DoesNotFindWarningForEnumurableEmptyCheckWithChainedLinq(
+		string collection,
+		string comparison)
+	{
+		var source = $@"
+using System.Linq;
+class TestClass
+{{
+    void TestMethod()
+    {{
+        Xunit.Assert.Empty({collection}.Where(f => {comparison}).Select(f => f));
+    }}
+}}";
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	public static TheoryData<string> GetSampleStrings() =>
+		new(string.Empty, "123", @"abc\n\t\\\""");
+
+	[Theory]
+	[MemberData(nameof(GetSampleStrings))]
+	public async Task Strings_WithWhereClause_DoesNotTrigger(string sampleString)
+	{
+		var source = $@"
+using System.Linq;
+class TestClass
+{{
+    void TestMethod()
+    {{
+        [|Xunit.Assert.Empty(""{sampleString}"".Where(f => f > 0))|];
+    }}
+}}";
+		await Verify.VerifyAnalyzer(source);
+	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckFixerTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Analyzers.Fixes;
+using Verify = CSharpVerifier<Xunit.Analyzers.AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck>;
+
+public class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckFixerTests
+{
+	const string template = @"
+using System.Linq;
+using Xunit;
+
+public class TestClass {{
+    [Fact]
+    public void TestMethod() {{
+        var list = new[] {{ -1, 0, 1, 2 }};
+
+        {0};
+    }}
+
+	public bool IsEven(int num) => num % 2 == 0;
+}}";
+
+	[Theory]
+	[InlineData("[|Assert.Empty(list.Where(f => f > 0))|]", "Assert.DoesNotContain(list, f => f > 0)")]
+	[InlineData("[|Assert.Empty(list.Where(n => n == 1))|]", "Assert.DoesNotContain(list, n => n == 1)")]
+	[InlineData("[|Assert.Empty(list.Where(IsEven))|]", "Assert.DoesNotContain(list, IsEven)")]
+	public async Task FixerReplacesAssertEmptyWithAssertDoesNotContain(
+		string beforeAssert,
+		string afterAssert)
+	{
+		var before = string.Format(template, beforeAssert);
+		var after = string.Format(template, afterAssert);
+
+		await Verify.VerifyCodeFix(before, after, AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckFixer.Key_UseAlternateAssert);
+	}
+}

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheckFixerTests.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Analyzers.Fixes;

--- a/src/xunit.analyzers/Utility/Descriptors.xUnit2xxx.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.xUnit2xxx.cs
@@ -266,7 +266,7 @@ public static partial class Descriptors
 			"Do not use Empty() to check if a value does not exist in a collection",
 			Assertions,
 			Warning,
-			"Do not use Assert.Empty() to check if a valude does not exist in a collection. Use Assert.DoesNotContain() instead."
+			"Do not use Assert.Empty() to check if a value does not exist in a collection. Use Assert.DoesNotContain() instead."
 		);
 
 	// Placeholder for rule X2030

--- a/src/xunit.analyzers/Utility/Descriptors.xUnit2xxx.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.xUnit2xxx.cs
@@ -260,7 +260,13 @@ public static partial class Descriptors
 			"Using Assert.{0} with an instance of {1} is problematic, because {2}. Check the length with .Count instead."
 		);
 
-	// Placeholder for rule X2029
+	public static DiagnosticDescriptor X2029_AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck { get; } =
+		Diagnostic(
+			"xUnit2029",
+			"Do not use Empty() to check if a value does not exist in a collection",
+			Assertions,
+			Warning,
+			"Do not use Assert.Empty() to check if a valude does not exist in a collection. Use Assert.DoesNotContain() instead.")
 
 	// Placeholder for rule X2030
 

--- a/src/xunit.analyzers/Utility/Descriptors.xUnit2xxx.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.xUnit2xxx.cs
@@ -266,7 +266,8 @@ public static partial class Descriptors
 			"Do not use Empty() to check if a value does not exist in a collection",
 			Assertions,
 			Warning,
-			"Do not use Assert.Empty() to check if a valude does not exist in a collection. Use Assert.DoesNotContain() instead.")
+			"Do not use Assert.Empty() to check if a valude does not exist in a collection. Use Assert.DoesNotContain() instead."
+		);
 
 	// Placeholder for rule X2030
 

--- a/src/xunit.analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
+++ b/src/xunit.analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis;
-using Xunit.Analyzers;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.CSharp;
-using System.Collections.Immutable;
 
 namespace Xunit.Analyzers;
 

--- a/src/xunit.analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
+++ b/src/xunit.analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis;
 using Xunit.Analyzers;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.CSharp;
+using System.Collections.Immutable;
 
 namespace Xunit.Analyzers;
 

--- a/src/xunit.analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
+++ b/src/xunit.analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis;
+using Xunit.Analyzers;
+using Microsoft.CodeAnalysis.Operations;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck : AssertUsageAnalyzerBase
+{
+	static readonly string[] targetMethods =
+	{
+		Constants.Asserts.Empty,
+	};
+
+	public AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck()
+		: base(Descriptors.X2029_AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck, targetMethods)
+	{ }
+
+	protected override void AnalyzeInvocation(
+		OperationAnalysisContext context, 
+		XunitContext xunitContext, 
+		IInvocationOperation invocationOperation, 
+		IMethodSymbol method)
+	{
+		throw new NotImplementedException();
+	}
+}

--- a/src/xunit.analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
+++ b/src/xunit.analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
@@ -6,6 +6,8 @@ using Microsoft.CodeAnalysis;
 using Xunit.Analyzers;
 using Microsoft.CodeAnalysis.Operations;
 
+namespace Xunit.Analyzers;
+
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck : AssertUsageAnalyzerBase
 {

--- a/src/xunit.analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
+++ b/src/xunit.analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
@@ -26,6 +26,6 @@ public class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck : Assert
 		IInvocationOperation invocationOperation, 
 		IMethodSymbol method)
 	{
-		throw new NotImplementedException();
+		return;
 	}
 }

--- a/src/xunit.analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
+++ b/src/xunit.analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
@@ -5,12 +5,15 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Xunit.Analyzers;
 using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Xunit.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck : AssertUsageAnalyzerBase
 {
+	const string linqWhereMethod = "System.Linq.Enumerable.Where<TSource>(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource, bool>)";
+
 	static readonly string[] targetMethods =
 	{
 		Constants.Asserts.Empty,
@@ -26,6 +29,38 @@ public class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck : Assert
 		IInvocationOperation invocationOperation, 
 		IMethodSymbol method)
 	{
-		return;
+		Guard.ArgumentNotNull(xunitContext);
+		Guard.ArgumentNotNull(invocationOperation);
+		Guard.ArgumentNotNull(method);
+
+		var arguments = invocationOperation.Arguments;
+		if (arguments.Length != 1)
+			return;
+
+		var argument = arguments[0];
+		var value = argument.Value;
+		if (value is IConversionOperation conversion)
+			value = conversion.Operand;
+
+		if (value is not IInvocationOperation innerInvocation)
+			return;
+
+		var originalMethod = SymbolDisplay.ToDisplayString(innerInvocation.TargetMethod.OriginalDefinition);
+		if (originalMethod != linqWhereMethod)
+			return;
+
+		context.ReportDiagnostic(
+			Diagnostic.Create(
+				Descriptors.X2029_AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck,
+				invocationOperation.Syntax.GetLocation(),
+				SymbolDisplay.ToDisplayString(
+					method,
+					SymbolDisplayFormat
+						.CSharpShortErrorMessageFormat
+						.WithParameterOptions(SymbolDisplayParameterOptions.None)
+						.WithGenericsOptions(SymbolDisplayGenericsOptions.None)
+				)
+			)
+		);
 	}
 }

--- a/src/xunit.analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
+++ b/src/xunit.analyzers/X2000/AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck.cs
@@ -1,7 +1,7 @@
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Xunit.Analyzers;
 
@@ -20,9 +20,9 @@ public class AssertEmptyShouldNotBeUsedForCollectionDoesNotContainCheck : Assert
 	{ }
 
 	protected override void AnalyzeInvocation(
-		OperationAnalysisContext context, 
-		XunitContext xunitContext, 
-		IInvocationOperation invocationOperation, 
+		OperationAnalysisContext context,
+		XunitContext xunitContext,
+		IInvocationOperation invocationOperation,
 		IMethodSymbol method)
 	{
 		Guard.ArgumentNotNull(xunitContext);


### PR DESCRIPTION
A solution to issue xunit/xunit#1510, specifically the following part:

> Optionally could do the same thing with Assert.Empty(...) and Assert.NotEmpty(...), mapping them to Assert.DoesNotContain(...) and Assert.Contains(...), respectively.

The analyzer and fixer apply to the following situations:
`Assert.Empty(Enumerable.Where(expression))`
and suggest them to change to:
`Assert.DoesNotContain(Enumerable, expression)`

@bradwilson hope to get feedback on it, if there's anything wrong with this