### PR TITLE
Create Analyzer/Fixer for Assert.Single

### DIFF
--- a/src/xunit.analyzers.fixes/X2000/AssertSingleShouldUseTwoArgumentCallFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertSingleShouldUseTwoArgumentCallFixer.cs
@@ -1,11 +1,11 @@
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis;
 using System.Composition;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
-using System.Threading;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;

--- a/src/xunit.analyzers.fixes/X2000/AssertSingleShouldUseTwoArgumentCallFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertSingleShouldUseTwoArgumentCallFixer.cs
@@ -1,0 +1,19 @@
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis;
+using System.Composition;
+using System.Threading.Tasks;
+
+namespace Xunit.Analyzers.Fixes;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public class AssertSingleShouldUseTwoArgumentCallFixer : BatchedCodeFixProvider
+{
+	public AssertSingleShouldUseTwoArgumentCallFixer() :
+		base(Descriptors.X2031_AssertSingleShouldUseTwoArgumentCall.Id)
+	{ }
+
+	public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+	{
+		return Task.CompletedTask;
+	}
+}

--- a/src/xunit.analyzers.fixes/X2000/AssertSingleShouldUseTwoArgumentCallFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertSingleShouldUseTwoArgumentCallFixer.cs
@@ -8,6 +8,8 @@ namespace Xunit.Analyzers.Fixes;
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class AssertSingleShouldUseTwoArgumentCallFixer : BatchedCodeFixProvider
 {
+	public const string Key_UseTwoArguments = "xUnit2031_UseSingleTwoArgumentCall";
+
 	public AssertSingleShouldUseTwoArgumentCallFixer() :
 		base(Descriptors.X2031_AssertSingleShouldUseTwoArgumentCall.Id)
 	{ }

--- a/src/xunit.analyzers.fixes/X2000/AssertSingleShouldUseTwoArgumentCallFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertSingleShouldUseTwoArgumentCallFixer.cs
@@ -2,6 +2,11 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis;
 using System.Composition;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using System.Threading;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -14,8 +19,43 @@ public class AssertSingleShouldUseTwoArgumentCallFixer : BatchedCodeFixProvider
 		base(Descriptors.X2031_AssertSingleShouldUseTwoArgumentCall.Id)
 	{ }
 
-	public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{
-		return Task.CompletedTask;
+		var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+		if (root is null)
+			return;
+
+		var invocation = root.FindNode(context.Span).FirstAncestorOrSelf<InvocationExpressionSyntax>();
+		if (invocation is null)
+			return;
+
+		context.RegisterCodeFix(
+			XunitCodeAction.Create(
+				c => UseCheck(context.Document, invocation, c),
+				Key_UseTwoArguments,
+				"Use two-argument call"
+			),
+			context.Diagnostics
+		);
+	}
+
+	static async Task<Document> UseCheck(
+		Document document,
+		InvocationExpressionSyntax invocation,
+		CancellationToken cancellationToken)
+	{
+		var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+		var arguments = invocation.ArgumentList.Arguments;
+		if (arguments.Count == 1 && arguments[0].Expression is InvocationExpressionSyntax innerInvocationSyntax)
+			if (innerInvocationSyntax.Expression is MemberAccessExpressionSyntax memberAccess)
+				if (innerInvocationSyntax.ArgumentList.Arguments[0].Expression is ExpressionSyntax innerArgument)
+					editor.ReplaceNode(
+						invocation,
+						invocation
+							.WithArgumentList(ArgumentList(SeparatedList([Argument(memberAccess.Expression), Argument(innerArgument)])))
+					);
+
+		return editor.GetChangedDocument();
 	}
 }

--- a/src/xunit.analyzers.tests/Analyzers/X2000/AssertSingleShouldUseTwoArgumentCallTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X2000/AssertSingleShouldUseTwoArgumentCallTests.cs
@@ -1,0 +1,7 @@
+using System.Threading.Tasks;
+using Xunit;
+using Verify = CSharpVerifier<Xunit.Analyzers.AssertSingleShouldUseTwoArgumentCall>;
+
+public class AssertSingleShouldUseTwoArgumentCallTests
+{
+}

--- a/src/xunit.analyzers.tests/Analyzers/X2000/AssertSingleShouldUseTwoArgumentCallTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X2000/AssertSingleShouldUseTwoArgumentCallTests.cs
@@ -7,14 +7,7 @@ public class AssertSingleShouldUseTwoArgumentCallTests
 	public static TheoryData<string, string> GetEnumerables(
 		string typeName,
 		string comparison) =>
-			new()
-			{
-				{ $"new System.Collections.Generic.List<{typeName}>()", comparison },
-				{ $"new System.Collections.Generic.HashSet<{typeName}>()", comparison },
-				{ $"new System.Collections.ObjectModel.Collection<{typeName}>()", comparison },
-				{ $"new {typeName}[0]", comparison },
-				{ $"System.Linq.Enumerable.Empty<{typeName}>()", comparison },
-			};
+			AssertEmptyOrNotEmptyShouldNotBeUsedForContainsChecksTests.GetEnumerables(typeName, comparison);
 
 	[Theory]
 	[MemberData(nameof(GetEnumerables), "int", "")]

