### PR TITLE
xunit/xunit#1258 Analyzer for uninitialized member data

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
@@ -1528,12 +1528,22 @@ public class MemberDataShouldReferenceValidMemberTests
 					public static TheoryData<int> Property { get; } = null;
 					public static TheoryData<int> PropertyWithGetBody { get { return null; } }
 					public static TheoryData<int> PropertyWithGetExpression => null;
+					public static TheoryData<int> FieldWrittenInStaticConstructor;
+					public static TheoryData<int> PropertyWrittenInStaticConstructor { get; set; }
+
+					static TestClass()
+					{
+						FieldWrittenInStaticConstructor = null;
+						PropertyWrittenInStaticConstructor = null;
+					}
 
 					[Theory]
 					[MemberData(nameof(Field))]
 					[MemberData(nameof(Property))]
 					[MemberData(nameof(PropertyWithGetBody))]
 					[MemberData(nameof(PropertyWithGetExpression))]
+					[MemberData(nameof(FieldWrittenInStaticConstructor))]
+					[MemberData(nameof(PropertyWrittenInStaticConstructor))]
 					public void TestCase(int _) {}
 				}
 			""";

--- a/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
@@ -12,6 +12,7 @@ public class MemberDataShouldReferenceValidMemberTests
 		{
 			var source = /* lang=c#-test */ """
 				#pragma warning disable xUnit1053
+
 				using System.Collections.Generic;
 				using Xunit;
 
@@ -151,6 +152,7 @@ public class MemberDataShouldReferenceValidMemberTests
 		{
 			var source = /* lang=c#-test */ """
 				#pragma warning disable xUnit1053
+
 				using System;
 				using System.Collections.Generic;
 				using Xunit;
@@ -376,6 +378,7 @@ public class MemberDataShouldReferenceValidMemberTests
 		{
 			var source = /* lang=c#-test */ """
 				#pragma warning disable xUnit1053
+
 				using Xunit;
 
 				public class TestClass {
@@ -405,6 +408,7 @@ public class MemberDataShouldReferenceValidMemberTests
 		{
 			var source = /* lang=c#-test */ """
 				#pragma warning disable xUnit1053
+
 				using Xunit;
 
 				public class TestClassBase {
@@ -1368,6 +1372,7 @@ public class MemberDataShouldReferenceValidMemberTests
 		{
 			var source = /* lang=c#-test */ """
 				#pragma warning disable xUnit1053
+
 				using System.Collections.Generic;
 				using Xunit;
 
@@ -1417,6 +1422,7 @@ public class MemberDataShouldReferenceValidMemberTests
 		{
 			var source = /* lang=c#-test */ """
 				#pragma warning disable xUnit1053
+
 				using System.Collections.Generic;
 				using System.Threading.Tasks;
 				using Xunit;

--- a/src/xunit.analyzers.tests/Fixes/X1000/MemberDataShouldReferenceValidMember_NameOfFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/MemberDataShouldReferenceValidMember_NameOfFixerTests.cs
@@ -14,7 +14,7 @@ public class MemberDataShouldReferenceValidMember_NameOfFixerTests
 			using Xunit;
 
 			public class TestClass {
-				public static TheoryData<int> DataSource;
+				public static TheoryData<int> DataSource = new TheoryData<int>();
 
 				[Theory]
 				[MemberData({|xUnit1014:"DataSource"|})]
@@ -27,7 +27,7 @@ public class MemberDataShouldReferenceValidMember_NameOfFixerTests
 			using Xunit;
 
 			public class TestClass {
-				public static TheoryData<int> DataSource;
+				public static TheoryData<int> DataSource = new TheoryData<int>();
 
 				[Theory]
 				[MemberData(nameof(DataSource))]

--- a/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
@@ -483,7 +483,14 @@ public static partial class Descriptors
 			"'TheoryData<...>' should not be used with one or more type arguments that implement 'ITheoryDataRow' or a derived variant. This usage is not supported. Use either 'TheoryData' or a type of 'ITheoryDataRow' exclusively."
 		);
 
-	// Placeholder for rule X1053
+	public static DiagnosticDescriptor X1053_MemberDataMemberMustBeStaticallyWrittenTo { get; } =
+		Diagnostic(
+			"xUnit1053",
+			"The static member used as theory data must be statically initialized.",
+			Usage,
+			Warning,
+			"The member {0} referenced by MemberData is not initialized before use."
+		);
 
 	// Placeholder for rule X1054
 

--- a/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
@@ -489,7 +489,7 @@ public static partial class Descriptors
 			"The static member used as theory data must be statically initialized.",
 			Usage,
 			Warning,
-			"The member {0} referenced by MemberData is not initialized before use."
+			"The member {0} referenced by MemberData is not initialized before use. Add an inline initializer or initialize the value in the static constructor."
 		);
 
 	// Placeholder for rule X1054


### PR DESCRIPTION
Initial implementation of an analyzer that verifies `MemberData` has an associated initializer expression or static constructor.

This PR is in Draft to solicit feedback on test cases that still need covering and guidance on how to preferrably handle existing test cases generating new analyzer results now that there is a stricter analyzer.