### PR TITLE
Handle switching from params to non-params overload in xUnit1051

### DIFF
--- a/src/xunit.analyzers.tests/Fixes/X1000/UseCancellationTokenFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/UseCancellationTokenFixerTests.cs
@@ -90,7 +90,7 @@ public class UseCancellationTokenFixerTests
 			        Function(MyContext.Current.CancellationToken);
 			    }
 			
-				void Function(CancellationToken token = default(CancellationToken)) { }
+			    void Function(CancellationToken token = default(CancellationToken)) { }
 			}
 			""";
 

--- a/src/xunit.analyzers.tests/Fixes/X1000/UseCancellationTokenFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/UseCancellationTokenFixerTests.cs
@@ -90,7 +90,130 @@ public class UseCancellationTokenFixerTests
 			        Function(MyContext.Current.CancellationToken);
 			    }
 			
-			    void Function(CancellationToken token = default(CancellationToken)) { }
+				void Function(CancellationToken token = default(CancellationToken)) { }
+			}
+			""";
+
+		await Verify.VerifyCodeFixV3(before, after, UseCancellationTokenFixer.Key_UseCancellationTokenArgument);
+	}
+
+	[Fact]
+	public async Task UseCancellationTokenArgument_ParamsArgument()
+	{
+		var before = /* lang=c#-test */ """
+			using System.Threading;
+			using System.Threading.Tasks;
+			using MyContext = Xunit.TestContext;
+
+			public class TestClass {
+				[Xunit.Fact]
+				public void TestMethod()
+				{
+					[|Function(1, 2, 3)|];
+				}
+
+				void Function(params int[] integers) { }
+
+				void Function(int[] integers, CancellationToken token = default(CancellationToken)) { }
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using System.Threading;
+			using System.Threading.Tasks;
+			using MyContext = Xunit.TestContext;
+
+			public class TestClass {
+				[Xunit.Fact]
+				public void TestMethod()
+				{
+					Function(new int[] { 1, 2, 3 }, MyContext.Current.CancellationToken);
+				}
+			
+				void Function(params int[] integers) { }
+
+				void Function(int[] integers, CancellationToken token = default(CancellationToken)) { }
+			}
+			""";
+
+		await Verify.VerifyCodeFixV3(before, after, UseCancellationTokenFixer.Key_UseCancellationTokenArgument);
+	}
+
+	[Fact]
+	public async Task UseCancellationTokenArgument_ParamsArgumentAfterRegularArguments()
+	{
+		var before = /* lang=c#-test */ """
+			using System.Threading;
+			using System.Threading.Tasks;
+			using MyContext = Xunit.TestContext;
+
+			public class TestClass {
+				[Xunit.Fact]
+				public void TestMethod()
+				{
+					[|Function("hello", System.Guid.NewGuid(), System.Guid.NewGuid())|];
+				}
+			
+				void Function(string str, params System.Guid[] guids) { }
+			
+				void Function(string str, System.Guid[] guids, CancellationToken token = default(CancellationToken)) { }
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using System.Threading;
+			using System.Threading.Tasks;
+			using MyContext = Xunit.TestContext;
+
+			public class TestClass {
+				[Xunit.Fact]
+				public void TestMethod()
+				{
+					Function("hello", new System.Guid[] { System.Guid.NewGuid(), System.Guid.NewGuid() }, MyContext.Current.CancellationToken);
+				}
+			
+				void Function(string str, params System.Guid[] guids) { }
+			
+				void Function(string str, System.Guid[] guids, CancellationToken token = default(CancellationToken)) { }
+			}
+			""";
+
+		await Verify.VerifyCodeFixV3(before, after, UseCancellationTokenFixer.Key_UseCancellationTokenArgument);
+	}
+
+	[Fact]
+	public async Task UseCancellationTokenArgument_ParamsArgumentWithNoValues()
+	{
+		var before = /* lang=c#-test */ """
+			using System.Threading;
+			using System.Threading.Tasks;
+			using MyContext = Xunit.TestContext;
+
+			public class TestClass {
+				[Xunit.Fact]
+				public void TestMethod()
+				{
+					[|Function()|];
+				}
+
+				void Function(params int[] integers) { }
+
+				void Function(int[] integers, CancellationToken token = default(CancellationToken)) { }
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using System.Threading;
+			using System.Threading.Tasks;
+			using MyContext = Xunit.TestContext;
+
+			public class TestClass {
+				[Xunit.Fact]
+				public void TestMethod()
+				{
+					Function(new int[] { }, MyContext.Current.CancellationToken);
+				}
+			
+				void Function(params int[] integers) { }
+
+				void Function(int[] integers, CancellationToken token = default(CancellationToken)) { }
 			}
 			""";
 

--- a/src/xunit.analyzers.tests/Fixes/X1000/UseCancellationTokenFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/UseCancellationTokenFixerTests.cs
@@ -106,15 +106,15 @@ public class UseCancellationTokenFixerTests
 			using MyContext = Xunit.TestContext;
 
 			public class TestClass {
-				[Xunit.Fact]
-				public void TestMethod()
-				{
-					[|Function(1, 2, 3)|];
-				}
+			    [Xunit.Fact]
+			    public void TestMethod()
+			    {
+			        [|Function(1, 2, 3)|];
+			    }
 
-				void Function(params int[] integers) { }
+			    void Function(params int[] integers) { }
 
-				void Function(int[] integers, CancellationToken token = default(CancellationToken)) { }
+			    void Function(int[] integers, CancellationToken token = default(CancellationToken)) { }
 			}
 			""";
 		var after = /* lang=c#-test */ """
@@ -123,15 +123,15 @@ public class UseCancellationTokenFixerTests
 			using MyContext = Xunit.TestContext;
 
 			public class TestClass {
-				[Xunit.Fact]
-				public void TestMethod()
-				{
-					Function(new int[] { 1, 2, 3 }, MyContext.Current.CancellationToken);
-				}
+			    [Xunit.Fact]
+			    public void TestMethod()
+			    {
+			        Function(new int[] { 1, 2, 3 }, MyContext.Current.CancellationToken);
+			    }
 			
-				void Function(params int[] integers) { }
+			    void Function(params int[] integers) { }
 
-				void Function(int[] integers, CancellationToken token = default(CancellationToken)) { }
+			    void Function(int[] integers, CancellationToken token = default(CancellationToken)) { }
 			}
 			""";
 
@@ -147,15 +147,15 @@ public class UseCancellationTokenFixerTests
 			using MyContext = Xunit.TestContext;
 
 			public class TestClass {
-				[Xunit.Fact]
-				public void TestMethod()
-				{
-					[|Function("hello", System.Guid.NewGuid(), System.Guid.NewGuid())|];
-				}
+			    [Xunit.Fact]
+			    public void TestMethod()
+			    {
+			        [|Function("hello", System.Guid.NewGuid(), System.Guid.NewGuid())|];
+			    }
 			
-				void Function(string str, params System.Guid[] guids) { }
+			    void Function(string str, params System.Guid[] guids) { }
 			
-				void Function(string str, System.Guid[] guids, CancellationToken token = default(CancellationToken)) { }
+			    void Function(string str, System.Guid[] guids, CancellationToken token = default(CancellationToken)) { }
 			}
 			""";
 		var after = /* lang=c#-test */ """
@@ -164,15 +164,15 @@ public class UseCancellationTokenFixerTests
 			using MyContext = Xunit.TestContext;
 
 			public class TestClass {
-				[Xunit.Fact]
-				public void TestMethod()
-				{
-					Function("hello", new System.Guid[] { System.Guid.NewGuid(), System.Guid.NewGuid() }, MyContext.Current.CancellationToken);
-				}
+			    [Xunit.Fact]
+			    public void TestMethod()
+			    {
+			        Function("hello", new System.Guid[] { System.Guid.NewGuid(), System.Guid.NewGuid() }, MyContext.Current.CancellationToken);
+			    }
 			
-				void Function(string str, params System.Guid[] guids) { }
+			    void Function(string str, params System.Guid[] guids) { }
 			
-				void Function(string str, System.Guid[] guids, CancellationToken token = default(CancellationToken)) { }
+			    void Function(string str, System.Guid[] guids, CancellationToken token = default(CancellationToken)) { }
 			}
 			""";
 
@@ -188,15 +188,15 @@ public class UseCancellationTokenFixerTests
 			using MyContext = Xunit.TestContext;
 
 			public class TestClass {
-				[Xunit.Fact]
-				public void TestMethod()
-				{
-					[|Function()|];
-				}
+			    [Xunit.Fact]
+			    public void TestMethod()
+			    {
+			        [|Function()|];
+			    }
 
-				void Function(params int[] integers) { }
+			    void Function(params int[] integers) { }
 
-				void Function(int[] integers, CancellationToken token = default(CancellationToken)) { }
+			    void Function(int[] integers, CancellationToken token = default(CancellationToken)) { }
 			}
 			""";
 		var after = /* lang=c#-test */ """
@@ -205,15 +205,15 @@ public class UseCancellationTokenFixerTests
 			using MyContext = Xunit.TestContext;
 
 			public class TestClass {
-				[Xunit.Fact]
-				public void TestMethod()
-				{
-					Function(new int[] { }, MyContext.Current.CancellationToken);
-				}
+			    [Xunit.Fact]
+			    public void TestMethod()
+			    {
+			        Function(new int[] { }, MyContext.Current.CancellationToken);
+			    }
 			
-				void Function(params int[] integers) { }
+			    void Function(params int[] integers) { }
 
-				void Function(int[] integers, CancellationToken token = default(CancellationToken)) { }
+			    void Function(int[] integers, CancellationToken token = default(CancellationToken)) { }
 			}
 			""";
 


### PR DESCRIPTION
If the analyzer has fired on a `params` method, it means that the new overload is actually array + `CancellationToken`, since C# forbids placing any argument after a params argument. To avoid generating invalid code, we need to replace the params expression with an array creation expression.

Does not currently handle the expanded range of allowed `params` types implemented in C# 13. Considering you can use _any_ type that implements `IEnumerable<T>`, I think it would be quite difficult to handle all the different cases there. Being a new feature, it's also less likely to be used, though this will of course change over time...

Closes [#3068](https://github.com/xunit/xunit/issues/3068)