### PR TITLE
Analyzer - theory data row inside theory data

### DIFF
--- a/src/xunit.analyzers.fixes/X1000/TheoryDataShouldNotUseTheoryDataRowFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/TheoryDataShouldNotUseTheoryDataRowFixer.cs
@@ -12,13 +12,10 @@ using Microsoft.CodeAnalysis.Editing;
 namespace Xunit.Analyzers.Fixes;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
-public class TheoryDataShouldNotUseTheoryDataRowFixer : BatchedCodeFixProvider
+public class TheoryDataShouldNotUseTheoryDataRowFixer() :
+	XunitCodeFixProvider(Descriptors.X1052_TheoryDataShouldNotUseITheoryDataRow.Id)
 {
 	public const string Key_UseIEnumerable = "xUnit1052_UseIEnumerable";
-
-	public TheoryDataShouldNotUseTheoryDataRowFixer() :
-		base(Descriptors.X1052_TheoryDataShouldNotUseITheoryDataRow.Id)
-	{ }
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{
@@ -32,19 +29,13 @@ public class TheoryDataShouldNotUseTheoryDataRowFixer : BatchedCodeFixProvider
 			var node = root.FindNode(span);
 
 			if (node is not GenericNameSyntax genericNameNode)
-			{
 				return;
-			}
 
 			if (genericNameNode.TypeArgumentList.Arguments.Count != 1)
-			{
 				return;
-			}
 
 			if (!IsPartOfOnlyTypeDeclaration(genericNameNode))
-			{
 				return;
-			}
 
 			context.RegisterCodeFix(
 				CodeAction.Create(
@@ -62,14 +53,10 @@ public class TheoryDataShouldNotUseTheoryDataRowFixer : BatchedCodeFixProvider
 		var parent = genericName.Parent;
 
 		if (parent is VariableDeclarationSyntax variableDeclaration)
-		{
 			return variableDeclaration.Variables.All(v => v.Initializer is null);
-		}
 
 		if (parent is PropertyDeclarationSyntax propertyDeclaration)
-		{
 			return propertyDeclaration.Initializer is null;
-		}
 
 		return parent is ParameterSyntax or MethodDeclarationSyntax;
 	}
@@ -80,9 +67,8 @@ public class TheoryDataShouldNotUseTheoryDataRowFixer : BatchedCodeFixProvider
 		CancellationToken ct)
 	{
 		var editor = await DocumentEditor.CreateAsync(document, ct).ConfigureAwait(false);
-
-		SyntaxToken token = SyntaxFactory.IdentifierName("IEnumerable").Identifier;
-		GenericNameSyntax newGenericName = SyntaxFactory.GenericName(token, node.TypeArgumentList);
+		var token = SyntaxFactory.IdentifierName("IEnumerable").Identifier;
+		var newGenericName = SyntaxFactory.GenericName(token, node.TypeArgumentList);
 
 		editor.ReplaceNode(node, newGenericName);
 

--- a/src/xunit.analyzers.fixes/X1000/TheoryDataShouldNotUseTheoryDataRowFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/TheoryDataShouldNotUseTheoryDataRowFixer.cs
@@ -1,0 +1,82 @@
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace Xunit.Analyzers.Fixes;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public class TheoryDataShouldNotUseTheoryDataRowFixer : BatchedCodeFixProvider
+{
+	public const string Key_UseIEnumerable = "xUnit1052_UseIEnumerable";
+
+	public TheoryDataShouldNotUseTheoryDataRowFixer() :
+		base(Descriptors.X1052_TheoryDataShouldNotUseITheoryDataRow.Id)
+	{ }
+
+	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+	{
+		var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+		if (root is null)
+			return;
+
+		var node = root.FindNode(context.Span);
+
+		if (node is not GenericNameSyntax genericNameNode)
+		{
+			return;
+		}
+
+		if (!IsPartOfOnlyTypeDeclaration(genericNameNode))
+		{
+			return;
+		}
+
+		context.RegisterCodeFix(
+			CodeAction.Create(
+				"Use IEnumerable instead of TheoryData",
+				ct => ConvertToIEnumerable(context.Document, genericNameNode, ct),
+				Key_UseIEnumerable
+			),
+			context.Diagnostics
+		);
+	}
+
+	static bool IsPartOfOnlyTypeDeclaration(GenericNameSyntax genericName)
+	{
+		var parent = genericName.Parent;
+
+		if (parent is VariableDeclarationSyntax variableDeclaration)
+		{
+			return variableDeclaration.Variables.All(v => v.Initializer is null);
+		}
+
+		if (parent is PropertyDeclarationSyntax propertyDeclaration)
+		{
+			return propertyDeclaration.Initializer is null;
+		}
+
+		return parent is ParameterSyntax or MethodDeclarationSyntax;
+	}
+
+	static async Task<Document> ConvertToIEnumerable(
+		Document document,
+		GenericNameSyntax node,
+		CancellationToken ct)
+	{
+		var editor = await DocumentEditor.CreateAsync(document, ct).ConfigureAwait(false);
+
+		SyntaxToken token = SyntaxFactory.IdentifierName("IEnumerable").Identifier;
+		GenericNameSyntax newGenericName = SyntaxFactory.GenericName(token, node.TypeArgumentList);
+
+		editor.ReplaceNode(node, newGenericName);
+
+		return editor.GetChangedDocument();
+	}
+}

--- a/src/xunit.analyzers.fixes/X1000/TheoryDataShouldNotUseTheoryDataRowFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/TheoryDataShouldNotUseTheoryDataRowFixer.cs
@@ -26,26 +26,30 @@ public class TheoryDataShouldNotUseTheoryDataRowFixer : BatchedCodeFixProvider
 		if (root is null)
 			return;
 
-		var node = root.FindNode(context.Span);
-
-		if (node is not GenericNameSyntax genericNameNode)
+		foreach (var diagnostic in context.Diagnostics)
 		{
-			return;
-		}
+			var span = diagnostic.Location.SourceSpan;
+			var node = root.FindNode(span);
 
-		if (!IsPartOfOnlyTypeDeclaration(genericNameNode))
-		{
-			return;
-		}
+			if (node is not GenericNameSyntax genericNameNode)
+			{
+				return;
+			}
 
-		context.RegisterCodeFix(
-			CodeAction.Create(
-				"Use IEnumerable instead of TheoryData",
-				ct => ConvertToIEnumerable(context.Document, genericNameNode, ct),
-				Key_UseIEnumerable
-			),
-			context.Diagnostics
-		);
+			if (!IsPartOfOnlyTypeDeclaration(genericNameNode))
+			{
+				return;
+			}
+
+			context.RegisterCodeFix(
+				CodeAction.Create(
+					"Use IEnumerable instead of TheoryData",
+					ct => ConvertToIEnumerable(context.Document, genericNameNode, ct),
+					Key_UseIEnumerable
+				),
+				diagnostic
+			);
+		}
 	}
 
 	static bool IsPartOfOnlyTypeDeclaration(GenericNameSyntax genericName)

--- a/src/xunit.analyzers.fixes/X1000/TheoryDataShouldNotUseTheoryDataRowFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/TheoryDataShouldNotUseTheoryDataRowFixer.cs
@@ -36,6 +36,11 @@ public class TheoryDataShouldNotUseTheoryDataRowFixer : BatchedCodeFixProvider
 				return;
 			}
 