--- a/src/xunit.analyzers.tests/Analyzers/X2000/AssertSingleShouldUseTwoArgumentCallTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X2000/AssertSingleShouldUseTwoArgumentCallTests.cs
@@ -4,4 +4,112 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertSingleShouldUseTwoArgumentCa
 
 public class AssertSingleShouldUseTwoArgumentCallTests
 {
+	public static TheoryData<string, string> GetEnumerables(
+		string typeName,
+		string comparison) =>
+			new()
+			{
+				{ $"new System.Collections.Generic.List<{typeName}>()", comparison },
+				{ $"new System.Collections.Generic.HashSet<{typeName}>()", comparison },
+				{ $"new System.Collections.ObjectModel.Collection<{typeName}>()", comparison },
+				{ $"new {typeName}[0]", comparison },
+				{ $"System.Linq.Enumerable.Empty<{typeName}>()", comparison },
+			};
+
+	[Theory]
+	[MemberData(nameof(GetEnumerables), "int", "")]
+	[MemberData(nameof(GetEnumerables), "string", "")]
+	public async Task Containers_WithoutWhereClause_DoesNotTrigger(
+		string collection,
+		string _)
+	{
+		var source = string.Format(/* lang=c#-test */ """
+			class TestClass {{
+			    void TestMethod() {{
+					Xunit.Assert.Single({0});
+			    }}
+			}}
+			""", collection);
+
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Theory]
+	[MemberData(nameof(GetEnumerables), "int", "f > 0")]
+	[MemberData(nameof(GetEnumerables), "string", "f.Length > 0")]
+	public async Task Containers_WithWhereClauseWithIndex_DoesNotTrigger(
+		string collection,
+		string comparison)
+	{
+		var source = string.Format(/* lang=c#-test */ """
+			using System.Linq;
+
+			class TestClass {{
+			    void TestMethod() {{
+					Xunit.Assert.Single({0}.Where((f, i) => {1} && i > 0));
+			    }}
+			}}
+			""", collection, comparison);
+
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Theory]
+	[MemberData(nameof(GetEnumerables), "int", "f > 0")]
+	[MemberData(nameof(GetEnumerables), "string", "f.Length > 0")]
+	public async Task EnumurableEmptyCheck_WithChainedLinq_DoesNotTrigger(
+		string collection,
+		string comparison)
+	{
+		var source = string.Format(/* lang=c#-test */ """
+			using System.Linq;
+
+			class TestClass {{
+			    void TestMethod() {{
+					Xunit.Assert.Single({0}.Where(f => {1}).Select(f => f));
+			    }}
+			}}
+			""", collection, comparison);
+
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Theory]
+	[MemberData(nameof(GetEnumerables), "int", "f > 0")]
+	[MemberData(nameof(GetEnumerables), "string", "f.Length > 0")]
+	public async Task Containers_WithWhereClause_Triggers(
+		string collection,
+		string comparison)
+	{
+		var source = string.Format(/* lang=c#-test */ """
+			using System.Linq;
+
+			class TestClass {{
+			    void TestMethod() {{
+					[|Xunit.Assert.Single({0}.Where(f => {1}))|];
+			    }}
+			}}
+			""", collection, comparison);
+
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("123")]
+	[InlineData(@"abc\n\t\\\""")]
+	public async Task Strings_WithWhereClause_Triggers(string sampleString)
+	{
+		var source = string.Format(/* lang=c#-test */ """
+			using System.Linq;
+
+			class TestClass {{
+			    void TestMethod() {{
+					[|Xunit.Assert.Single("{0}".Where(f => f > 0))|];
+			    }}
+			}}
+			""", sampleString);
+
+		await Verify.VerifyAnalyzer(source);
+	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertSingleShouldUseTwoArgumentCallFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertSingleShouldUseTwoArgumentCallFixerTests.cs
@@ -1,0 +1,43 @@
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Analyzers.Fixes;
+using Verify = CSharpVerifier<Xunit.Analyzers.AssertSingleShouldUseTwoArgumentCall>;
+
+public class AssertSingleShouldUseTwoArgumentCallFixerTests
+{
+	const string template = /* lang=c#-test */ """
+		using System.Linq;
+		using Xunit;
+
+		public class TestClass {{
+		    [Fact]
+		    public void TestMethod() {{
+		        var list = new[] {{ -1, 0, 1, 2 }};
+
+		        {0};
+		    }}
+
+			public bool IsEven(int num) => num % 2 == 0;
+		}}
+		""";
+
+	[Theory]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.Single(list.Where(f => f > 0))|]",
+		/* lang=c#-test */ "Assert.Single(list, f => f > 0)")]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.Single(list.Where(n => n == 1))|]",
+		/* lang=c#-test */ "Assert.Single(list, n => n == 1)")]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.Single(list.Where(IsEven))|]",
+		/* lang=c#-test */ "Assert.Single(list, IsEven)")]
+	public async Task FixerReplacesAssertSingleOneArgumentToTwoArgumentCall(
+		string beforeAssert,
+		string afterAssert)
+	{
+		var before = string.Format(template, beforeAssert);
+		var after = string.Format(template, afterAssert);
+
+		await Verify.VerifyCodeFix(before, after, AssertSingleShouldUseTwoArgumentCallFixer.Key_UseTwoArguments);
+	}
+}

