### PR TITLE
Fix bug in xUnit1051 to account for arbitrary argument order

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/UseCancellationTokenTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/UseCancellationTokenTests.cs
@@ -53,9 +53,13 @@ public class UseCancellationTokenTests
 
 			class TestClass {{
 			    [Fact]
-			    public async Task TestMethod() {{
-			        await Task.Delay(1, {0});
+			    public void TestMethod() {{
+			        FunctionWithDefaults(42, {0});
+			        FunctionWithDefaults(42, cancellationToken: {0});
+			        FunctionWithDefaults(cancellationToken: {0});
 			    }}
+
+			    void FunctionWithDefaults(int _1 = 2112, CancellationToken cancellationToken = default(CancellationToken)) {{ }}
 			}}
 			""", token);
 


### PR DESCRIPTION
Argument order can not be trusted, always check if parameter matches argument parameter.

Fixes https://github.com/xunit/xunit/issues/3011