### PR TITLE
Fix X2022: Preserve all arguments when fixing negated boolean assertions

### DIFF
--- a/src/xunit.analyzers.fixes/X2000/BooleanAssertsShouldNotBeNegatedFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/BooleanAssertsShouldNotBeNegatedFixer.cs
@@ -58,12 +58,20 @@ public class BooleanAssertsShouldNotBeNegatedFixer : XunitCodeFixProvider
 
 		if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
 			if (invocation.ArgumentList.Arguments[0].Expression is PrefixUnaryExpressionSyntax prefixUnaryExpression)
+			{
+				var newArguments = invocation.ArgumentList.Arguments
+					.Select((arg, index) => index == 0
+						? Argument(prefixUnaryExpression.Operand).WithTriviaFrom(arg)
+						: arg)
+					.ToArray();
+
 				editor.ReplaceNode(
 					invocation,
 					invocation
-						.WithArgumentList(ArgumentList(SeparatedList([Argument(prefixUnaryExpression.Operand)])))
+						.WithArgumentList(ArgumentList(SeparatedList(newArguments)))
 						.WithExpression(memberAccess.WithName(IdentifierName(replacement)))
 				);
+			}
 
 		return editor.GetChangedDocument();
 	}

--- a/src/xunit.analyzers.tests/Fixes/X2000/BooleanAssertsShouldNotBeNegatedFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/BooleanAssertsShouldNotBeNegatedFixerTests.cs
@@ -30,4 +30,44 @@ public class BooleanAssertsShouldNotBeNegatedFixerTests
 
 		await Verify.VerifyCodeFix(before, after, BooleanAssertsShouldNotBeNegatedFixer.Key_UseSuggestedAssert);
 	}
+
+	[Theory]
+	[InlineData("False", "True")]
+	[InlineData("True", "False")]
+	public async Task WithUserMessage_PreservesAdditionalArgument(
+	string assertion,
+	string replacement)
+	{
+		var before = string.Format(template, $"[|Assert.{assertion}(!condition, userMessage: \"Custom message\")|]");
+		var after = string.Format(template, $"Assert.{replacement}(condition, userMessage: \"Custom message\")");
+
+		await Verify.VerifyCodeFix(before, after, BooleanAssertsShouldNotBeNegatedFixer.Key_UseSuggestedAssert);
+	}
+
+	[Theory]
+	[InlineData("False", "True")]
+	[InlineData("True", "False")]
+	public async Task WithMultipleArguments_PreservesAllAdditionalArguments(
+	string assertion,
+	string replacement)
+	{
+		var before = string.Format(template, $"[|Assert.{assertion}(!condition, \"message {0}\", 42)|]");
+		var after = string.Format(template, $"Assert.{replacement}(condition, \"message {0}\", 42)");
+
+		await Verify.VerifyCodeFix(before, after, BooleanAssertsShouldNotBeNegatedFixer.Key_UseSuggestedAssert);
+	}
+
+	[Theory]
+	[InlineData("False", "True")]
+	[InlineData("True", "False")]
+	public async Task WithNamedArguments_PreservesAllArguments(
+	string assertion,
+	string replacement)
+	{
+		var before = string.Format(template, $"[|Assert.{assertion}(condition: !condition, userMessage: \"test\")|]");
+		var after = string.Format(template, $"Assert.{replacement}(condition: condition, userMessage: \"test\")");
+
+		await Verify.VerifyCodeFix(before, after, BooleanAssertsShouldNotBeNegatedFixer.Key_UseSuggestedAssert);
+	}
+
 }


### PR DESCRIPTION
Fixes xunit/xunit#3446 - Code fixer was incorrectly removing second argument (userMessage) when converting Assert.True(!false) to Assert.False(false)

- Modified BooleanAssertsShouldNotBeNegatedFixer to preserve all arguments
- Added tests for userMessage, multiple arguments, and named arguments
- Existing test case continues to work as before