--- a/src/xunit.analyzers/Utility/Descriptors.xUnit2xxx.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.xUnit2xxx.cs
@@ -278,7 +278,14 @@ public static partial class Descriptors
 			"Do not use Assert.NotEmpty to check if a value exists in a collection. Use Assert.Contains instead."
 		);
 
-	// Placeholder for rule X2031
+	public static DiagnosticDescriptor X2031_AssertSingleShouldUseTwoArgumentCall { get; } =
+		Diagnostic(
+			"xUnit2031",
+			"Do not use single-argument Assert.Single in a filtered collection",
+			Assertions,
+			Warning,
+			"Do not use single-argument call to Assert.Single to check for a single item in a filtered collection. Use two-argument call instead."
+		);
 
 	// Placeholder for rule X2032
 

--- a/src/xunit.analyzers/Utility/Descriptors.xUnit2xxx.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.xUnit2xxx.cs
@@ -281,10 +281,10 @@ public static partial class Descriptors
 	public static DiagnosticDescriptor X2031_AssertSingleShouldUseTwoArgumentCall { get; } =
 		Diagnostic(
 			"xUnit2031",
-			"Do not use single-argument Assert.Single in a filtered collection",
+			"Do not use Where clause with Assert.Single",
 			Assertions,
 			Warning,
-			"Do not use single-argument call to Assert.Single to check for a single item in a filtered collection. Use two-argument call instead."
+			"Do not use a Where clause to filter before calling Assert.Single. Use the overload of Assert.Single that accepts a filtering function."
 		);
 
 	// Placeholder for rule X2032

--- a/src/xunit.analyzers/X2000/AssertSingleShouldUseTwoArgumentCall.cs
+++ b/src/xunit.analyzers/X2000/AssertSingleShouldUseTwoArgumentCall.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -7,6 +8,8 @@ namespace Xunit.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class AssertSingleShouldUseTwoArgumentCall : AssertUsageAnalyzerBase
 {
+	const string linqWhereMethod = "System.Linq.Enumerable.Where<TSource>(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource, bool>)";
+
 	static readonly string[] targetMethods =
 	[
 		Constants.Asserts.Single,
@@ -22,6 +25,38 @@ public class AssertSingleShouldUseTwoArgumentCall : AssertUsageAnalyzerBase
 		IInvocationOperation invocationOperation,
 		IMethodSymbol method)
 	{
-		return;
+		Guard.ArgumentNotNull(xunitContext);
+		Guard.ArgumentNotNull(invocationOperation);
+		Guard.ArgumentNotNull(method);
+
+		var arguments = invocationOperation.Arguments;
+		if (arguments.Length != 1)
+			return;
+
+		var argument = arguments[0];
+		var value = argument.Value;
+		if (value is IConversionOperation conversion)
+			value = conversion.Operand;
+
+		if (value is not IInvocationOperation innerInvocation)
+			return;
+
+		var originalMethod = SymbolDisplay.ToDisplayString(innerInvocation.TargetMethod.OriginalDefinition);
+		if (originalMethod != linqWhereMethod)
+			return;
+
+		context.ReportDiagnostic(
+			Diagnostic.Create(
+				Descriptors.X2031_AssertSingleShouldUseTwoArgumentCall,
+				invocationOperation.Syntax.GetLocation(),
+				SymbolDisplay.ToDisplayString(
+					method,
+					SymbolDisplayFormat
+						.CSharpShortErrorMessageFormat
+						.WithParameterOptions(SymbolDisplayParameterOptions.None)
+						.WithGenericsOptions(SymbolDisplayGenericsOptions.None)
+				)
+			)
+		);
 	}
 }

--- a/src/xunit.analyzers/X2000/AssertSingleShouldUseTwoArgumentCall.cs
+++ b/src/xunit.analyzers/X2000/AssertSingleShouldUseTwoArgumentCall.cs
@@ -1,0 +1,27 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Xunit.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class AssertSingleShouldUseTwoArgumentCall : AssertUsageAnalyzerBase
+{
+	static readonly string[] targetMethods =
+	[
+		Constants.Asserts.Single,
+	];
+
+	public AssertSingleShouldUseTwoArgumentCall() :
+		base(Descriptors.X2031_AssertSingleShouldUseTwoArgumentCall, targetMethods)
+	{ }
+
+	protected override void AnalyzeInvocation(
+		OperationAnalysisContext context,
+		XunitContext xunitContext,
+		IInvocationOperation invocationOperation,
+		IMethodSymbol method)
+	{
+		return;
+	}
+}


### PR DESCRIPTION
This is intended to solve the final part of xunit/xunit#1510 (if I haven't missed anything).

It maps the single-argument call to Assert.Single with linq where expression, and suggests to change it to two-argument call:

```diff
- Assert.Single(list.Where(f => f > 0));
+ Assert.Single(list, f => f > 0);
```