### PR TITLE
Fix AD0001 in MemberDataShouldReferenceValidMember for metadata symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -409,3 +409,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea/

--- a/src/xunit.analyzers/X1000/MemberDataShouldReferenceValidMember.cs
+++ b/src/xunit.analyzers/X1000/MemberDataShouldReferenceValidMember.cs
@@ -207,6 +207,9 @@ public class MemberDataShouldReferenceValidMember : XunitDiagnosticAnalyzer
 		if (!memberSymbol.IsStatic || memberSymbol is IMethodSymbol)
 			// assume initialized, if nonstatic or method to avoid spurious results
 			return true;
+		
+		if (memberSymbol.DeclaringSyntaxReferences.IsEmpty)
+			return true;
 
 		var semantics = context.SemanticModel;
 		var declarationReference = memberSymbol.DeclaringSyntaxReferences.First();

--- a/src/xunit.analyzers/X1000/MemberDataShouldReferenceValidMember.cs
+++ b/src/xunit.analyzers/X1000/MemberDataShouldReferenceValidMember.cs
@@ -207,7 +207,7 @@ public class MemberDataShouldReferenceValidMember : XunitDiagnosticAnalyzer
 		if (!memberSymbol.IsStatic || memberSymbol is IMethodSymbol)
 			// assume initialized, if nonstatic or method to avoid spurious results
 			return true;
-		
+
 		if (memberSymbol.DeclaringSyntaxReferences.IsEmpty)
 			return true;
 


### PR DESCRIPTION
Fixes xunit/xunit#3474

Prevent a crash in `MemberDataShouldReferenceValidMember` when analyzing metadata symbols from referenced projects by guarding against empty `DeclaringSyntaxReferences`.
