### PR TITLE
Fix X1019: Added special-cases handling to correctly validate types convertible to IEnumerable<T[]>

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -197,26 +195,6 @@ public class MemberDataShouldReferenceValidMemberTests
 		const string V2AllowedTypes = "'System.Collections.Generic.IEnumerable<object[]>'";
 		const string V3AllowedTypes = "'System.Collections.Generic.IEnumerable<object[]>', 'System.Collections.Generic.IAsyncEnumerable<object[]>', 'System.Collections.Generic.IEnumerable<Xunit.ITheoryDataRow>', 'System.Collections.Generic.IAsyncEnumerable<Xunit.ITheoryDataRow>', 'System.Collections.Generic.IEnumerable<System.Runtime.CompilerServices.ITuple>', or 'System.Collections.Generic.IAsyncEnumerable<System.Runtime.CompilerServices.ITuple>'";
 
-		public sealed class ValidExamples : IEnumerable<string[]>
-		{
-			private readonly List<string[]> _items = [];
-
-			public void Add(string sdl)
-			{
-				_items.Add([sdl]);
-			}
-
-			public IEnumerator<string[]> GetEnumerator()
-			{
-				return _items.GetEnumerator();
-			}
-
-			IEnumerator IEnumerable.GetEnumerator()
-			{
-				return GetEnumerator();
-			}
-		}
-
 		[Fact]
 		public async ValueTask V2_and_V3()
 		{
@@ -229,7 +207,7 @@ public class MemberDataShouldReferenceValidMemberTests
 				using System.Collections.Generic;
 				using System.Threading.Tasks;
 				using Xunit;
-				
+
 				public class NamedTypeForIEnumerableStringArray : IEnumerable<string[]>
 				{
 				    private readonly List<string[]> _items = new List<string[]>();
@@ -238,18 +216,18 @@ public class MemberDataShouldReferenceValidMemberTests
 				    {
 				        _items.Add(new string[] { sdl });
 				    }
-				
+
 				    public IEnumerator<string[]> GetEnumerator()
 				    {
 				        return _items.GetEnumerator();
 				    }
-				
+
 				    IEnumerator IEnumerable.GetEnumerator()
 				    {
 				        return GetEnumerator();
 				    }
 				}
-				
+
 				public class NamedSubtypeForIEnumerableStringArray : NamedTypeForIEnumerableStringArray {}
 
 				public class TestClass {
@@ -257,7 +235,7 @@ public class MemberDataShouldReferenceValidMemberTests
 					public static object NakedObjectSource;
 					public static object[] NakedObjectArraySource;
 					public static object[][] NakedObjectMatrixSource;
-				
+
 					public static IEnumerable<object[]> ObjectArraySource;
 					public static IEnumerable<string[]> StringArraySource;
 					public static NamedTypeForIEnumerableStringArray NamedTypeForIEnumerableStringArraySource;
@@ -1452,7 +1430,7 @@ public class MemberDataShouldReferenceValidMemberTests
 					[{|#1:MemberData(nameof(PropertyUntypedData))|}]
 					[{|#2:MemberData(nameof(MethodUntypedData))|}]
 					[{|#3:MemberData(nameof(MethodWithArgsUntypedData), 42)|}]
-					
+
 					public void TestMethod2(int _) { }
 				}
 				""";

--- a/src/xunit.analyzers/X1000/MemberDataShouldReferenceValidMember.cs
+++ b/src/xunit.analyzers/X1000/MemberDataShouldReferenceValidMember.cs
@@ -291,6 +291,42 @@ public class MemberDataShouldReferenceValidMember : XunitDiagnosticAnalyzer
 		return null;
 	}
 
+	static ITypeSymbol? FindTypeArgumentFromIEnumerable(
+		ITypeSymbol? start,
+		Compilation compilation)
+	{
+		if (start is not INamedTypeSymbol namedStart)
+			return null;
+
+		var iEnumerableOfT = TypeSymbolFactory.IEnumerableOfT(compilation);
+		if (iEnumerableOfT is null)
+			return null;
+
+		var current = namedStart;
+		while (current != null)
+		{
+			// If this class implements IEnumerable<T>, return T type argument
+			foreach (var iface in current.AllInterfaces)
+				if (SymbolEqualityComparer.Default.Equals(iface.OriginalDefinition, iEnumerableOfT))
+					return iface.TypeArguments.FirstOrDefault();
+
+			// Navigate to its Base types to investigate if they implement IEnumerable,
+			// attempt to resolve the base type from the source syntax (handles `: ValidExamples`).
+			var declaredBase = ResolveDeclaredBaseTypeFromSyntax(current, compilation) as INamedTypeSymbol;
+
+			// Prefer declaredBase when available; otherwise fall back to the BaseType symbol.
+			var next = declaredBase ?? current.BaseType;
+
+			// Stop if we reached object
+			if (next?.SpecialType == SpecialType.System_Object)
+				break;
+
+			current = next;
+		}
+
+		return null;
+	}
+
 	public static (INamedTypeSymbol? TestClass, ITypeSymbol? MemberClass) GetClassTypesForAttribute(
 		AttributeArgumentListSyntax attributeList,
 		SemanticModel semanticModel,
@@ -319,7 +355,7 @@ public class MemberDataShouldReferenceValidMember : XunitDiagnosticAnalyzer
 		List<AttributeArgumentSyntax> arguments, SemanticModel semanticModel)
 	{
 		if (arguments.Count > 1)
-			return arguments.Select(a => a.Expression).ToList();
+			return [.. arguments.Select(a => a.Expression)];
 		if (arguments.Count != 1)
 			return null;
 
@@ -673,6 +709,52 @@ public class MemberDataShouldReferenceValidMember : XunitDiagnosticAnalyzer
 		);
 	}
 
+	/// <summary>
+	/// Resolve declared base type and find the first base class that implements IEnumerable
+	/// (e.g. "ValidExample" from "class SubtypeValidExample : ValidExample {}")
+	/// </summary>
+	static ITypeSymbol? ResolveDeclaredBaseTypeFromSyntax(
+		ITypeSymbol type,
+		Compilation compilation)
+	{
+		if (type is null)
+			return null;
+
+		// Look through source declarations for an explicit base type in the syntax.
+		foreach (var declaringReference in type.DeclaringSyntaxReferences)
+		{
+			var syntax = declaringReference.GetSyntax();
+			if (syntax is ClassDeclarationSyntax cls && cls.BaseList is not null && cls.BaseList.Types.Count > 0)
+			{
+				var baseTypeSyntax = cls.BaseList.Types.First().Type;
+				var baseTypeName = baseTypeSyntax.ToString(); // may be qualified
+
+				// Try direct metadata lookup first (works for namespace-qualified names)
+				var byMetadata = compilation.GetTypeByMetadataName(baseTypeName);
+				if (byMetadata is not null)
+					return byMetadata;
+
+				// Fallback: search symbols by the simple name and try to match fully-qualified textual form.
+				var simpleName = baseTypeName.Split('.').Last();
+				var candidates =
+					compilation
+						.GetSymbolsWithName(n => n == simpleName, SymbolFilter.Type)
+						.OfType<INamedTypeSymbol>()
+						.ToList();
+
+				// Prefer exact textual match of declared name (handles namespace-qualified baseTypeSyntax)
+				var exact = candidates.FirstOrDefault(c => string.Equals(c.ToDisplayString(), baseTypeName, StringComparison.Ordinal));
+				if (exact is not null)
+					return exact;
+
+				// Otherwise return the first candidate in the current compilation with the simple name
+				return candidates.FirstOrDefault();
+			}
+		}
+
+		return null;
+	}
+
 	static void VerifyDataMethodParameterUsage(
 		SemanticModel semanticModel,
 		SyntaxNodeAnalysisContext context,
@@ -830,9 +912,7 @@ public class MemberDataShouldReferenceValidMember : XunitDiagnosticAnalyzer
 		{
 			var resolvedIEnumerableTypeArgument = FindTypeArgumentFromIEnumerable(memberType, compilation);
 			if (resolvedIEnumerableTypeArgument is not null)
-			{
 				valid = (resolvedIEnumerableTypeArgument.TypeKind == TypeKind.Array);
-			}
 		}
 
 		if (!valid)
@@ -947,86 +1027,5 @@ public class MemberDataShouldReferenceValidMember : XunitDiagnosticAnalyzer
 
 			ReportMemberMethodTheoryDataExtraTypeArguments(context, attributeSyntax.GetLocation(), builder, theoryDataType);
 		}
-	}
-
-	/// <summary>
-	/// Resolve declared base type and find the first base class that implements IEnumerable
-	/// (e.g. "ValidExample" from "class SubtypeValidExample : ValidExample {}")
-	/// </summary>
-	static ITypeSymbol? ResolveDeclaredBaseTypeFromSyntax(ITypeSymbol type, Compilation compilation)
-	{
-		if (type is null)
-			return null;
-
-		// Look through source declarations for an explicit base type in the syntax.
-		foreach (var declaringReference in type.DeclaringSyntaxReferences)
-		{
-			var syntax = declaringReference.GetSyntax();
-			if (syntax is ClassDeclarationSyntax cls && cls.BaseList is not null && cls.BaseList.Types.Count > 0)
-			{
-				var baseTypeSyntax = cls.BaseList.Types.First().Type;
-				var baseTypeName = baseTypeSyntax.ToString(); // may be qualified
-
-				// Try direct metadata lookup first (works for namespace-qualified names)
-				var byMetadata = compilation.GetTypeByMetadataName(baseTypeName);
-				if (byMetadata is not null)
-					return byMetadata;
-
-				// Fallback: search symbols by the simple name and try to match fully-qualified textual form.
-				var simpleName = baseTypeName.Split('.').Last();
-				var candidates = compilation.GetSymbolsWithName(n => n == simpleName, SymbolFilter.Type)
-					.OfType<INamedTypeSymbol>();
-
-				// In ResolveDeclaredBaseTypeFromSyntax, avoid multiple enumerations of 'candidates'
-				var candidatesList = candidates.ToList();
-
-				// Prefer exact textual match of declared name (handles namespace-qualified baseTypeSyntax)
-				var exact = candidatesList.FirstOrDefault(c => string.Equals(c.ToDisplayString(), baseTypeName, StringComparison.Ordinal));
-				if (exact is not null)
-					return exact;
-
-				// Otherwise return the first candidate in the current compilation with the simple name
-				return candidatesList.FirstOrDefault();
-			}
-		}
-		return null;
-	}
-
-	static ITypeSymbol? FindTypeArgumentFromIEnumerable(ITypeSymbol? start, Compilation compilation)
-	{
-		if (start is not INamedTypeSymbol namedStart)
-			return null;
-
-		var iEnumerableDef = compilation.GetTypeByMetadataName("System.Collections.Generic.IEnumerable`1");
-		if (iEnumerableDef is null)
-			return null;
-
-		var current = namedStart;
-		while (current != null)
-		{
-			// If this class implements IEnumerable<T>, return T type argument
-			foreach (var iface in current.AllInterfaces)
-			{
-				if (SymbolEqualityComparer.Default.Equals(iface.OriginalDefinition, iEnumerableDef))
-				{
-					return iface.TypeArguments.FirstOrDefault();
-				}
-			}
-
-			// Navigate to its Base types to investigate if they implement IEnumerable,
-			// attempt to resolve the base type from the source syntax (handles `: ValidExamples`).
-			var declaredBase = ResolveDeclaredBaseTypeFromSyntax(current, compilation) as INamedTypeSymbol;
-
-			// Prefer declaredBase when available; otherwise fall back to the BaseType symbol.
-			var next = declaredBase ?? (current.BaseType as INamedTypeSymbol);
-
-			// Stop if we reached object
-			if (next?.SpecialType == SpecialType.System_Object)
-				break;
-
-			current = next;
-		}
-
-		return null;
 	}
 }


### PR DESCRIPTION
Fixes [xunit/xunit#3411](https://github.com/xunit/xunit/issues/3411)

### Added special-cases handling to MemberDataShouldReferenceValidMember.cs

- Extracts the generic argument `T` from `IEnumerable<T>` and treats any array type (`T[]`) as assignable to `object[]`. This enables `IEnumerable<string[]>` to be recognized as a valid MemberData reference type.
- Adds support for named types that are convertible to `IEnumerable<T[]>` by analyzing their source‑declared type syntax. As a result, classes declared such as `class NamedTypeForIEnumerableStringArray : IEnumerable<string[]>` are now correctly identified as valid MemberData reference types.

Alternatives explored:
- While evaluating `compilation.ClassifyConversion(fromType, toType)`, I found that Roslyn often reports `IsImplicit = true` for conversions that are not actually valid at runtime. Because of this, it isn’t a reliable mechanism for determining true assignability or convertibility between types.
- When resolving named types, I wasn’t able to reliably extract the concrete generic argument using only `ITypeSymbol` / `INamedTypeSymbol`. For example, in the case of `NamedTypeForIEnumerableStringArray` class, the implemented interface appeared as `IEnumerable<T>` rather than `IEnumerable<string[]>`, which prevents inspection of the actual generic type argument. To address this, I leveraged the source‑declared type syntax instead, allowing me to accurately extract the generic argument and walk the declared base‑type chain.

### Tests updated to cover these scenarios and ensure existing diagnostics remain stable.

### Notes
I’d welcome any feedback on this, as it’s my first contribution to this repository. Some of the logic I introduced could potentially be folded into `SymbolExtensions.IsAssignableFrom()` to improve its handling of special‑case assignability scenarios, particularly where non‑exact matches are interesting. However, since that method is widely used across the codebase, I opted to implement the special‑case handling locally to avoid unintended regressions, especially given my limited familiarity with the repo.