### PR TITLE
Support analyzers / fixers on custom Fact / Theory attributes

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/TestMethodSupportedReturnTypeTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/TestMethodSupportedReturnTypeTests.cs
@@ -66,7 +66,7 @@ public class TestMethodSupportedReturnTypeTests
 	[Theory]
 	[InlineData("MyTest")]
 	[InlineData("MyTestAttribute")]
-	public async Task CustomTestAttribute_DoesNotTrigger(string attribute)
+	public async Task CustomTestAttribute_Triggers(string attribute)
 	{
 		var source = string.Format(/* lang=c#-test */ """
 			using Xunit;
@@ -80,7 +80,10 @@ public class TestMethodSupportedReturnTypeTests
 				}}
 			}}
 			""", attribute);
+		var expectedV2 = Verify.Diagnostic().WithSpan(7, 16, 7, 26).WithArguments("void, Task");
+		var expectedV3 = Verify.Diagnostic().WithSpan(7, 16, 7, 26).WithArguments("void, Task, ValueTask");
 
-		await Verify.VerifyAnalyzer(source);
+		await Verify.VerifyAnalyzerV2(source, expectedV2);
+		await Verify.VerifyAnalyzerV3(source, expectedV3);
 	}
 }

--- a/src/xunit.analyzers/Utility/CodeAnalysisExtensions.cs
+++ b/src/xunit.analyzers/Utility/CodeAnalysisExtensions.cs
@@ -96,8 +96,8 @@ static class CodeAnalysisExtensions
 					return false;
 
 				return
-					SymbolEqualityComparer.Default.Equals(typeInfo.Type, xunitContext.Core.FactAttributeType) ||
-					SymbolEqualityComparer.Default.Equals(typeInfo.Type, xunitContext.Core.TheoryAttributeType);
+					xunitContext.Core.FactAttributeType.IsAssignableFrom(typeInfo.Type) ||
+					xunitContext.Core.TheoryAttributeType.IsAssignableFrom(typeInfo.Type);
 			});
 		}
 

--- a/src/xunit.analyzers/X1000/TestMethodSupportedReturnType.cs
+++ b/src/xunit.analyzers/X1000/TestMethodSupportedReturnType.cs
@@ -27,7 +27,7 @@ public class TestMethodSupportedReturnType : XunitDiagnosticAnalyzer
 		{
 			if (context.Symbol is not IMethodSymbol method)
 				return;
-			if (!method.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(xunitContext.Core.FactAttributeType, a.AttributeClass) || SymbolEqualityComparer.Default.Equals(xunitContext.Core.TheoryAttributeType, a.AttributeClass)))
+			if (!method.GetAttributes().Any(a => xunitContext.Core.FactAttributeType.IsAssignableFrom(a.AttributeClass) || xunitContext.Core.TheoryAttributeType.IsAssignableFrom(a.AttributeClass)))
 				return;
 
 			var validReturnTypes = GetValidReturnTypes(context.Compilation, xunitContext);


### PR DESCRIPTION
There were two instances where the Fact / Theory attribute weren't checked with `IsAssignableFrom`.

The change in `CodeAnalysisExtensions.cs` allows analysers / fixers to work with custom attributes inheriting `FactAttribute` / `TheoryAttribute`.