+			if (genericNameNode.TypeArgumentList.Arguments.Count != 1)
+			{
+				return;
+			}
+
 			if (!IsPartOfOnlyTypeDeclaration(genericNameNode))
 			{
 				return;

--- a/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataShouldNotUseTheoryDataRowTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataShouldNotUseTheoryDataRowTests.cs
@@ -1,0 +1,225 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+using Xunit.Analyzers;
+using Verify = CSharpVerifier<Xunit.Analyzers.TheoryDataShouldNotUseTheoryDataRow>;
+
+public class TheoryDataShouldNotUseTheoryDataRowTests
+{
+	const string strongerType = /* lang=c#-test */ """
+		public class MyRow : ITheoryDataRow {
+			public object?[] GetData() { return null; } 
+			public bool? Explicit { get; }
+			public string? Label { get; }
+			public string? Skip { get; }
+			public Type? SkipType { get; }
+			public string? SkipUnless { get; }
+			public string? SkipWhen { get; }
+			public string? TestDisplayName { get; }
+			public int? Timeout { get; }
+			public Dictionary<string, HashSet<string>>? Traits { get; }
+		}
+		""";
+
+	[Theory]
+	[InlineData("ITheoryDataRow")]
+	[InlineData("MyRow")]
+	public async Task InvalidCombination_Assignment(string type)
+	{
+		var source = string.Format(/* lang=C#-test */ """
+			using Xunit;
+			using System;
+			using System.Collections.Generic;
+			public class Test {{
+				object data = new [|TheoryData<{0}>|]();
+			}}
+
+			{1}
+			""", type, strongerType);
+
+		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
+	}
+
+	[Theory]
+	[InlineData("ITheoryDataRow")]
+	[InlineData("MyRow")]
+	public async Task InvalidCombination_MethodReturnType(string type)
+	{
+		var source = string.Format(/* lang=C#-test */ """
+			using Xunit;
+			using System;
+			using System.Collections.Generic;
+			public class Test {{
+
+				[|TheoryData<{0}>|] GetData() {{ return null; }}
+			}}
+
+			{1}
+			""", type, strongerType);
+
+		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
+	}
+
+	[Theory]
+	[InlineData("ITheoryDataRow")]
+	[InlineData("MyRow")]
+	public async Task ValidCombination_OnlyTheoryDataRow_DoesNotTrigger(string type)
+	{
+		var source = string.Format(/* lang=c#-test */ """
+			using Xunit;
+			using System;
+			using System.Collections.Generic;
+
+			public class TestClass {{
+				IEnumerable<ITheoryDataRow> rows = new List<{0}>();
+			}}
+
+			{1}
+			""", type, strongerType);
+
+		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
+	}
+
+	[Fact]
+	public async Task ValidCombination_OnlyTheoryData_DoesNotTrigger()
+	{
+		var source = /* lang=c#-test */ """
+			using Xunit;
+			using System;
+			using System.Collections.Generic;
+
+			public class TestClass {
+				TheoryData<int, int> rows = new TheoryData<int, int>();
+			}
+			""";
+
+		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
+	}
+
+	[Theory]
+	[InlineData("ITheoryDataRow")]
+	[InlineData("MyRow")]
+	public async Task InvalidCombination_GenericConstraintToStrongerType(string type)
+	{
+		var source = string.Format(/* lang=C#-test */ """
+		using Xunit;
+		using System;
+		using System.Collections.Generic;
+
+		class Test<T> where T : {0} {{
+			[|TheoryData<T>|] data = null;
+		}}
+
+		{1}
+		""", type, strongerType);
+
+		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
+	}
+
+	[Theory]
+	[InlineData("ITheoryDataRow")]
+	[InlineData("MyRow")]
+	public async Task InvalidCombination_Property_UseOfITheoryDataRow(string type)
+	{
+		var source = string.Format(/* lang=C#-test */ """
+		using Xunit;
+		using System;
+		using System.Collections.Generic;
+
+		class Test {{
+			public [|TheoryData<{0}>|] Data {{ get; set; }}
+		}}
+
+		{1}
+		""", type, strongerType);
+
+		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
+	}
+
+	[Theory]
+	[InlineData("ITheoryDataRow")]
+	[InlineData("MyRow")]
+	public async Task InvalidCombination_ArrayOfTheoryDataRow(string type)
+	{
+		var source = string.Format(/* lang=C#-test */ """
+		using Xunit;
+		using System;
+		using System.Collections.Generic;
+
+		class Test {{
+			public [|TheoryData<{0}>|][] AllData = null;
+		}}
+
+		{1}
+		""", type, strongerType);
+
+		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
+	}
+
+	[Theory]
+	[InlineData("ITheoryDataRow")]
+	[InlineData("MyRow")]
+	public async Task InvalidCombination_MultipleMatches_ArrayOfTheoryDataRow(string type)
+	{
+		var source = string.Format(/* lang=C#-test */ """
+		using Xunit;
+		using System;
+		using System.Collections.Generic;
+
+		class Test {{
+			public {{|#0:TheoryData<{0}>|}}[] AllData = new {{|#1:TheoryData<{0}>|}}[1];
+		}}
+
+		{1}
+		""", type, strongerType);
+
+
+		var expected = new[] {
+			Verify.Diagnostic(Descriptors.X1052_TheoryDataShouldNotUseITheoryDataRow.Id).WithLocation(0),
+			Verify.Diagnostic(Descriptors.X1052_TheoryDataShouldNotUseITheoryDataRow.Id).WithLocation(1),
+		};
+
+		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source, expected);
+	}
+
+	[Theory]
+	[InlineData("ITheoryDataRow")]
+	[InlineData("MyRow")]
+	public async Task InvalidCombination_StaticField(string type)
+	{
+		var source = string.Format(/* lang=C#-test */ """
+		using Xunit;
+		using System;
+		using System.Collections.Generic;
+
+		class Test {{
+			private static [|TheoryData<{0}>|] StaticData = null;
+		}}
+
+		{1}
+		""", type, strongerType);
+
+		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
+	}
+
+	[Theory]
+	[InlineData("ITheoryDataRow")]
+	[InlineData("MyRow")]
+	public async Task InvalidCombination_ConstructorParameter(string type)
+	{
+		var source = string.Format(/* lang=C#-test */ """
+		using Xunit;
+		using System;
+		using System.Collections.Generic;
+
+		class Test {{
+			public Test([|TheoryData<{0}>|] data) {{
+			}}
+		}}
+
+		{1}
+		""", type, strongerType);
+
+		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
+	}
+}

