### PR TITLE
Update xUnit1004 to not trigger with SkipWhen or SkipUnless

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/TestMethodShouldNotBeSkippedTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/TestMethodShouldNotBeSkippedTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 using Verify = CSharpVerifier<Xunit.Analyzers.TestMethodShouldNotBeSkipped>;
 
@@ -32,5 +33,37 @@ public class TestMethodShouldNotBeSkippedTests
 			""", attribute);
 
 		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Theory]
+	[InlineData("Fact")]
+	[InlineData("Theory")]
+	public async Task SkippedTestWhenConditionIsTrue_V3_DoesNotTrigger(string attribute)
+	{
+		var source = string.Format(/* lang=c#-test */ """
+			public class TestClass {{
+				public static bool Condition {{ get; set; }}
+				[Xunit.{0}(Skip="Lazy", SkipWhen=nameof(Condition))]
+				public void TestMethod() {{ }}
+			}}
+			""", attribute);
+
+		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp7, source);
+	}
+
+	[Theory]
+	[InlineData("Fact")]
+	[InlineData("Theory")]
+	public async Task SkippedTestUnlessConditionIsTrue_V3_DoesNotTrigger(string attribute)
+	{
+		var source = string.Format(/* lang=c#-test */ """
+			public class TestClass {{
+				public static bool Condition {{ get; set; }}
+				[Xunit.{0}(Skip="Lazy", SkipUnless=nameof(Condition))]
+				public void TestMethod() {{ }}
+			}}
+			""", attribute);
+
+		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp7, source);
 	}
 }

--- a/src/xunit.analyzers/X1000/TestMethodShouldNotBeSkipped.cs
+++ b/src/xunit.analyzers/X1000/TestMethodShouldNotBeSkipped.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -26,8 +25,21 @@ public class TestMethodShouldNotBeSkipped : XunitDiagnosticAnalyzer
 				return;
 			if (context.Node is not AttributeSyntax attribute)
 				return;
+			if (attribute.ArgumentList is null)
+				return;
 
-			var skipArgument = attribute.ArgumentList?.Arguments.FirstOrDefault(arg => arg.NameEquals?.Name?.Identifier.ValueText == "Skip");
+			var skipArgument = default(AttributeArgumentSyntax);
+			foreach (var argument in attribute.ArgumentList.Arguments)
+			{
+				var valueText = argument.NameEquals?.Name?.Identifier.ValueText;
+
+				if (valueText == "SkipWhen" || valueText == "SkipUnless")
+					return;
+
+				if (valueText == "Skip")
+					skipArgument = argument;
+			}
+
 			if (skipArgument is null)
 				return;
 


### PR DESCRIPTION
Closes https://github.com/xunit/xunit/issues/2988

- Updates xUnit1004 analyzer to not trigger on `Fact` attributes with `SkipWhen` or `SkipUnless` parameters.
- The analyzer returns without reporting xUnit1004 if `attribute.ArgumentList is null`, as there cannot be a `Skip` parameter in the `Fact` attribute (consistent with previous behavior).
- The analyzer checks for `Skip`, `SkipWhen`, and `SkipUnless` in a single loop (for a slightly better performance) and returns without reporting xUnit1004 if `SkipWhen` or `SkipUnless` is found.
- The update to the analyzer does not report xUnit1004 in the case where `SkipWhen` or `SkipUnless` are explicitly mentioned, but have a `null` value. The explicit use of either parameter with a `null` value seems like a misuse of the parameters that would be better addressed by a separate analyzer / fixer.
- The new tests cover the cases for `Fact` attributes with `SkipWhen` or `SkipUnless` parameters and the existing `SkippedTest_Triggers` covers the cases without either.