### PR TITLE
Feat trigger x1010 when InlineData is negative int and parameter is uint

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/InlineDataMustMatchTheoryParametersTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/InlineDataMustMatchTheoryParametersTests.cs
@@ -1038,17 +1038,18 @@ public class InlineDataMustMatchTheoryParametersTests
 				await Verify.VerifyAnalyzer(source);
 			}
 
-			[Fact]
-			public async Task FromNegativeInt_ToUint()
+			[Theory]
+			[MemberData(nameof(UnsignedInt))]
+			public async Task FromNegativeInt_ToUnsignedInt(string unsignedType)
 			{
-				var source =/* lang=c#-test */ """
-					public class TestClass {
+				var source = string.Format(/* lang=c#-test */ """
+					public class TestClass {{
 					    [Xunit.Theory]
-					    [Xunit.InlineData({|#0:-1|})]
-					    public void TestMethod(uint value) { }
-					}
-					""";
-				var expected = Verify.Diagnostic("xUnit1010").WithLocation(0).WithArguments("value", "uint");
+					    [Xunit.InlineData({{|#0:-1|}})]
+					    public void TestMethod({0} value) {{ }}
+					}}
+					""", unsignedType);
+				var expected = Verify.Diagnostic("xUnit1010").WithLocation(0).WithArguments("value", unsignedType);
 
 				await Verify.VerifyAnalyzer(source, expected);
 			}
@@ -1267,6 +1268,8 @@ public class InlineDataMustMatchTheoryParametersTests
 
 		public static TheoryData<string> ValueTypedValues =
 			new(((IEnumerable<string>)IntegerValues).Concat(FloatingPointValues).Concat(BoolValues).Append("typeof(int)"));
+
+		public static readonly TheoryData<string> UnsignedInt = ["uint", "ulong", "ushort", "byte"];
 	}
 
 	public class X1011_ExtraValue

--- a/src/xunit.analyzers.tests/Analyzers/X1000/InlineDataMustMatchTheoryParametersTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/InlineDataMustMatchTheoryParametersTests.cs
@@ -1039,16 +1039,16 @@ public class InlineDataMustMatchTheoryParametersTests
 			}
 
 			[Theory]
-			[MemberData(nameof(UnsignedInt))]
-			public async Task FromNegativeInt_ToUnsignedInt(string unsignedType)
+			[MemberData(nameof(SignedIntAndUnsignedInt))]
+			public async Task FromNegativeInteger_ToUnsignedInteger(string signedType, string unsignedType)
 			{
 				var source = string.Format(/* lang=c#-test */ """
 					public class TestClass {{
 					    [Xunit.Theory]
-					    [Xunit.InlineData({{|#0:-1|}})]
-					    public void TestMethod({0} value) {{ }}
+					    [Xunit.InlineData({{|#0:({0})-1|}})]
+					    public void TestMethod({1} value) {{ }}
 					}}
-					""", unsignedType);
+					""", signedType, unsignedType);
 				var expected = Verify.Diagnostic("xUnit1010").WithLocation(0).WithArguments("value", unsignedType);
 
 				await Verify.VerifyAnalyzer(source, expected);
@@ -1269,7 +1269,11 @@ public class InlineDataMustMatchTheoryParametersTests
 		public static TheoryData<string> ValueTypedValues =
 			new(((IEnumerable<string>)IntegerValues).Concat(FloatingPointValues).Concat(BoolValues).Append("typeof(int)"));
 
-		public static readonly TheoryData<string> UnsignedInt = ["uint", "ulong", "ushort", "byte"];
+		public static readonly TheoryData<string> SignedInteger = ["int", "long", "short", "sbyte"];
+
+		public static readonly TheoryData<string> UnsignedInteger = ["uint", "ulong", "ushort", "byte"];
+
+		public static readonly MatrixTheoryData<string, string> SignedIntAndUnsignedInt = new(SignedInteger, UnsignedInteger);
 	}
 
 	public class X1011_ExtraValue

--- a/src/xunit.analyzers.tests/Analyzers/X1000/InlineDataMustMatchTheoryParametersTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/InlineDataMustMatchTheoryParametersTests.cs
@@ -1021,7 +1021,7 @@ public class InlineDataMustMatchTheoryParametersTests
 			}
 
 			[Fact]
-			public async Task FromInt_ToUint()
+			public async Task FromNegativeInt_ToUint()
 			{
 				var source =/* lang=c#-test */ """
 					public class TestClass {

--- a/src/xunit.analyzers.tests/Analyzers/X1000/InlineDataMustMatchTheoryParametersTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/InlineDataMustMatchTheoryParametersTests.cs
@@ -1019,6 +1019,21 @@ public class InlineDataMustMatchTheoryParametersTests
 
 				await Verify.VerifyAnalyzer(source);
 			}
+
+			[Fact]
+			public async Task FromInt_ToUint()
+			{
+				var source =/* lang=c#-test */ """
+					public class TestClass {
+					    [Xunit.Theory]
+					    [Xunit.InlineData({|#0:-1|})]
+					    public void TestMethod(uint value) { }
+					}
+					""";
+				var expected = Verify.Diagnostic("xUnit1010").WithLocation(0).WithArguments("value", "uint");
+
+				await Verify.VerifyAnalyzer(source, expected);
+			}
 		}
 
 		public class DateTimeLikeParameter : X1010_IncompatibleValueType

--- a/src/xunit.analyzers/Utility/ConversionChecker.cs
+++ b/src/xunit.analyzers/Utility/ConversionChecker.cs
@@ -14,7 +14,7 @@ static class ConversionChecker
 		ITypeSymbol source,
 		ITypeSymbol destination,
 		XunitContext xunitContext,
-		int? valueSource = null)
+		object? valueSource = null)
 	{
 		Guard.ArgumentNotNull(compilation);
 		Guard.ArgumentNotNull(source);
@@ -66,9 +66,10 @@ static class ConversionChecker
 	static bool IsConvertibleNumeric(
 		ITypeSymbol source,
 		ITypeSymbol destination,
-		int? valueSource = null)
+		object? valueSource = null)
 	{
-		if (IsSigned(source) && IsUnsigned(destination) && valueSource.HasValue && valueSource < 0)
+		var isInt = int.TryParse(valueSource?.ToString(), out int valueInt);
+		if (isInt && valueInt < 0 && IsSigned(source) && IsUnsigned(destination))
 			return false;
 
 		if (destination.SpecialType == SpecialType.System_Char

--- a/src/xunit.analyzers/Utility/ConversionChecker.cs
+++ b/src/xunit.analyzers/Utility/ConversionChecker.cs
@@ -68,7 +68,7 @@ static class ConversionChecker
 		ITypeSymbol destination,
 		int? valueSource = null)
 	{
-		if (IsInt(source) && IsUInt(destination) && valueSource.HasValue && valueSource < 0)
+		if (IsSigned(source) && IsUnsigned(destination) && valueSource.HasValue && valueSource < 0)
 			return false;
 
 		if (destination.SpecialType == SpecialType.System_Char
@@ -89,17 +89,19 @@ static class ConversionChecker
 		return destination.MetadataName == nameof(DateTimeOffset) || destination.MetadataName == nameof(Guid);
 	}
 
-	static bool IsInt(ITypeSymbol typeSymbol) =>
+	static bool IsSigned(ITypeSymbol typeSymbol) =>
 		new List<SpecialType>() {
+			SpecialType.System_SByte,
 			SpecialType.System_Int16,
 			SpecialType.System_Int32,
 			SpecialType.System_Int64
 		}.Contains(typeSymbol.SpecialType);
 
-	static bool IsUInt(ITypeSymbol typeSymbol) =>
+	static bool IsUnsigned(ITypeSymbol typeSymbol) =>
 		new List<SpecialType>() {
-				SpecialType.System_UInt16,
-				SpecialType.System_UInt32,
-				SpecialType.System_UInt64
+			SpecialType.System_Byte,
+			SpecialType.System_UInt16,
+			SpecialType.System_UInt32,
+			SpecialType.System_UInt64
 		}.Contains(typeSymbol.SpecialType);
 }

--- a/src/xunit.analyzers/X1000/InlineDataMustMatchTheoryParameters.cs
+++ b/src/xunit.analyzers/X1000/InlineDataMustMatchTheoryParameters.cs
@@ -166,9 +166,9 @@ public class InlineDataMustMatchTheoryParameters : XunitDiagnosticAnalyzer
 						if (value.Type is null)
 							continue;
 
-						var isCompatible = ConversionChecker.IsConvertible(compilation, value.Type, parameter.Type, xunitContext);
+						var isCompatible = ConversionChecker.IsConvertible(compilation, value.Type, parameter.Type, xunitContext, value.Kind != TypedConstantKind.Array ? value.Value as int? : null);
 						if (!isCompatible && paramsElementType is not null)
-							isCompatible = ConversionChecker.IsConvertible(compilation, value.Type, paramsElementType, xunitContext);
+							isCompatible = ConversionChecker.IsConvertible(compilation, value.Type, paramsElementType, xunitContext, value.Kind != TypedConstantKind.Array ? value.Value as int? : null);
 
 						if (!isCompatible)
 						{

--- a/src/xunit.analyzers/X1000/InlineDataMustMatchTheoryParameters.cs
+++ b/src/xunit.analyzers/X1000/InlineDataMustMatchTheoryParameters.cs
@@ -171,9 +171,9 @@ public class InlineDataMustMatchTheoryParameters : XunitDiagnosticAnalyzer
 						if (value.Type is null)
 							continue;
 
-						var isCompatible = ConversionChecker.IsConvertible(compilation, value.Type, parameter.Type, xunitContext, value.Kind != TypedConstantKind.Array ? value.Value as int? : null);
+						var isCompatible = ConversionChecker.IsConvertible(compilation, value.Type, parameter.Type, xunitContext, value.Kind == TypedConstantKind.Primitive ? value.Value : null);
 						if (!isCompatible && paramsElementType is not null)
-							isCompatible = ConversionChecker.IsConvertible(compilation, value.Type, paramsElementType, xunitContext, value.Kind != TypedConstantKind.Array ? value.Value as int? : null);
+							isCompatible = ConversionChecker.IsConvertible(compilation, value.Type, paramsElementType, xunitContext, value.Kind == TypedConstantKind.Primitive ? value.Value : null);
 
 						if (!isCompatible)
 						{


### PR DESCRIPTION
When pass negative int in inlinedata and the parameter of test is uint, the test will fail in runtime