--- a/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataShouldNotUseTheoryDataRowTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataShouldNotUseTheoryDataRowTests.cs
@@ -1,245 +1,86 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
-using Xunit.Analyzers;
 using Verify = CSharpVerifier<Xunit.Analyzers.TheoryDataShouldNotUseTheoryDataRow>;
 
 public class TheoryDataShouldNotUseTheoryDataRowTests
 {
-	const string strongerType = /* lang=c#-test */ """
-		public class MyRow : ITheoryDataRow {
-			public object?[] GetData() { return null; } 
-			public bool? Explicit { get; }
-			public string? Label { get; }
-			public string? Skip { get; }
-			public Type? SkipType { get; }
-			public string? SkipUnless { get; }
-			public string? SkipWhen { get; }
-			public string? TestDisplayName { get; }
-			public int? Timeout { get; }
-			public Dictionary<string, HashSet<string>>? Traits { get; }
-		}
-		""";
-
-	[Theory]
-	[InlineData("ITheoryDataRow")]
-	[InlineData("MyRow")]
-	public async Task InvalidCombination_Assignment(string type)
-	{
-		var source = string.Format(/* lang=C#-test */ """
-			using Xunit;
-			using System;
-			using System.Collections.Generic;
-			public class Test {{
-				object data = new [|TheoryData<{0}>|]();
-			}}
-
-			{1}
-			""", type, strongerType);
-
-		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
-	}
-
-	[Theory]
-	[InlineData("ITheoryDataRow")]
-	[InlineData("MyRow")]
-	public async Task InvalidCombination_MethodReturnType(string type)
-	{
-		var source = string.Format(/* lang=C#-test */ """
-			using Xunit;
-			using System;
-			using System.Collections.Generic;
-			public class Test {{
-
-				[|TheoryData<{0}>|] GetData() {{ return null; }}
-			}}
-
-			{1}
-			""", type, strongerType);
-
-		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
-	}
-
-	[Theory]
-	[InlineData("ITheoryDataRow")]
-	[InlineData("MyRow")]
-	public async Task ValidCombination_OnlyTheoryDataRow_DoesNotTrigger(string type)
-	{
-		var source = string.Format(/* lang=c#-test */ """
-			using Xunit;
-			using System;
-			using System.Collections.Generic;
-
-			public class TestClass {{
-				IEnumerable<ITheoryDataRow> rows = new List<{0}>();
-			}}
-
-			{1}
-			""", type, strongerType);
-
-		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
-	}
-
 	[Fact]
-	public async Task ValidCombination_OnlyTheoryData_DoesNotTrigger()
+	public async Task AcceptanceTest()
 	{
-		var source = /* lang=c#-test */ """
-			using Xunit;
+		var source = /* lang=C#-test */ """
 			using System;
 			using System.Collections.Generic;
+			using Xunit;
 
-			public class TestClass {
-				TheoryData<int, int> rows = new TheoryData<int, int>();
+			public class Triggers1 {
+				// Constructors
+				public Triggers1([|TheoryData<ITheoryDataRow>|] data) { }
+				public Triggers1([|TheoryData<TheoryDataRow<int>>|] data) { }
+				public Triggers1([|TheoryData<MyRow>|] data) { }
+
+				// Fields
+				private [|TheoryData<ITheoryDataRow>|] field1 = new [|TheoryData<ITheoryDataRow>|]();
+				private [|TheoryData<TheoryDataRow<int>>|] field2 = new [|TheoryData<TheoryDataRow<int>>|]();
+				private [|TheoryData<MyRow>|] field3 = new [|TheoryData<MyRow>|]();
+
+				// Array fields
+				public [|TheoryData<ITheoryDataRow>|][] field11 = null;
+				public [|TheoryData<TheoryDataRow<int>>|][] field12 = null;
+				public [|TheoryData<MyRow>|][] field13 = null;
+
+				// Static fields
+				private static [|TheoryData<ITheoryDataRow>|] field21 = null;
+				private static [|TheoryData<TheoryDataRow<int>>|] field22 = null;
+				private static [|TheoryData<MyRow>|] field23 = null;
+
+				// Properties
+				public [|TheoryData<ITheoryDataRow>|] property1 { get; set; } = new [|TheoryData<ITheoryDataRow>|]();
+				public [|TheoryData<TheoryDataRow<int>>|] property2 { get; set; } = new [|TheoryData<TheoryDataRow<int>>|]();
+				public [|TheoryData<MyRow>|] property3 { get; set; } = new [|TheoryData<MyRow>|]();
+
+				// Methods
+				public [|TheoryData<ITheoryDataRow>|] Method1() { return null; }
+				public [|TheoryData<TheoryDataRow<int>>|] Method2() { return null; }
+				public [|TheoryData<MyRow>|] Method3() { return null; }
+			}
+
+			// Generic constraints
+			class Triggers2<T> where T : ITheoryDataRow {
+				[|TheoryData<T>|] data = null;
+			}
+
+			class Triggers3<T> where T : MyRow {
+				[|TheoryData<T>|] data = null;
+			}
+
+			public class DoesNotTrigger {
+				IEnumerable<ITheoryDataRow> field1 = new List<ITheoryDataRow>();
+				IEnumerable<TheoryDataRow<int>> field2 = new List<TheoryDataRow<int>>();
+				IEnumerable<MyRow> field3 = new List<MyRow>();
+
+				IEnumerable<ITheoryDataRow> property1 { get; set; } = new List<ITheoryDataRow>();
+				IEnumerable<TheoryDataRow<int>> property2 { get; set; } = new List<TheoryDataRow<int>>();
+				IEnumerable<MyRow> property3 { get; set; } = new List<MyRow>();
+
+				IEnumerable<ITheoryDataRow> method1() { return null; }
+				IEnumerable<TheoryDataRow<int>> method2() { return null; }
+				IEnumerable<MyRow> method3() { return null; }
+			}
+
+			public class MyRow : ITheoryDataRow {
+				public object?[] GetData() { return null; }
+				public bool? Explicit { get; }
+				public string? Label { get; }
+				public string? Skip { get; }
+				public Type? SkipType { get; }
+				public string? SkipUnless { get; }
+				public string? SkipWhen { get; }
+				public string? TestDisplayName { get; }
+				public int? Timeout { get; }
+				public Dictionary<string, HashSet<string>>? Traits { get; }
 			}
 			""";
-
-		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
-	}
-
-	[Theory]
-	[InlineData("ITheoryDataRow")]
-	[InlineData("MyRow")]
-	public async Task InvalidCombination_GenericConstraintToStrongerType(string type)
-	{
-		var source = string.Format(/* lang=C#-test */ """
-		using Xunit;
-		using System;
-		using System.Collections.Generic;
-
-		class Test<T> where T : {0} {{
-			[|TheoryData<T>|] data = null;
-		}}
-
-		{1}
-		""", type, strongerType);
-
-		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
-	}
-
-	[Theory]
-	[InlineData("ITheoryDataRow")]
-	[InlineData("MyRow")]
-	public async Task InvalidCombination_Property_UseOfITheoryDataRow(string type)
-	{
-		var source = string.Format(/* lang=C#-test */ """
-		using Xunit;
-		using System;
-		using System.Collections.Generic;
-
-		class Test {{
-			public [|TheoryData<{0}>|] Data {{ get; set; }}
-		}}
-
-		{1}
-		""", type, strongerType);
-
-		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
-	}
-
-	[Theory]
-	[InlineData("ITheoryDataRow")]
-	[InlineData("MyRow")]
-	public async Task InvalidCombination_ArrayOfTheoryDataRow(string type)
-	{
-		var source = string.Format(/* lang=C#-test */ """
-		using Xunit;
-		using System;
-		using System.Collections.Generic;
-
-		class Test {{
-			public [|TheoryData<{0}>|][] AllData = null;
-		}}
-
-		{1}
-		""", type, strongerType);
-
-		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
-	}
-
-	[Theory]
-	[InlineData("ITheoryDataRow")]
-	[InlineData("MyRow")]
-	public async Task InvalidCombination_MultipleMatches_ArrayOfTheoryDataRow(string type)
-	{
-		var source = string.Format(/* lang=C#-test */ """
-		using Xunit;
-		using System;
-		using System.Collections.Generic;
-
-		class Test {{
-			public {{|#0:TheoryData<{0}>|}}[] AllData = new {{|#1:TheoryData<{0}>|}}[1];
-		}}
-
-		{1}
-		""", type, strongerType);
-
-
-		var expected = new[] {
-			Verify.Diagnostic(Descriptors.X1052_TheoryDataShouldNotUseITheoryDataRow.Id).WithLocation(0),
-			Verify.Diagnostic(Descriptors.X1052_TheoryDataShouldNotUseITheoryDataRow.Id).WithLocation(1),
-		};
-
-		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source, expected);
-	}
-
-	[Theory]
-	[InlineData("ITheoryDataRow")]
-	[InlineData("MyRow")]
-	public async Task InvalidCombination_StaticField(string type)
-	{
-		var source = string.Format(/* lang=C#-test */ """
-		using Xunit;
-		using System;
-		using System.Collections.Generic;
-
-		class Test {{
-			private static [|TheoryData<{0}>|] StaticData = null;
-		}}
-
-		{1}
-		""", type, strongerType);
-
-		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
-	}
-
-	[Theory]
-	[InlineData("ITheoryDataRow")]
-	[InlineData("MyRow")]
-	public async Task InvalidCombination_ConstructorParameter(string type)
-	{
-		var source = string.Format(/* lang=C#-test */ """
-		using Xunit;
-		using System;
-		using System.Collections.Generic;
-
-		class Test {{
-			public Test([|TheoryData<{0}>|] data) {{
-			}}
-		}}
-
-		{1}
-		""", type, strongerType);
-
-		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
-	}
-
-	[Theory]
-	[InlineData("ITheoryDataRow")]
-	[InlineData("MyRow")]
-	public async Task InvalidCombination_ConstructorParameter_WithMultipleGenericArguments(string type)
-	{
-		var source = string.Format(/* lang=C#-test */ """
-		using Xunit;
-		using System;
-		using System.Collections.Generic;
-
-		class Test {{
-			public Test([|TheoryData<{0}, int, int>|] data) {{
-			}}
-		}}
-
-		{1}
-		""", type, strongerType);
 
 		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
 	}

--- a/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataShouldNotUseTheoryDataRowTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/TheoryDataShouldNotUseTheoryDataRowTests.cs
@@ -222,4 +222,25 @@ public class TheoryDataShouldNotUseTheoryDataRowTests
 
 		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
 	}
+
+	[Theory]
+	[InlineData("ITheoryDataRow")]
+	[InlineData("MyRow")]
+	public async Task InvalidCombination_ConstructorParameter_WithMultipleGenericArguments(string type)
+	{
+		var source = string.Format(/* lang=C#-test */ """
+		using Xunit;
+		using System;
+		using System.Collections.Generic;
+
+		class Test {{
+			public Test([|TheoryData<{0}, int, int>|] data) {{
+			}}
+		}}
+
+		{1}
+		""", type, strongerType);
+
+		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp8, source);
+	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/TheoryDataShouldNotUseTheoryDataRowFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/TheoryDataShouldNotUseTheoryDataRowFixerTests.cs
@@ -6,9 +6,9 @@ using Verify = CSharpVerifier<Xunit.Analyzers.TheoryDataShouldNotUseTheoryDataRo
 
 public class TheoryDataShouldNotUseTheoryDataRowFixerTests
 {
-	const string strongerType = /* lang=c#-test */ """
+	const string myRowSource = /* lang=c#-test */ """
 		public class MyRow : ITheoryDataRow {
-			public object?[] GetData() { return null; } 
+			public object?[] GetData() { return null; }
 			public bool? Explicit { get; }
 			public string? Label { get; }
 			public string? Skip { get; }
@@ -21,239 +21,82 @@ public class TheoryDataShouldNotUseTheoryDataRowFixerTests
 		}
 		""";
 
-	[Theory]
-	[InlineData("ITheoryDataRow")]
-	[InlineData("MyRow")]
-	public async Task VariableDeclaration_ToIEnumerable(string type)
+	[Fact]
+	public async Task AcceptanceTest_Fixable()
 	{
-		var before = string.Format(/* lang=c#-test */ """
-			using Xunit;
+		var before = /* lang=c#-test */ """
 			using System;
 			using System.Collections.Generic;
-
-			public class TestClass {{
-				private [|TheoryData<{0}>|] data;
-			}}
-
-			{1}
-			""", type, strongerType);
-
-		var after = string.Format(/* lang=c#-test */ """
 			using Xunit;
+
+			public class TestClass {
+				private [|TheoryData<ITheoryDataRow>|] field1;
+				private [|TheoryData<TheoryDataRow<int>>|] field2;
+				private [|TheoryData<MyRow>|] field3;
+
+				public [|TheoryData<ITheoryDataRow>|] property1 { get; set; }
+				public [|TheoryData<TheoryDataRow<int>>|] property2 { get; set; }
+				public [|TheoryData<MyRow>|] property3 { get; set; }
+
+				public [|TheoryData<ITheoryDataRow>|] method1() {  [|TheoryData<ITheoryDataRow>|] data; return null; }
+				public [|TheoryData<TheoryDataRow<int>>|] method2() { [|TheoryData<TheoryDataRow<int>>|] data; return null; }
+				public [|TheoryData<MyRow>|] method3() { [|TheoryData<MyRow>|] data; return null; }
+			}
+			""" + myRowSource;
+		var after = /* lang=c#-test */ """
 			using System;
 			using System.Collections.Generic;
+			using Xunit;
 
-			public class TestClass {{
-				private IEnumerable<{0}> data;
-			}}
+			public class TestClass {
+				private IEnumerable<ITheoryDataRow> field1;
+				private IEnumerable<TheoryDataRow<int>> field2;
+				private IEnumerable<MyRow> field3;
 
-			{1}
-			""", type, strongerType);
+				public IEnumerable<ITheoryDataRow> property1 { get; set; }
+				public IEnumerable<TheoryDataRow<int>> property2 { get; set; }
+				public IEnumerable<MyRow> property3 { get; set; }
 
-		await Verify.VerifyCodeFixV3(LanguageVersion.CSharp8, before, after, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
+				public IEnumerable<ITheoryDataRow> method1() { IEnumerable<ITheoryDataRow> data; return null; }
+				public IEnumerable<TheoryDataRow<int>> method2() { IEnumerable<TheoryDataRow<int>> data; return null; }
+				public IEnumerable<MyRow> method3() { IEnumerable<MyRow> data; return null; }
+			}
+			""" + myRowSource;
+
+		await Verify.VerifyCodeFixV3(LanguageVersion.CSharp9, before, after, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
 	}
 
-
-	[Theory]
-	[InlineData("ITheoryDataRow")]
-	[InlineData("MyRow")]
-	public async Task PropertyDeclaration_ToIEnumerable(string type)
+	[Fact]
+	public async Task AcceptanceTest_Unfixable()
 	{
-		var before = string.Format(/* lang=c#-test */ """
-			using Xunit;
+		var before = /* lang=c#-test */ """
 			using System;
 			using System.Collections.Generic;
-
-			public class TestClass {{
-				public [|TheoryData<{0}>|] data {{ get; set; }}
-			}}
-
-			{1}
-			""", type, strongerType);
-
-		var after = string.Format(/* lang=c#-test */ """
 			using Xunit;
-			using System;
-			using System.Collections.Generic;
 
-			public class TestClass {{
-				public IEnumerable<{0}> data {{ get; set; }}
-			}}
+			public class TestClass {
+				private [|TheoryData<ITheoryDataRow>|] field11 = new();
+				private [|TheoryData<TheoryDataRow<int>>|] field12 = new();
+				private [|TheoryData<MyRow>|] field13 = new();
 
-			{1}
-			""", type, strongerType);
+				private [|TheoryData<ITheoryDataRow, int>|] field21;
+				private [|TheoryData<TheoryDataRow<int>, int>|] field22;
+				private [|TheoryData<MyRow, int>|] field23;
 
-		await Verify.VerifyCodeFixV3(LanguageVersion.CSharp8, before, after, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
-	}
+				public [|TheoryData<ITheoryDataRow>|] property11 { get; set; } = new();
+				public [|TheoryData<TheoryDataRow<int>>|] property12 { get; set; } = new();
+				public [|TheoryData<MyRow>|] property13 { get; set; } = new();
 
-	[Theory]
-	[InlineData("ITheoryDataRow")]
-	[InlineData("MyRow")]
-	public async Task Parameter_ToIEnumerable(string type)
-	{
-		var before = string.Format(/* lang=c#-test */ """
-			using Xunit;
-			using System;
-			using System.Collections.Generic;
+				public [|TheoryData<ITheoryDataRow, int>|] property21 { get; set; }
+				public [|TheoryData<TheoryDataRow<int>, int>|] property22 { get; set; }
+				public [|TheoryData<MyRow, int>|] property23 { get; set; }
 
-			public class TestClass {{
-				public TestClass([|TheoryData<{0}>|] data) {{ }}
-			}}
+				public [|TheoryData<ITheoryDataRow, int>|] method11() { [|TheoryData<ITheoryDataRow, int>|] data; return null; }
+				public [|TheoryData<TheoryDataRow<int>, int>|] method12() { [|TheoryData<TheoryDataRow<int>, int>|] data; return null; }
+				public [|TheoryData<MyRow, int>|] method13() { [|TheoryData<MyRow, int>|] data; return null; }
+			}
+			""" + myRowSource;
 
-			{1}
-			""", type, strongerType);
-
-		var after = string.Format(/* lang=c#-test */ """
-			using Xunit;
-			using System;
-			using System.Collections.Generic;
-
-			public class TestClass {{
-				public TestClass(IEnumerable<{0}> data) {{ }}
-			}}
-
-			{1}
-			""", type, strongerType);
-
-		await Verify.VerifyCodeFixV3(LanguageVersion.CSharp8, before, after, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
-	}
-
-	[Theory]
-	[InlineData("ITheoryDataRow")]
-	[InlineData("MyRow")]
-	public async Task MethodDeclaration_ToIEnumerable(string type)
-	{
-		var before = string.Format(/* lang=c#-test */ """
-			using Xunit;
-			using System;
-			using System.Collections.Generic;
-
-			public class TestClass {{
-				public [|TheoryData<{0}>|] GetData() {{ return null; }}
-			}}
-
-			{1}
-			""", type, strongerType);
-
-		var after = string.Format(/* lang=c#-test */ """
-			using Xunit;
-			using System;
-			using System.Collections.Generic;
-
-			public class TestClass {{
-				public IEnumerable<{0}> GetData() {{ return null; }}
-			}}
-
-			{1}
-			""", type, strongerType);
-
-		await Verify.VerifyCodeFixV3(LanguageVersion.CSharp8, before, after, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
-	}
-
-
-	[Theory]
-	[InlineData("ITheoryDataRow")]
-	[InlineData("MyRow")]
-	public async Task LocalVariableDeclaration_ToIEnumerable(string type)
-	{
-		var before = string.Format(/* lang=c#-test */ """
-			using Xunit;
-			using System;
-			using System.Collections.Generic;
-
-			public class TestClass {{
-				public TestClass()
-				{{
-					[|TheoryData<{0}>|] data;
-				}}
-			}}
-
-			{1}
-			""", type, strongerType);
-
-		var after = string.Format(/* lang=c#-test */ """
-			using Xunit;
-			using System;
-			using System.Collections.Generic;
-
-			public class TestClass {{
-				public TestClass()
-				{{
-					IEnumerable<{0}> data;
-				}}
-			}}
-
-			{1}
-			""", type, strongerType);
-
-		await Verify.VerifyCodeFixV3(LanguageVersion.CSharp8, before, after, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
-	}
-
-	[Theory]
-	[InlineData("ITheoryDataRow")]
-	[InlineData("MyRow")]
-	public async Task LocalVariableDeclaration_WithMultipleGenericArguments_DoesNotFix(string type)
-	{
-		var before = string.Format(/* lang=c#-test */ """
-			using Xunit;
-			using System;
-			using System.Collections.Generic;
-
-			public class TestClass {{
-				public TestClass()
-				{{
-					[|TheoryData<{0}, int>|] data;
-				}}
-			}}
-
-			{1}
-			""", type, strongerType);
-
-		await Verify.VerifyCodeFixV3(LanguageVersion.CSharp8, before, after: before, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
-	}
-
-	[Theory]
-	[InlineData("ITheoryDataRow")]
-	[InlineData("MyRow")]
-	public async Task VariableDeclaration_WithAssignment_DoesNotFix(string type)
-	{
-		var before = string.Format(/* lang=c#-test */ """
-			using Xunit;
-			using System;
-			using System.Collections.Generic;
-
-			public class TestClass {{
-				public TestClass()
-				{{
-					[|TheoryData<{0}>|] data = new [|TheoryData<{0}>|]();
-				}}
-			}}
-
-			{1}
-			""", type, strongerType);
-
-
-		await Verify.VerifyCodeFixV3(LanguageVersion.CSharp8, before, after: before, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
-	}
-
-	[Theory]
-	[InlineData("ITheoryDataRow")]
-	[InlineData("MyRow")]
-	public async Task PropertyDeclaration_WithAssignment_DoesNotFix(string type)
-	{
-		var before = string.Format(/* lang=c#-test */ """
-			using Xunit;
-			using System;
-			using System.Collections.Generic;
-
-			public class TestClass {{
-				public [|TheoryData<{0}>|] data {{ get; set; }} = new [|TheoryData<{0}>|]();
-			}}
-
-			{1}
-			""", type, strongerType);
-
-
-		await Verify.VerifyCodeFixV3(LanguageVersion.CSharp8, before, after: before, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
+		await Verify.VerifyCodeFixV3(LanguageVersion.CSharp9, before, after: before, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/TheoryDataShouldNotUseTheoryDataRowFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/TheoryDataShouldNotUseTheoryDataRowFixerTests.cs
@@ -1,0 +1,236 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+using Xunit.Analyzers.Fixes;
+using Verify = CSharpVerifier<Xunit.Analyzers.TheoryDataShouldNotUseTheoryDataRow>;
+
+public class TheoryDataShouldNotUseTheoryDataRowFixerTests
+{
+	const string strongerType = /* lang=c#-test */ """
+		public class MyRow : ITheoryDataRow {
+			public object?[] GetData() { return null; } 
+			public bool? Explicit { get; }
+			public string? Label { get; }
+			public string? Skip { get; }
+			public Type? SkipType { get; }
+			public string? SkipUnless { get; }
+			public string? SkipWhen { get; }
+			public string? TestDisplayName { get; }
+			public int? Timeout { get; }
+			public Dictionary<string, HashSet<string>>? Traits { get; }
+		}
+		""";
+
+	[Theory]
+	[InlineData("ITheoryDataRow")]
+	[InlineData("MyRow")]
+	public async Task VariableDeclaration_ToIEnumerable(string type)
+	{
+		var before = string.Format(/* lang=c#-test */ """
+			using Xunit;
+			using System;
+			using System.Collections.Generic;
+
+			public class TestClass {{
+				private [|TheoryData<{0}>|] data;
+			}}
+
+			{1}
+			""", type, strongerType);
+
+		var after = string.Format(/* lang=c#-test */ """
+			using Xunit;
+			using System;
+			using System.Collections.Generic;
+
+			public class TestClass {{
+				private IEnumerable<{0}> data;
+			}}
+
+			{1}
+			""", type, strongerType);
+
+		await Verify.VerifyCodeFixV3(LanguageVersion.CSharp8, before, after, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
+	}
+
+
+	[Theory]
+	[InlineData("ITheoryDataRow")]
+	[InlineData("MyRow")]
+	public async Task PropertyDeclaration_ToIEnumerable(string type)
+	{
+		var before = string.Format(/* lang=c#-test */ """
+			using Xunit;
+			using System;
+			using System.Collections.Generic;
+
+			public class TestClass {{
+				public [|TheoryData<{0}>|] data {{ get; set; }}
+			}}
+
+			{1}
+			""", type, strongerType);
+
+		var after = string.Format(/* lang=c#-test */ """
+			using Xunit;
+			using System;
+			using System.Collections.Generic;
+
+			public class TestClass {{
+				public IEnumerable<{0}> data {{ get; set; }}
+			}}
+
+			{1}
+			""", type, strongerType);
+
+		await Verify.VerifyCodeFixV3(LanguageVersion.CSharp8, before, after, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
+	}
+
+	[Theory]
+	[InlineData("ITheoryDataRow")]
+	[InlineData("MyRow")]
+	public async Task Parameter_ToIEnumerable(string type)
+	{
+		var before = string.Format(/* lang=c#-test */ """
+			using Xunit;
+			using System;
+			using System.Collections.Generic;
+
+			public class TestClass {{
+				public TestClass([|TheoryData<{0}>|] data) {{ }}
+			}}
+
+			{1}
+			""", type, strongerType);
+
+		var after = string.Format(/* lang=c#-test */ """
+			using Xunit;
+			using System;
+			using System.Collections.Generic;
+
+			public class TestClass {{
+				public TestClass(IEnumerable<{0}> data) {{ }}
+			}}
+
+			{1}
+			""", type, strongerType);
+
+		await Verify.VerifyCodeFixV3(LanguageVersion.CSharp8, before, after, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
+	}
+
+	[Theory]
+	[InlineData("ITheoryDataRow")]
+	[InlineData("MyRow")]
+	public async Task MethodDeclaration_ToIEnumerable(string type)
+	{
+		var before = string.Format(/* lang=c#-test */ """
+			using Xunit;
+			using System;
+			using System.Collections.Generic;
+
+			public class TestClass {{
+				public [|TheoryData<{0}>|] GetData() {{ return null; }}
+			}}
+
+			{1}
+			""", type, strongerType);
+
+		var after = string.Format(/* lang=c#-test */ """
+			using Xunit;
+			using System;
+			using System.Collections.Generic;
+
+			public class TestClass {{
+				public IEnumerable<{0}> GetData() {{ return null; }}
+			}}
+
+			{1}
+			""", type, strongerType);
+
+		await Verify.VerifyCodeFixV3(LanguageVersion.CSharp8, before, after, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
+	}
+
+
+	[Theory]
+	[InlineData("ITheoryDataRow")]
+	[InlineData("MyRow")]
+	public async Task LocalVariableDeclaration_ToIEnumerable(string type)
+	{
+		var before = string.Format(/* lang=c#-test */ """
+			using Xunit;
+			using System;
+			using System.Collections.Generic;
+
+			public class TestClass {{
+				public TestClass()
+				{{
+					[|TheoryData<{0}>|] data;
+				}}
+			}}
+
+			{1}
+			""", type, strongerType);
+
+		var after = string.Format(/* lang=c#-test */ """
+			using Xunit;
+			using System;
+			using System.Collections.Generic;
+
+			public class TestClass {{
+				public TestClass()
+				{{
+					IEnumerable<{0}> data;
+				}}
+			}}
+
+			{1}
+			""", type, strongerType);
+
+		await Verify.VerifyCodeFixV3(LanguageVersion.CSharp8, before, after, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
+	}
+
+	[Theory]
+	[InlineData("ITheoryDataRow")]
+	[InlineData("MyRow")]
+	public async Task VariableDeclaration_WithAssignment_DoesNotFix(string type)
+	{
+		var before = string.Format(/* lang=c#-test */ """
+			using Xunit;
+			using System;
+			using System.Collections.Generic;
+
+			public class TestClass {{
+				public TestClass()
+				{{
+					[|TheoryData<{0}>|] data = new [|TheoryData<{0}>|]();
+				}}
+			}}
+
+			{1}
+			""", type, strongerType);
+
+
+		await Verify.VerifyCodeFixV3(LanguageVersion.CSharp8, before, after: before, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
+	}
+
+	[Theory]
+	[InlineData("ITheoryDataRow")]
+	[InlineData("MyRow")]
+	public async Task PropertyDeclaration_WithAssignment_DoesNotFix(string type)
+	{
+		var before = string.Format(/* lang=c#-test */ """
+			using Xunit;
+			using System;
+			using System.Collections.Generic;
+
+			public class TestClass {{
+				public [|TheoryData<{0}>|] data {{ get; set; }} = new [|TheoryData<{0}>|]();
+			}}
+
+			{1}
+			""", type, strongerType);
+
+
+		await Verify.VerifyCodeFixV3(LanguageVersion.CSharp8, before, after: before, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
+	}
+}

--- a/src/xunit.analyzers.tests/Fixes/X1000/TheoryDataShouldNotUseTheoryDataRowFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/TheoryDataShouldNotUseTheoryDataRowFixerTests.cs
@@ -192,6 +192,29 @@ public class TheoryDataShouldNotUseTheoryDataRowFixerTests
 	[Theory]
 	[InlineData("ITheoryDataRow")]
 	[InlineData("MyRow")]
+	public async Task LocalVariableDeclaration_WithMultipleGenericArguments_DoesNotFix(string type)
+	{
+		var before = string.Format(/* lang=c#-test */ """
+			using Xunit;
+			using System;
+			using System.Collections.Generic;
+
+			public class TestClass {{
+				public TestClass()
+				{{
+					[|TheoryData<{0}, int>|] data;
+				}}
+			}}
+
+			{1}
+			""", type, strongerType);
+
+		await Verify.VerifyCodeFixV3(LanguageVersion.CSharp8, before, after: before, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
+	}
+
+	[Theory]
+	[InlineData("ITheoryDataRow")]
+	[InlineData("MyRow")]
 	public async Task VariableDeclaration_WithAssignment_DoesNotFix(string type)
 	{
 		var before = string.Format(/* lang=c#-test */ """

--- a/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
@@ -474,7 +474,13 @@ public static partial class Descriptors
 			"Calls to methods which accept CancellationToken should use TestContext.Current.CancellationToken to allow test cancellation to be more responsive."
 		);
 
-	// Placeholder for rule X1052
+	public static DiagnosticDescriptor X1052_TheoryDataShouldNotUseITheoryDataRow { get; } =
+		Diagnostic(
+			"xUnit1052",
+			"Using 'TheoryData<ITheoryDataRow>' or stronger typed variants is not an expected usage.",
+			Usage,
+			Warning,
+			"Using 'TheoryData<ITheoryDataRow>' or stronger typed variants is not an expected usage, and does not work as expected. Consider using either 'TheoryData' or an type of 'ITheoryDataRow' exclusively.");
 
 	// Placeholder for rule X1053
 
@@ -489,4 +495,6 @@ public static partial class Descriptors
 	// Placeholder for rule X1058
 
 	// Placeholder for rule X1059
+
+	// Placeholder for rule X1060
 }

--- a/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
@@ -480,7 +480,8 @@ public static partial class Descriptors
 			"Avoid using 'TheoryData<T>' with types that implement 'ITheoryDataRow'.",
 			Usage,
 			Warning,
-			"'TheoryData<...>' should not be used with one or more type arguments that implement 'ITheoryDataRow' or a derived variant. This usage is not supported. Use either 'TheoryData' or a type of 'ITheoryDataRow' exclusively.");
+			"'TheoryData<...>' should not be used with one or more type arguments that implement 'ITheoryDataRow' or a derived variant. This usage is not supported. Use either 'TheoryData' or a type of 'ITheoryDataRow' exclusively."
+		);
 
 	// Placeholder for rule X1053
 

--- a/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
@@ -477,7 +477,7 @@ public static partial class Descriptors
 	public static DiagnosticDescriptor X1052_TheoryDataShouldNotUseITheoryDataRow { get; } =
 		Diagnostic(
 			"xUnit1052",
-			"Avoid using 'TheoryData<T>' with types that implement 'ITheoryDataRow'.",
+			"Avoid using 'TheoryData<...>' with types that implement 'ITheoryDataRow'.",
 			Usage,
 			Warning,
 			"'TheoryData<...>' should not be used with one or more type arguments that implement 'ITheoryDataRow' or a derived variant. This usage is not supported. Use either 'TheoryData' or a type of 'ITheoryDataRow' exclusively."

--- a/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
@@ -477,10 +477,10 @@ public static partial class Descriptors
 	public static DiagnosticDescriptor X1052_TheoryDataShouldNotUseITheoryDataRow { get; } =
 		Diagnostic(
 			"xUnit1052",
-			"Using 'TheoryData<ITheoryDataRow>' or stronger typed variants is not an expected usage.",
+			"Avoid using 'TheoryData<T>' with types that implement 'ITheoryDataRow'.",
 			Usage,
 			Warning,
-			"Using 'TheoryData<ITheoryDataRow>' or stronger typed variants is not an expected usage, and does not work as expected. Consider using either 'TheoryData' or an type of 'ITheoryDataRow' exclusively.");
+			"'TheoryData<...>' should not be used with one or more type arguments that implement 'ITheoryDataRow' or a derived variant. This usage is not supported. Use either 'TheoryData' or a type of 'ITheoryDataRow' exclusively.");
 
 	// Placeholder for rule X1053
 

--- a/src/xunit.analyzers/X1000/TheoryDataShouldNotUseTheoryDataRow.cs
+++ b/src/xunit.analyzers/X1000/TheoryDataShouldNotUseTheoryDataRow.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Xunit.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class TheoryDataShouldNotUseTheoryDataRow : XunitV3DiagnosticAnalyzer
+{
+	public TheoryDataShouldNotUseTheoryDataRow() : base(Descriptors.X1052_TheoryDataShouldNotUseITheoryDataRow) { }
+
+	public override void AnalyzeCompilation(CompilationStartAnalysisContext context, XunitContext xunitContext)
+	{
+		Guard.ArgumentNotNull(context);
+		Guard.ArgumentNotNull(xunitContext);
+
+		Dictionary<int, INamedTypeSymbol> theoryDataDict = TypeSymbolFactory.TheoryData_ByGenericArgumentCount(context.Compilation);
+		INamedTypeSymbol? itheoryDataRowSymbol = TypeSymbolFactory.ITheoryDataRow_V3(context.Compilation);
+
+		if (itheoryDataRowSymbol is null)
+		{
+			return;
+		}
+
+		context.RegisterSyntaxNodeAction(context =>
+		{
+			var genericName = (GenericNameSyntax)context.Node;
+			ISymbol? symbol = context.SemanticModel.GetSymbolInfo(genericName).Symbol;
+
+			if (symbol is null)
+			{
+				return;
+			}
+
+			if (symbol is not INamedTypeSymbol typeSymbol)
+			{
+				return;
+			}
+
+			if (!theoryDataDict.TryGetValue(typeSymbol.TypeArguments.Length, out var expectedSymbol))
+			{
+				return;
+			}
+
+			if (!SymbolEqualityComparer.Default.Equals(expectedSymbol, typeSymbol.OriginalDefinition))
+			{
+				return;
+			}
+
+			foreach (var typeArg in typeSymbol.TypeArguments)
+			{
+				if (IsOrImplementsITheoryDataRow(typeArg, itheoryDataRowSymbol))
+				{
+					context.ReportDiagnostic(
+							Diagnostic.Create(Descriptors.X1052_TheoryDataShouldNotUseITheoryDataRow, genericName.GetLocation()));
+				}
+			}
+
+		}, SyntaxKind.GenericName);
+	}
+
+
+	private static bool IsOrImplementsITheoryDataRow(ITypeSymbol typeArg, INamedTypeSymbol itheoryDataSymbol)
+	{
+		if (SymbolEqualityComparer.Default.Equals(typeArg, itheoryDataSymbol) ||
+		   typeArg.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, itheoryDataSymbol)))
+		{
+			return true;
+		}
+
+		if (typeArg is ITypeParameterSymbol typeParameter)
+		{
+			foreach (var constraint in typeParameter.ConstraintTypes)
+			{
+				if (SymbolEqualityComparer.Default.Equals(constraint, itheoryDataSymbol) ||
+					constraint.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, itheoryDataSymbol)))
+				{
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
## Addresses [issue #3113](https://github.com/xunit/xunit/issues/3113) - Add analyzer to flag using ITheoryDataRow inside of TheoryData

Includes:
- Analyzer to detect `TheoryData<ITheoryDataRow>` and stronger types
- Added code fix to suggest` IEnumerable<ITheoryDataRow>` 
- Analyzer/Codefix tests

Note: This is my first time contributing to this project and also my first time writing a Roslyn analyzer, so I wasn’t completely sure about some of the design decisions. Feedback is very welcome!

For instance, I was not sure if a code fix should be provided in such a scenario:
```
TheoryData<ITheoryDataRow> GetData() { return null; } // Currently: Codefix enabled, but could lead to invalid code (depending on method implementation)
```
