### PR TITLE
Enable Fix All functionality where it is safe to do so

### DIFF
--- a/src/xunit.analyzers.fixes/Utility/XunitCodeFixProvider.cs
+++ b/src/xunit.analyzers.fixes/Utility/XunitCodeFixProvider.cs
@@ -10,6 +10,6 @@ public abstract class XunitCodeFixProvider(params string[] diagnostics) :
 	public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } = diagnostics.ToImmutableArray();
 #pragma warning restore IDE0305
 
-	public sealed override FixAllProvider? GetFixAllProvider() =>
+	public override FixAllProvider? GetFixAllProvider() =>
 		null;
 }

--- a/src/xunit.analyzers.fixes/X1000/CollectionDefinitionClassesMustBePublicFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/CollectionDefinitionClassesMustBePublicFixer.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -15,6 +16,8 @@ public class CollectionDefinitionClassesMustBePublicFixer : XunitCodeFixProvider
 	public CollectionDefinitionClassesMustBePublicFixer() :
 		base(Descriptors.X1027_CollectionDefinitionClassMustBePublic.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X1000/ConvertToFactFix.cs
+++ b/src/xunit.analyzers.fixes/X1000/ConvertToFactFix.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -17,6 +18,8 @@ public class ConvertToFactFix : XunitCodeFixProvider
 			Descriptors.X1006_TheoryMethodShouldHaveParameters.Id
 		)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X1000/ConvertToTheoryFix.cs
+++ b/src/xunit.analyzers.fixes/X1000/ConvertToTheoryFix.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -17,6 +18,8 @@ public class ConvertToTheoryFix : XunitCodeFixProvider
 			Descriptors.X1005_FactMethodShouldNotHaveTestData.Id
 		)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X1000/DataAttributeShouldBeUsedOnATheoryFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/DataAttributeShouldBeUsedOnATheoryFixer.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -19,6 +20,8 @@ public class DataAttributeShouldBeUsedOnATheoryFixer : XunitCodeFixProvider
 	public DataAttributeShouldBeUsedOnATheoryFixer() :
 		base(Descriptors.X1008_DataAttributeShouldBeUsedOnATheory.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X1000/DoNotUseAsyncVoidForTestMethodsFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/DoNotUseAsyncVoidForTestMethodsFixer.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -18,6 +19,8 @@ public class DoNotUseAsyncVoidForTestMethodsFixer : XunitMemberFixProvider
 			Descriptors.X1049_DoNotUseAsyncVoidForTestMethods_V3.Id
 		)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public override async Task RegisterCodeFixesAsync(
 		CodeFixContext context,

--- a/src/xunit.analyzers.fixes/X1000/DoNotUseConfigureAwaitFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/DoNotUseConfigureAwaitFixer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -18,6 +19,8 @@ public class DoNotUseConfigureAwaitFixer : XunitCodeFixProvider
 	public DoNotUseConfigureAwaitFixer() :
 		base(Descriptors.X1030_DoNotUseConfigureAwait.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X1000/FactMethodMustNotHaveParametersFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/FactMethodMustNotHaveParametersFixer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -17,6 +18,8 @@ public class FactMethodMustNotHaveParametersFixer : XunitCodeFixProvider
 	public FactMethodMustNotHaveParametersFixer() :
 		base(Descriptors.X1001_FactMethodMustNotHaveParameters.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X1000/FactMethodShouldNotHaveTestDataFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/FactMethodShouldNotHaveTestDataFixer.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -15,6 +16,8 @@ public class FactMethodShouldNotHaveTestDataFixer : XunitCodeFixProvider
 	public FactMethodShouldNotHaveTestDataFixer() :
 		base(Descriptors.X1005_FactMethodShouldNotHaveTestData.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X1000/InlineDataMustMatchTheoryParameters_ExtraValueFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/InlineDataMustMatchTheoryParameters_ExtraValueFixer.cs
@@ -10,12 +10,14 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class InlineDataMustMatchTheoryParameters_ExtraValueFixer : XunitCodeFixProvider
 {
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 	public const string Key_AddTheoryParameter = "xUnit1011_AddTheoryParameter";
 	public const string Key_RemoveExtraDataValue = "xUnit1011_RemoveExtraDataValue";
 

--- a/src/xunit.analyzers.fixes/X1000/InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameterFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameterFixer.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -19,6 +20,8 @@ public class InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompati
 	public InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameterFixer() :
 		base(Descriptors.X1012_InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameter.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X1000/InlineDataMustMatchTheoryParameters_TooFewValuesFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/InlineDataMustMatchTheoryParameters_TooFewValuesFixer.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -20,6 +21,8 @@ public class InlineDataMustMatchTheoryParameters_TooFewValuesFixer : XunitCodeFi
 	public InlineDataMustMatchTheoryParameters_TooFewValuesFixer() :
 		base(Descriptors.X1009_InlineDataMustMatchTheoryParameters_TooFewValues.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X1000/InlineDataShouldBeUniqueWithinTheoryFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/InlineDataShouldBeUniqueWithinTheoryFixer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -17,6 +18,8 @@ public class InlineDataShouldBeUniqueWithinTheoryFixer : XunitCodeFixProvider
 	public InlineDataShouldBeUniqueWithinTheoryFixer() :
 		base(Descriptors.X1025_InlineDataShouldBeUniqueWithinTheory.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X1000/LocalFunctionsCannotBeTestFunctionsFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/LocalFunctionsCannotBeTestFunctionsFixer.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -14,6 +15,8 @@ public class LocalFunctionsCannotBeTestFunctionsFixer : XunitCodeFixProvider
 	public LocalFunctionsCannotBeTestFunctionsFixer() :
 		base(Descriptors.X1029_LocalFunctionsCannotBeTestFunctions.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X1000/MemberDataShouldReferenceValidMember_ExtraValueFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/MemberDataShouldReferenceValidMember_ExtraValueFixer.cs
@@ -10,12 +10,15 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class MemberDataShouldReferenceValidMember_ExtraValueFixer : XunitCodeFixProvider
 {
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
+
 	public const string Key_AddMethodParameter = "xUnit1036_AddMethodParameter";
 	public const string Key_RemoveExtraDataValue = "xUnit1036_RemoveExtraDataValue";
 

--- a/src/xunit.analyzers.fixes/X1000/MemberDataShouldReferenceValidMember_NameOfFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/MemberDataShouldReferenceValidMember_NameOfFixer.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -18,6 +19,8 @@ public class MemberDataShouldReferenceValidMember_NameOfFixer : XunitCodeFixProv
 	public MemberDataShouldReferenceValidMember_NameOfFixer() :
 		base(Descriptors.X1014_MemberDataShouldUseNameOfOperator.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X1000/MemberDataShouldReferenceValidMember_NullShouldNotBeUsedForIncompatibleParameterFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/MemberDataShouldReferenceValidMember_NullShouldNotBeUsedForIncompatibleParameterFixer.cs
@@ -8,12 +8,15 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public class MemberDataShouldReferenceValidMember_NullShouldNotBeUsedForIncompatibleParameterFixer : XunitCodeFixProvider
 {
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
+
 	public const string Key_MakeParameterNullable = "xUnit1034_MakeParameterNullable";
 
 	public MemberDataShouldReferenceValidMember_NullShouldNotBeUsedForIncompatibleParameterFixer() :

--- a/src/xunit.analyzers.fixes/X1000/MemberDataShouldReferenceValidMember_ParamsForNonMethodFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/MemberDataShouldReferenceValidMember_ParamsForNonMethodFixer.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Text;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -19,6 +20,8 @@ public class MemberDataShouldReferenceValidMember_ParamsForNonMethodFixer : Xuni
 	public MemberDataShouldReferenceValidMember_ParamsForNonMethodFixer() :
 		base(Descriptors.X1021_MemberDataNonMethodShouldNotHaveParameters.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X1000/MemberDataShouldReferenceValidMember_ReturnTypeFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/MemberDataShouldReferenceValidMember_ReturnTypeFixer.cs
@@ -3,12 +3,15 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public sealed class MemberDataShouldReferenceValidMember_ReturnTypeFixer : XunitMemberFixProvider
 {
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
+
 	public const string Key_ChangeMemberReturnType_ObjectArray = "xUnit1019_ChangeMemberReturnType_ObjectArray";
 	public const string Key_ChangeMemberReturnType_ITheoryDataRow = "xUnit1019_ChangeMemberReturnType_ITheoryDataRow";
 

--- a/src/xunit.analyzers.fixes/X1000/MemberDataShouldReferenceValidMember_StaticFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/MemberDataShouldReferenceValidMember_StaticFixer.cs
@@ -3,12 +3,15 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public sealed class MemberDataShouldReferenceValidMember_StaticFixer : XunitMemberFixProvider
 {
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
+
 	public const string Key_MakeMemberStatic = "xUnit1017_MakeMemberStatic";
 
 	public MemberDataShouldReferenceValidMember_StaticFixer() :

--- a/src/xunit.analyzers.fixes/X1000/MemberDataShouldReferenceValidMember_VisibilityFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/MemberDataShouldReferenceValidMember_VisibilityFixer.cs
@@ -3,12 +3,15 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
 [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 public sealed class MemberDataShouldReferenceValidMember_VisibilityFixer : XunitMemberFixProvider
 {
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
+
 	public const string Key_MakeMemberPublic = "xUnit1016_MakeMemberPublic";
 
 	public MemberDataShouldReferenceValidMember_VisibilityFixer() :

--- a/src/xunit.analyzers.fixes/X1000/PublicMethodShouldBeMarkedAsTestFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/PublicMethodShouldBeMarkedAsTestFixer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -19,6 +20,8 @@ public class PublicMethodShouldBeMarkedAsTestFixer : XunitCodeFixProvider
 	public PublicMethodShouldBeMarkedAsTestFixer() :
 		base(Descriptors.X1013_PublicMethodShouldBeMarkedAsTest.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X1000/TestClassMustBePublicFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/TestClassMustBePublicFixer.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -15,6 +16,8 @@ public class TestClassMustBePublicFixer : XunitCodeFixProvider
 	public TestClassMustBePublicFixer() :
 		base(Descriptors.X1000_TestClassMustBePublic.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X1000/TestMethodMustNotHaveMultipleFactAttributesFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/TestMethodMustNotHaveMultipleFactAttributesFixer.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -19,6 +20,8 @@ public class TestMethodMustNotHaveMultipleFactAttributesFixer : XunitCodeFixProv
 	public TestMethodMustNotHaveMultipleFactAttributesFixer() :
 		base(Descriptors.X1002_TestMethodMustNotHaveMultipleFactAttributes.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public static string Key_KeepAttribute(string simpleTypeName) =>
 		string.Format(CultureInfo.InvariantCulture, "xUnit1002_KeepAttribute_{0}", simpleTypeName);

--- a/src/xunit.analyzers.fixes/X1000/TestMethodShouldNotBeSkippedFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/TestMethodShouldNotBeSkippedFixer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -17,6 +18,8 @@ public class TestMethodShouldNotBeSkippedFixer : XunitCodeFixProvider
 	public TestMethodShouldNotBeSkippedFixer() :
 		base(Descriptors.X1004_TestMethodShouldNotBeSkipped.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X1000/TheoryDataShouldNotUseTheoryDataRowFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/TheoryDataShouldNotUseTheoryDataRowFixer.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -16,6 +17,8 @@ public class TheoryDataShouldNotUseTheoryDataRowFixer() :
 	XunitCodeFixProvider(Descriptors.X1052_TheoryDataShouldNotUseITheoryDataRow.Id)
 {
 	public const string Key_UseIEnumerable = "xUnit1052_UseIEnumerable";
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X1000/TheoryMethodCannotHaveDefaultParameterFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/TheoryMethodCannotHaveDefaultParameterFixer.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -15,6 +16,8 @@ public class TheoryMethodCannotHaveDefaultParameterFixer : XunitCodeFixProvider
 	public TheoryMethodCannotHaveDefaultParameterFixer() :
 		base(Descriptors.X1023_TheoryMethodCannotHaveDefaultParameter.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X1000/UseCancellationTokenFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/UseCancellationTokenFixer.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Operations;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -20,6 +21,8 @@ public class UseCancellationTokenFixer : XunitCodeFixProvider
 	public UseCancellationTokenFixer() :
 		base(Descriptors.X1051_UseCancellationToken.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/AssertCollectionContainsShouldNotUseBoolCheckFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertCollectionContainsShouldNotUseBoolCheckFixer.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -20,6 +21,8 @@ public class AssertCollectionContainsShouldNotUseBoolCheckFixer : XunitCodeFixPr
 	public AssertCollectionContainsShouldNotUseBoolCheckFixer() :
 		base(Descriptors.X2017_AssertCollectionContainsShouldNotUseBoolCheck.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/AssertEmptyCollectionCheckShouldNotBeUsedFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertEmptyCollectionCheckShouldNotBeUsedFixer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -19,6 +20,8 @@ public class AssertEmptyCollectionCheckShouldNotBeUsedFixer : XunitCodeFixProvid
 	public AssertEmptyCollectionCheckShouldNotBeUsedFixer() :
 		base(Descriptors.X2011_AssertEmptyCollectionCheckShouldNotBeUsed.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/AssertEmptyOrNotEmptyShouldNotBeUsedForContainsChecksFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertEmptyOrNotEmptyShouldNotBeUsedForContainsChecksFixer.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -16,6 +17,8 @@ public class AssertEmptyOrNotEmptyShouldNotBeUsedForContainsChecksFixer : XunitC
 {
 	public const string Key_UseDoesNotContain = "xUnit2029_UseDoesNotContain";
 	public const string Key_UseContains = "xUnit2030_UseContains";
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	static readonly string[] targetDiagnostics =
 	[

--- a/src/xunit.analyzers.fixes/X2000/AssertEnumerableAnyCheckShouldNotBeUsedForCollectionContainsCheckFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertEnumerableAnyCheckShouldNotBeUsedForCollectionContainsCheckFixer.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -19,6 +20,8 @@ public class AssertEnumerableAnyCheckShouldNotBeUsedForCollectionContainsCheckFi
 	public AssertEnumerableAnyCheckShouldNotBeUsedForCollectionContainsCheckFixer() :
 		base(Descriptors.X2012_AssertEnumerableAnyCheckShouldNotBeUsedForCollectionContainsCheck.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/AssertEqualGenericShouldNotBeUsedForStringValueFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertEqualGenericShouldNotBeUsedForStringValueFixer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -18,6 +19,8 @@ public class AssertEqualGenericShouldNotBeUsedForStringValueFixer : XunitCodeFix
 	public AssertEqualGenericShouldNotBeUsedForStringValueFixer() :
 		base(Descriptors.X2006_AssertEqualGenericShouldNotBeUsedForStringValue.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/AssertEqualLiteralValueShouldBeFirstFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertEqualLiteralValueShouldBeFirstFixer.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -18,6 +19,8 @@ public class AssertEqualLiteralValueShouldBeFirstFixer : XunitCodeFixProvider
 	public AssertEqualLiteralValueShouldBeFirstFixer() :
 		base(Descriptors.X2000_AssertEqualLiteralValueShouldBeFirst.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/AssertEqualPrecisionShouldBeInRangeFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertEqualPrecisionShouldBeInRangeFixer.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -20,6 +21,8 @@ public class AssertEqualPrecisionShouldBeInRangeFixer : XunitCodeFixProvider
 	public AssertEqualPrecisionShouldBeInRangeFixer() :
 		base(Descriptors.X2016_AssertEqualPrecisionShouldBeInRange.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/AssertEqualShouldNotBeUsedForBoolLiteralCheckFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertEqualShouldNotBeUsedForBoolLiteralCheckFixer.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -19,6 +20,8 @@ public class AssertEqualShouldNotBeUsedForBoolLiteralCheckFixer : XunitCodeFixPr
 	public AssertEqualShouldNotBeUsedForBoolLiteralCheckFixer() :
 		base(Descriptors.X2004_AssertEqualShouldNotUsedForBoolLiteralCheck.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/AssertEqualShouldNotBeUsedForCollectionSizeCheckFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertEqualShouldNotBeUsedForCollectionSizeCheckFixer.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -19,6 +20,8 @@ public class AssertEqualShouldNotBeUsedForCollectionSizeCheckFixer : XunitCodeFi
 	public AssertEqualShouldNotBeUsedForCollectionSizeCheckFixer() :
 		base(Descriptors.X2013_AssertEqualShouldNotBeUsedForCollectionSizeCheck.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/AssertEqualShouldNotBeUsedForNullCheckFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertEqualShouldNotBeUsedForNullCheckFixer.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -19,6 +20,8 @@ public class AssertEqualShouldNotBeUsedForNullCheckFixer : XunitCodeFixProvider
 	public AssertEqualShouldNotBeUsedForNullCheckFixer() :
 		base(Descriptors.X2003_AssertEqualShouldNotUsedForNullCheck.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/AssertEqualsShouldNotBeUsedFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertEqualsShouldNotBeUsedFixer.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -16,6 +17,8 @@ public class AssertEqualsShouldNotBeUsedFixer : XunitCodeFixProvider
 	public AssertEqualsShouldNotBeUsedFixer() :
 		base(Descriptors.X2001_AssertEqualsShouldNotBeUsed.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/AssertIsTypeShouldNotBeUsedForAbstractTypeFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertIsTypeShouldNotBeUsedForAbstractTypeFixer.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -19,6 +20,8 @@ public class AssertIsTypeShouldNotBeUsedForAbstractTypeFixer : XunitCodeFixProvi
 	public AssertIsTypeShouldNotBeUsedForAbstractTypeFixer() :
 		base(Descriptors.X2018_AssertIsTypeShouldNotBeUsedForAbstractType.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/AssertNullShouldNotBeCalledOnValueTypesFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertNullShouldNotBeCalledOnValueTypesFixer.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -19,6 +20,8 @@ public class AssertNullShouldNotBeCalledOnValueTypesFixer : XunitCodeFixProvider
 	public AssertNullShouldNotBeCalledOnValueTypesFixer() :
 		base(Descriptors.X2002_AssertNullShouldNotBeCalledOnValueTypes.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/AssertRegexMatchShouldNotUseBoolLiteralCheckFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertRegexMatchShouldNotUseBoolLiteralCheckFixer.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -19,6 +20,8 @@ public class AssertRegexMatchShouldNotUseBoolLiteralCheckFixer : XunitCodeFixPro
 	public AssertRegexMatchShouldNotUseBoolLiteralCheckFixer() :
 		base(Descriptors.X2008_AssertRegexMatchShouldNotUseBoolLiteralCheck.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/AssertSameShouldNotBeCalledOnValueTypesFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertSameShouldNotBeCalledOnValueTypesFixer.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -16,6 +17,8 @@ public class AssertSameShouldNotBeCalledOnValueTypesFixer : XunitCodeFixProvider
 	public AssertSameShouldNotBeCalledOnValueTypesFixer() :
 		base(Descriptors.X2005_AssertSameShouldNotBeCalledOnValueTypes.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/AssertSingleShouldUseTwoArgumentCallFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertSingleShouldUseTwoArgumentCallFixer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -18,6 +19,8 @@ public class AssertSingleShouldUseTwoArgumentCallFixer : XunitCodeFixProvider
 	public AssertSingleShouldUseTwoArgumentCallFixer() :
 		base(Descriptors.X2031_AssertSingleShouldUseTwoArgumentCall.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/AssertStringEqualityCheckShouldNotUseBoolCheckFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertStringEqualityCheckShouldNotUseBoolCheckFixer.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -20,6 +21,8 @@ public class AssertStringEqualityCheckShouldNotUseBoolCheckFixer : XunitCodeFixP
 	public AssertStringEqualityCheckShouldNotUseBoolCheckFixer() :
 		base(Descriptors.X2010_AssertStringEqualityCheckShouldNotUseBoolCheckFixer.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/AssertSubstringCheckShouldNotUseBoolCheckFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertSubstringCheckShouldNotUseBoolCheckFixer.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -19,6 +20,8 @@ public class AssertSubstringCheckShouldNotUseBoolCheckFixer : XunitCodeFixProvid
 	public AssertSubstringCheckShouldNotUseBoolCheckFixer() :
 		base(Descriptors.X2009_AssertSubstringCheckShouldNotUseBoolCheck.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/AssignableFromAssertionIsConfusinglyNamedFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssignableFromAssertionIsConfusinglyNamedFixer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -18,6 +19,8 @@ public class AssignableFromAssertionIsConfusinglyNamedFixer : XunitCodeFixProvid
 	public AssignableFromAssertionIsConfusinglyNamedFixer() :
 		base(Descriptors.X2032_AssignableFromAssertionIsConfusinglyNamed.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/BooleanAssertsShouldNotBeNegatedFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/BooleanAssertsShouldNotBeNegatedFixer.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -20,6 +21,8 @@ public class BooleanAssertsShouldNotBeNegatedFixer : XunitCodeFixProvider
 	public BooleanAssertsShouldNotBeNegatedFixer() :
 		base(Descriptors.X2022_BooleanAssertionsShouldNotBeNegated.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckBooleanFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckBooleanFixer.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -19,6 +20,8 @@ public class BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckBooleanFixer : X
 	public BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckBooleanFixer() :
 		base(Descriptors.X2025_BooleanAssertionCanBeSimplified.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixer.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -19,6 +20,8 @@ public class BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixer 
 	public BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixer() :
 		base(Descriptors.X2024_BooleanAssertionsShouldNotBeUsedForSimpleEqualityCheck.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/UseAssertFailInsteadOfBooleanAssertFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/UseAssertFailInsteadOfBooleanAssertFixer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -18,6 +19,8 @@ public class UseAssertFailInsteadOfBooleanAssertFixer : XunitCodeFixProvider
 	public UseAssertFailInsteadOfBooleanAssertFixer() :
 		base(Descriptors.X2020_UseAssertFailInsteadOfBooleanAssert.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X2000/UseGenericOverloadFix.cs
+++ b/src/xunit.analyzers.fixes/X2000/UseGenericOverloadFix.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Xunit.Analyzers.Fixes;
@@ -22,6 +23,8 @@ public class UseGenericOverloadFix : XunitCodeFixProvider
 			Descriptors.X2015_AssertThrowsShouldUseGenericOverload.Id
 		)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X3000/CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectFixer.cs
+++ b/src/xunit.analyzers.fixes/X3000/CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectFixer.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -16,6 +17,8 @@ public class CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectFixer : Xunit
 	public CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectFixer() :
 		base(Descriptors.X3000_CrossAppDomainClassesMustBeLongLivedMarshalByRefObject.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.fixes/X3000/SerializableClassMustHaveParameterlessConstructorFixer.cs
+++ b/src/xunit.analyzers.fixes/X3000/SerializableClassMustHaveParameterlessConstructorFixer.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Microsoft.CodeAnalysis.CodeFixes.WellKnownFixAllProviders;
 
 namespace Xunit.Analyzers.Fixes;
 
@@ -23,6 +24,8 @@ public class SerializableClassMustHaveParameterlessConstructorFixer : XunitCodeF
 	public SerializableClassMustHaveParameterlessConstructorFixer() :
 		base(Descriptors.X3001_SerializableClassMustHaveParameterlessConstructor.Id)
 	{ }
+
+	public override FixAllProvider? GetFixAllProvider() => BatchFixer;
 
 	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 	{

--- a/src/xunit.analyzers.tests/Fixes/X1000/CollectionDefinitionClassesMustBePublicFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/CollectionDefinitionClassesMustBePublicFixerTests.cs
@@ -5,34 +5,36 @@ using Verify = CSharpVerifier<Xunit.Analyzers.CollectionDefinitionClassesMustBeP
 
 public class CollectionDefinitionClassesMustBePublicFixerTests
 {
-	[Theory]
-	[InlineData("")]
-	[InlineData("internal ")]
-	public async Task MakesClassPublic(string modifier)
+	[Fact]
+	public async Task FixAll_MakesAllClassesPublic()
 	{
-		var before = string.Format(/* lang=c#-test */ """
-			[Xunit.CollectionDefinition("MyCollection")]
-			{0}class [|CollectionDefinitionClass|] {{ }}
-			""", modifier);
+		var before = /* lang=c#-test */ """
+			[Xunit.CollectionDefinition("MyCollection1")]
+			class [|CollectionDefinitionClass1|] { }
+
+			[Xunit.CollectionDefinition("MyCollection2")]
+			internal class [|CollectionDefinitionClass2|] { }
+			""";
 		var after = /* lang=c#-test */ """
-			[Xunit.CollectionDefinition("MyCollection")]
-			public class CollectionDefinitionClass { }
+			[Xunit.CollectionDefinition("MyCollection1")]
+			public class CollectionDefinitionClass1 { }
+
+			[Xunit.CollectionDefinition("MyCollection2")]
+			public class CollectionDefinitionClass2 { }
 			""";
 
-		await Verify.VerifyCodeFix(before, after, CollectionDefinitionClassesMustBePublicFixer.Key_MakeCollectionDefinitionClassPublic);
+		await Verify.VerifyCodeFixFixAll(before, after, CollectionDefinitionClassesMustBePublicFixer.Key_MakeCollectionDefinitionClassPublic);
 	}
 
-	[Theory]
-	[InlineData("")]
-	[InlineData("internal ")]
-	public async Task ForPartialClassDeclarations_MakesSingleDeclarationPublic(string modifier)
+	[Fact]
+	public async Task ForPartialClassDeclarations_MakesSingleDeclarationPublic()
 	{
-		var before = string.Format(/* lang=c#-test */ """
+		var before = /* lang=c#-test */ """
 			[Xunit.CollectionDefinition("MyCollection")]
-			{0}partial class [|CollectionDefinitionClass|] {{ }}
+			partial class [|CollectionDefinitionClass|] { }
 
-			partial class CollectionDefinitionClass {{ }}
-			""", modifier);
+			partial class CollectionDefinitionClass { }
+			""";
 		var after = /* lang=c#-test */ """
 			[Xunit.CollectionDefinition("MyCollection")]
 			public partial class CollectionDefinitionClass { }
@@ -40,6 +42,6 @@ public class CollectionDefinitionClassesMustBePublicFixerTests
 			partial class CollectionDefinitionClass { }
 			""";
 
-		await Verify.VerifyCodeFix(before, after, CollectionDefinitionClassesMustBePublicFixer.Key_MakeCollectionDefinitionClassPublic);
+		await Verify.VerifyCodeFixFixAll(before, after, CollectionDefinitionClassesMustBePublicFixer.Key_MakeCollectionDefinitionClassPublic);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/ConvertToFactFixTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/ConvertToFactFixTests.cs
@@ -7,14 +7,17 @@ using Verify_X1006 = CSharpVerifier<Xunit.Analyzers.TheoryMethodShouldHaveParame
 public class ConvertToFactFixTests
 {
 	[Fact]
-	public async Task From_X1003()
+	public async Task FixAll_From_X1003()
 	{
 		var before = /* lang=c#-test */ """
 			using Xunit;
 
 			public class TestClass {
 				[Theory]
-				public void [|TestMethod|](int a) { }
+				public void [|TestMethod1|](int a) { }
+
+				[Theory]
+				public void [|TestMethod2|](string b) { }
 			}
 			""";
 		var after = /* lang=c#-test */ """
@@ -22,22 +25,28 @@ public class ConvertToFactFixTests
 
 			public class TestClass {
 				[Fact]
-				public void TestMethod(int a) { }
+				public void TestMethod1(int a) { }
+
+				[Fact]
+				public void TestMethod2(string b) { }
 			}
 			""";
 
-		await Verify_X1003.VerifyCodeFix(before, after, ConvertToFactFix.Key_ConvertToFact);
+		await Verify_X1003.VerifyCodeFixFixAll(before, after, ConvertToFactFix.Key_ConvertToFact);
 	}
 
 	[Fact]
-	public async Task From_X1006()
+	public async Task FixAll_From_X1006()
 	{
 		var before = /* lang=c#-test */ """
 			using Xunit;
 
 			public class TestClass {
 				[Theory]
-				public void [|TestMethod|]() { }
+				public void [|TestMethod1|]() { }
+
+				[Theory]
+				public void [|TestMethod2|]() { }
 			}
 			""";
 		var after = /* lang=c#-test */ """
@@ -45,10 +54,13 @@ public class ConvertToFactFixTests
 
 			public class TestClass {
 				[Fact]
-				public void TestMethod() { }
+				public void TestMethod1() { }
+
+				[Fact]
+				public void TestMethod2() { }
 			}
 			""";
 
-		await Verify_X1006.VerifyCodeFix(before, after, ConvertToFactFix.Key_ConvertToFact);
+		await Verify_X1006.VerifyCodeFixFixAll(before, after, ConvertToFactFix.Key_ConvertToFact);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/ConvertToTheoryFixTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/ConvertToTheoryFixTests.cs
@@ -7,14 +7,17 @@ using Verify_X1005 = CSharpVerifier<Xunit.Analyzers.FactMethodShouldNotHaveTestD
 public class ConvertToTheoryFixTests
 {
 	[Fact]
-	public async Task From_X1001()
+	public async Task FixAll_From_X1001()
 	{
 		var before = /* lang=c#-test */ """
 			using Xunit;
 
 			public class TestClass {
 				[Fact]
-				public void [|TestMethod|](int a) { }
+				public void [|TestMethod1|](int a) { }
+
+				[Fact]
+				public void [|TestMethod2|](string b) { }
 			}
 			""";
 		var after = /* lang=c#-test */ """
@@ -22,23 +25,30 @@ public class ConvertToTheoryFixTests
 
 			public class TestClass {
 				[Theory]
-				public void TestMethod(int a) { }
+				public void TestMethod1(int a) { }
+
+				[Theory]
+				public void TestMethod2(string b) { }
 			}
 			""";
 
-		await Verify_X1001.VerifyCodeFix(before, after, ConvertToTheoryFix.Key_ConvertToTheory);
+		await Verify_X1001.VerifyCodeFixFixAll(before, after, ConvertToTheoryFix.Key_ConvertToTheory);
 	}
 
 	[Fact]
-	public async Task From_X1005()
+	public async Task FixAll_From_X1005()
 	{
 		var before = /* lang=c#-test */ """
 			using Xunit;
 
 			public class TestClass {
 				[Fact]
-				[InlineData(42)]
-				public void [|TestMethod|]() { }
+				[InlineData(1)]
+				public void [|TestMethod1|]() { }
+
+				[Fact]
+				[InlineData("hello")]
+				public void [|TestMethod2|]() { }
 			}
 			""";
 		var after = /* lang=c#-test */ """
@@ -46,11 +56,15 @@ public class ConvertToTheoryFixTests
 
 			public class TestClass {
 				[Theory]
-				[InlineData(42)]
-				public void TestMethod() { }
+				[InlineData(1)]
+				public void TestMethod1() { }
+
+				[Theory]
+				[InlineData("hello")]
+				public void TestMethod2() { }
 			}
 			""";
 
-		await Verify_X1005.VerifyCodeFix(before, after, ConvertToTheoryFix.Key_ConvertToTheory);
+		await Verify_X1005.VerifyCodeFixFixAll(before, after, ConvertToTheoryFix.Key_ConvertToTheory);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/DataAttributeShouldBeUsedOnATheoryFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/DataAttributeShouldBeUsedOnATheoryFixerTests.cs
@@ -6,14 +6,17 @@ using Verify = CSharpVerifier<Xunit.Analyzers.DataAttributeShouldBeUsedOnATheory
 public class DataAttributeShouldBeUsedOnATheoryFixerTests
 {
 	[Fact]
-	public async Task AddsMissingTheoryAttribute()
+	public async Task FixAll_MarkAsTheory()
 	{
 		var before = /* lang=c#-test */ """
 			using Xunit;
 
 			public class TestClass {
-				[InlineData]
-				public void [|TestMethod|]() { }
+				[InlineData(1)]
+				public void [|TestMethod1|]() { }
+
+				[InlineData("hello")]
+				public void [|TestMethod2|]() { }
 			}
 			""";
 		var after = /* lang=c#-test */ """
@@ -21,33 +24,42 @@ public class DataAttributeShouldBeUsedOnATheoryFixerTests
 
 			public class TestClass {
 				[Theory]
-				[InlineData]
-				public void TestMethod() { }
+				[InlineData(1)]
+				public void TestMethod1() { }
+
+				[Theory]
+				[InlineData("hello")]
+				public void TestMethod2() { }
 			}
 			""";
 
-		await Verify.VerifyCodeFix(before, after, DataAttributeShouldBeUsedOnATheoryFixer.Key_MarkAsTheory);
+		await Verify.VerifyCodeFixFixAll(before, after, DataAttributeShouldBeUsedOnATheoryFixer.Key_MarkAsTheory);
 	}
 
 	[Fact]
-	public async Task RemovesDataAttributes()
+	public async Task FixAll_RemoveDataAttributes()
 	{
 		var before = /* lang=c#-test */ """
 			using Xunit;
 
 			public class TestClass {
-				[InlineData]
-				public void [|TestMethod|]() { }
+				[InlineData(1)]
+				public void [|TestMethod1|]() { }
+
+				[InlineData("hello")]
+				public void [|TestMethod2|]() { }
 			}
 			""";
 		var after = /* lang=c#-test */ """
 			using Xunit;
 
 			public class TestClass {
-				public void TestMethod() { }
+				public void TestMethod1() { }
+
+				public void TestMethod2() { }
 			}
 			""";
 
-		await Verify.VerifyCodeFix(before, after, DataAttributeShouldBeUsedOnATheoryFixer.Key_RemoveDataAttributes);
+		await Verify.VerifyCodeFixFixAll(before, after, DataAttributeShouldBeUsedOnATheoryFixer.Key_RemoveDataAttributes);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/DoNotUseAsyncVoidForTestMethodsFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/DoNotUseAsyncVoidForTestMethodsFixerTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Xunit;
 using Xunit.Analyzers.Fixes;
 using Verify = CSharpVerifier<Xunit.Analyzers.DoNotUseAsyncVoidForTestMethods>;
 
@@ -7,36 +8,7 @@ namespace Xunit.Analyzers;
 public class DoNotUseAsyncVoidForTestMethodsFixerTests
 {
 	[Fact]
-	public async Task WithoutNamespace_ConvertsToTask()
-	{
-		var beforeV2 = /* lang=c#-test */ """
-			using Xunit;
-
-			public class TestClass {
-				[Fact]
-				public async void {|xUnit1048:TestMethod|}() {
-					await System.Threading.Tasks.Task.Yield();
-				}
-			}
-			""";
-		var beforeV3 = beforeV2.Replace("xUnit1048", "xUnit1049");
-		var after = /* lang=c#-test */ """
-			using Xunit;
-
-			public class TestClass {
-				[Fact]
-				public async System.Threading.Tasks.Task TestMethod() {
-					await System.Threading.Tasks.Task.Yield();
-				}
-			}
-			""";
-
-		await Verify.VerifyCodeFixV2(beforeV2, after, DoNotUseAsyncVoidForTestMethodsFixer.Key_ConvertToTask);
-		await Verify.VerifyCodeFixV3(beforeV3, after, DoNotUseAsyncVoidForTestMethodsFixer.Key_ConvertToTask);
-	}
-
-	[Fact]
-	public async Task WithNamespace_ConvertsToTask()
+	public async Task FixAll_ConvertsMultipleMethodsToTask()
 	{
 		var beforeV2 = /* lang=c#-test */ """
 			using System.Threading.Tasks;
@@ -44,7 +16,12 @@ public class DoNotUseAsyncVoidForTestMethodsFixerTests
 
 			public class TestClass {
 				[Fact]
-				public async void {|xUnit1048:TestMethod|}() {
+				public async void {|xUnit1048:TestMethod1|}() {
+					await Task.Yield();
+				}
+
+				[Fact]
+				public async void {|xUnit1048:TestMethod2|}() {
 					await Task.Yield();
 				}
 			}
@@ -56,45 +33,23 @@ public class DoNotUseAsyncVoidForTestMethodsFixerTests
 
 			public class TestClass {
 				[Fact]
-				public async Task TestMethod() {
+				public async Task TestMethod1() {
+					await Task.Yield();
+				}
+
+				[Fact]
+				public async Task TestMethod2() {
 					await Task.Yield();
 				}
 			}
 			""";
 
-		await Verify.VerifyCodeFixV2(beforeV2, after, DoNotUseAsyncVoidForTestMethodsFixer.Key_ConvertToTask);
-		await Verify.VerifyCodeFixV3(beforeV3, after, DoNotUseAsyncVoidForTestMethodsFixer.Key_ConvertToTask);
+		await Verify.VerifyCodeFixV2FixAll(beforeV2, after, DoNotUseAsyncVoidForTestMethodsFixer.Key_ConvertToTask);
+		await Verify.VerifyCodeFixV3FixAll(beforeV3, after, DoNotUseAsyncVoidForTestMethodsFixer.Key_ConvertToTask);
 	}
 
 	[Fact]
-	public async Task WithoutNamespace_ConvertsToValueTask()
-	{
-		var before = /* lang=c#-test */ """
-			using Xunit;
-
-			public class TestClass {
-				[Fact]
-				public async void {|xUnit1049:TestMethod|}() {
-					await System.Threading.Tasks.Task.Yield();
-				}
-			}
-			""";
-		var after = /* lang=c#-test */ """
-			using Xunit;
-
-			public class TestClass {
-				[Fact]
-				public async System.Threading.Tasks.ValueTask TestMethod() {
-					await System.Threading.Tasks.Task.Yield();
-				}
-			}
-			""";
-
-		await Verify.VerifyCodeFixV3(before, after, DoNotUseAsyncVoidForTestMethodsFixer.Key_ConvertToValueTask);
-	}
-
-	[Fact]
-	public async Task WithNamespace_ConvertsToValueTask()
+	public async Task FixAll_ConvertsMultipleMethodsToValueTask()
 	{
 		var before = /* lang=c#-test */ """
 			using System.Threading.Tasks;
@@ -102,7 +57,12 @@ public class DoNotUseAsyncVoidForTestMethodsFixerTests
 
 			public class TestClass {
 				[Fact]
-				public async void {|xUnit1049:TestMethod|}() {
+				public async void {|xUnit1049:TestMethod1|}() {
+					await Task.Yield();
+				}
+
+				[Fact]
+				public async void {|xUnit1049:TestMethod2|}() {
 					await Task.Yield();
 				}
 			}
@@ -113,12 +73,17 @@ public class DoNotUseAsyncVoidForTestMethodsFixerTests
 
 			public class TestClass {
 				[Fact]
-				public async ValueTask TestMethod() {
+				public async ValueTask TestMethod1() {
+					await Task.Yield();
+				}
+
+				[Fact]
+				public async ValueTask TestMethod2() {
 					await Task.Yield();
 				}
 			}
 			""";
 
-		await Verify.VerifyCodeFixV3(before, after, DoNotUseAsyncVoidForTestMethodsFixer.Key_ConvertToValueTask);
+		await Verify.VerifyCodeFixV3FixAll(before, after, DoNotUseAsyncVoidForTestMethodsFixer.Key_ConvertToValueTask);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/FactMethodMustNotHaveParametersFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/FactMethodMustNotHaveParametersFixerTests.cs
@@ -6,14 +6,17 @@ using Verify = CSharpVerifier<Xunit.Analyzers.FactMethodMustNotHaveParameters>;
 public class FactMethodMustNotHaveParametersFixerTests
 {
 	[Fact]
-	public async Task RemovesParameter()
+	public async Task FixAll_RemovesParametersFromAllMethods()
 	{
 		var before = /* lang=c#-test */ """
 			using Xunit;
 
 			public class TestClass {
 				[Fact]
-				public void [|TestMethod|](int x) { }
+				public void [|TestMethod1|](int x) { }
+
+				[Fact]
+				public void [|TestMethod2|](string a, int b) { }
 			}
 			""";
 		var after = /* lang=c#-test */ """
@@ -21,10 +24,13 @@ public class FactMethodMustNotHaveParametersFixerTests
 
 			public class TestClass {
 				[Fact]
-				public void TestMethod() { }
+				public void TestMethod1() { }
+
+				[Fact]
+				public void TestMethod2() { }
 			}
 			""";
 
-		await Verify.VerifyCodeFix(before, after, FactMethodMustNotHaveParametersFixer.Key_RemoveParameters);
+		await Verify.VerifyCodeFixFixAll(before, after, FactMethodMustNotHaveParametersFixer.Key_RemoveParameters);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/FactMethodShouldNotHaveTestDataFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/FactMethodShouldNotHaveTestDataFixerTests.cs
@@ -6,7 +6,7 @@ using Verify = CSharpVerifier<Xunit.Analyzers.FactMethodShouldNotHaveTestData>;
 public class FactMethodShouldNotHaveTestDataFixerTests
 {
 	[Fact]
-	public async Task RemovesDataAttribute()
+	public async Task FixAll_RemovesDataAttributesFromAllMethods()
 	{
 		var before = /* lang=c#-test */ """
 			using Xunit;
@@ -14,7 +14,11 @@ public class FactMethodShouldNotHaveTestDataFixerTests
 			public class TestClass {
 				[Fact]
 				[InlineData(1)]
-				public void [|TestMethod|](int x) { }
+				public void [|TestMethod1|](int x) { }
+
+				[Fact]
+				[InlineData("a")]
+				public void [|TestMethod2|](string s) { }
 			}
 			""";
 		var after = /* lang=c#-test */ """
@@ -22,10 +26,13 @@ public class FactMethodShouldNotHaveTestDataFixerTests
 
 			public class TestClass {
 				[Fact]
-				public void TestMethod(int x) { }
+				public void TestMethod1(int x) { }
+
+				[Fact]
+				public void TestMethod2(string s) { }
 			}
 			""";
 
-		await Verify.VerifyCodeFix(before, after, FactMethodShouldNotHaveTestDataFixer.Key_RemoveDataAttributes);
+		await Verify.VerifyCodeFixFixAll(before, after, FactMethodShouldNotHaveTestDataFixer.Key_RemoveDataAttributes);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/InlineDataMustMatchTheoryParameters_ExtraValueFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/InlineDataMustMatchTheoryParameters_ExtraValueFixerTests.cs
@@ -6,6 +6,39 @@ using Verify = CSharpVerifier<Xunit.Analyzers.InlineDataMustMatchTheoryParameter
 public class InlineDataMustMatchTheoryParameters_ExtraValueFixerTests
 {
 	[Fact]
+	public async Task FixAll_RemovesMultipleUnusedDataValues()
+	{
+		var before = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Theory]
+				[InlineData(42, {|xUnit1011:21.12|})]
+				public void TestMethod1(int a) { }
+
+				[Theory]
+				[InlineData(1, {|xUnit1011:"extra"|})]
+				public void TestMethod2(int a) { }
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Theory]
+				[InlineData(42)]
+				public void TestMethod1(int a) { }
+
+				[Theory]
+				[InlineData(1)]
+				public void TestMethod2(int a) { }
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, InlineDataMustMatchTheoryParameters_ExtraValueFixer.Key_RemoveExtraDataValue);
+	}
+
+	[Fact]
 	public async Task RemovesUnusedData()
 	{
 		var before = /* lang=c#-test */ """

--- a/src/xunit.analyzers.tests/Fixes/X1000/InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameterFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameterFixerTests.cs
@@ -7,32 +7,7 @@ using Verify = CSharpVerifier<Xunit.Analyzers.InlineDataMustMatchTheoryParameter
 public class InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameterFixerTests
 {
 	[Fact]
-	public async Task MakesParameterNullable()
-	{
-		var before = /* lang=c#-test */ """
-			using Xunit;
-
-			public class TestClass {
-				[Theory]
-				[InlineData(42, {|xUnit1012:null|})]
-				public void TestMethod(int a, int b) { }
-			}
-			""";
-		var after = /* lang=c#-test */ """
-			using Xunit;
-
-			public class TestClass {
-				[Theory]
-				[InlineData(42, null)]
-				public void TestMethod(int a, int? b) { }
-			}
-			""";
-
-		await Verify.VerifyCodeFix(before, after, InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameterFixer.Key_MakeParameterNullable);
-	}
-
-	[Fact]
-	public async Task MakesReferenceParameterNullable()
+	public async Task FixAll_MakesMultipleParametersNullable()
 	{
 		var before = /* lang=c#-test */ """
 			#nullable enable
@@ -41,8 +16,12 @@ public class InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompati
 
 			public class TestClass {
 				[Theory]
+				[InlineData({|xUnit1012:null|}, {|xUnit1012:null|})]
+				public void TestMethod1(int a, int b) { }
+
+				[Theory]
 				[InlineData(42, {|xUnit1012:null|})]
-				public void TestMethod(int a, object b) { }
+				public void TestMethod2(int a, object b) { }
 			}
 			""";
 		var after = /* lang=c#-test */ """
@@ -52,11 +31,15 @@ public class InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompati
 
 			public class TestClass {
 				[Theory]
+				[InlineData(null, null)]
+				public void TestMethod1(int? a, int? b) { }
+
+				[Theory]
 				[InlineData(42, null)]
-				public void TestMethod(int a, object? b) { }
+				public void TestMethod2(int a, object? b) { }
 			}
 			""";
 
-		await Verify.VerifyCodeFix(LanguageVersion.CSharp8, before, after, InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameterFixer.Key_MakeParameterNullable);
+		await Verify.VerifyCodeFixFixAll(LanguageVersion.CSharp8, before, after, InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameterFixer.Key_MakeParameterNullable);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/InlineDataMustMatchTheoryParameters_TooFewValuesFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/InlineDataMustMatchTheoryParameters_TooFewValuesFixerTests.cs
@@ -43,4 +43,37 @@ public class InlineDataMustMatchTheoryParameters_TooFewValuesFixerTests
 
 		await Verify.VerifyCodeFix(before, after, InlineDataMustMatchTheoryParameters_TooFewValuesFixer.Key_AddDefaultValues);
 	}
+
+	[Fact]
+	public async Task FixAll_AddsDefaultValuesToMultipleAttributes()
+	{
+		var before = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Theory]
+				[{|xUnit1009:InlineData|}]
+				public void TestMethod1(int x) { }
+
+				[Theory]
+				[{|xUnit1009:InlineData|}]
+				public void TestMethod2(string a, bool b) { }
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Theory]
+				[InlineData(0)]
+				public void TestMethod1(int x) { }
+
+				[Theory]
+				[InlineData("", false)]
+				public void TestMethod2(string a, bool b) { }
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, InlineDataMustMatchTheoryParameters_TooFewValuesFixer.Key_AddDefaultValues);
+	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/InlineDataShouldBeUniqueWithinTheoryFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/InlineDataShouldBeUniqueWithinTheoryFixerTests.cs
@@ -6,7 +6,7 @@ using Verify = CSharpVerifier<Xunit.Analyzers.InlineDataShouldBeUniqueWithinTheo
 public class InlineDataShouldBeUniqueWithinTheoryFixerTests
 {
 	[Fact]
-	public async Task RemovesDuplicateData()
+	public async Task FixAll_RemovesDuplicateData()
 	{
 		var before = /* lang=c#-test */ """
 			using Xunit;
@@ -15,7 +15,12 @@ public class InlineDataShouldBeUniqueWithinTheoryFixerTests
 				[Theory]
 				[InlineData(1)]
 				[[|InlineData(1)|]]
-				public void TestMethod(int x) { }
+				public void TestMethod1(int x) { }
+
+				[Theory]
+				[InlineData("a")]
+				[[|InlineData("a")|]]
+				public void TestMethod2(string s) { }
 			}
 			""";
 		var after = /* lang=c#-test */ """
@@ -24,10 +29,14 @@ public class InlineDataShouldBeUniqueWithinTheoryFixerTests
 			public class TestClass {
 				[Theory]
 				[InlineData(1)]
-				public void TestMethod(int x) { }
+				public void TestMethod1(int x) { }
+
+				[Theory]
+				[InlineData("a")]
+				public void TestMethod2(string s) { }
 			}
 			""";
 
-		await Verify.VerifyCodeFix(before, after, InlineDataShouldBeUniqueWithinTheoryFixer.Key_RemoveDuplicateInlineData);
+		await Verify.VerifyCodeFixFixAll(before, after, InlineDataShouldBeUniqueWithinTheoryFixer.Key_RemoveDuplicateInlineData);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/LocalFunctionsCannotBeTestFunctionsFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/LocalFunctionsCannotBeTestFunctionsFixerTests.cs
@@ -6,33 +6,38 @@ using Verify = CSharpVerifier<Xunit.Analyzers.LocalFunctionsCannotBeTestFunction
 
 public class LocalFunctionsCannotBeTestFunctionsFixerTests
 {
-	[Theory]
-	[InlineData("Fact")]
-	[InlineData("Theory")]
-	public async Task LocalFunctionsCannotHaveTestAttributes(string attribute)
+	[Fact]
+	public async Task FixAll_RemovesAttributesFromAllLocalFunctions()
 	{
-		var before = string.Format(/* lang=c#-test */ """
+		var before = /* lang=c#-test */ """
 			using Xunit;
 
-			public class TestClass {{
-				public void Method() {{
-					[[|{0}|]]
-					void LocalFunction() {{
-					}}
-				}}
-			}}
-			""", attribute);
+			public class TestClass {
+				public void Method() {
+					[[|Fact|]]
+					void LocalFunction1() {
+					}
+
+					[[|Theory|]]
+					void LocalFunction2() {
+					}
+				}
+			}
+			""";
 		var after = /* lang=c#-test */ """
 			using Xunit;
 
 			public class TestClass {
 				public void Method() {
-					void LocalFunction() {
+					void LocalFunction1() {
+					}
+
+					void LocalFunction2() {
 					}
 				}
 			}
 			""";
 
-		await Verify.VerifyCodeFix(LanguageVersion.CSharp9, before, after, LocalFunctionsCannotBeTestFunctionsFixer.Key_RemoveAttribute);
+		await Verify.VerifyCodeFixFixAll(LanguageVersion.CSharp9, before, after, LocalFunctionsCannotBeTestFunctionsFixer.Key_RemoveAttribute);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/MemberDataShouldReferenceValidMember_NameOfFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/MemberDataShouldReferenceValidMember_NameOfFixerTests.cs
@@ -6,7 +6,7 @@ using Verify = CSharpVerifier<Xunit.Analyzers.MemberDataShouldReferenceValidMemb
 public class MemberDataShouldReferenceValidMember_NameOfFixerTests
 {
 	[Fact]
-	public async Task ConvertStringToNameOf()
+	public async Task FixAll_ConvertsAllStringsToNameOf()
 	{
 		var before = /* lang=c#-test */ """
 			using System;
@@ -14,11 +14,16 @@ public class MemberDataShouldReferenceValidMember_NameOfFixerTests
 			using Xunit;
 
 			public class TestClass {
-				public static TheoryData<int> DataSource = new TheoryData<int>();
+				public static TheoryData<int> DataSource1 = new TheoryData<int>();
+				public static TheoryData<int> DataSource2 = new TheoryData<int>();
 
 				[Theory]
-				[MemberData({|xUnit1014:"DataSource"|})]
-				public void TestMethod(int a) { }
+				[MemberData({|xUnit1014:"DataSource1"|})]
+				public void TestMethod1(int a) { }
+
+				[Theory]
+				[MemberData({|xUnit1014:"DataSource2"|})]
+				public void TestMethod2(int a) { }
 			}
 			""";
 		var after = /* lang=c#-test */ """
@@ -27,14 +32,19 @@ public class MemberDataShouldReferenceValidMember_NameOfFixerTests
 			using Xunit;
 
 			public class TestClass {
-				public static TheoryData<int> DataSource = new TheoryData<int>();
+				public static TheoryData<int> DataSource1 = new TheoryData<int>();
+				public static TheoryData<int> DataSource2 = new TheoryData<int>();
 
 				[Theory]
-				[MemberData(nameof(DataSource))]
-				public void TestMethod(int a) { }
+				[MemberData(nameof(DataSource1))]
+				public void TestMethod1(int a) { }
+
+				[Theory]
+				[MemberData(nameof(DataSource2))]
+				public void TestMethod2(int a) { }
 			}
 			""";
 
-		await Verify.VerifyCodeFix(before, after, MemberDataShouldReferenceValidMember_NameOfFixer.Key_UseNameof);
+		await Verify.VerifyCodeFixFixAll(before, after, MemberDataShouldReferenceValidMember_NameOfFixer.Key_UseNameof);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/MemberDataShouldReferenceValidMember_NullShouldNotBeUsedForIncompatibleParameterFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/MemberDataShouldReferenceValidMember_NullShouldNotBeUsedForIncompatibleParameterFixerTests.cs
@@ -7,6 +7,45 @@ using Verify = CSharpVerifier<Xunit.Analyzers.MemberDataShouldReferenceValidMemb
 public class MemberDataShouldReferenceValidMember_NullShouldNotBeUsedForIncompatibleParameterFixerTests
 {
 	[Fact]
+	public async Task FixAll_MakesMultipleParametersNullable()
+	{
+		var before = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				public static TheoryData<int> TestData1(int n, int k) => new TheoryData<int>();
+				public static TheoryData<int> TestData2(int n, int k) => new TheoryData<int>();
+
+				[Theory]
+				[MemberData(nameof(TestData1), 42, {|xUnit1034:null|})]
+				public void TestMethod1(int a) { }
+
+				[Theory]
+				[MemberData(nameof(TestData2), 42, {|xUnit1034:null|})]
+				public void TestMethod2(int a) { }
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				public static TheoryData<int> TestData1(int n, int? k) => new TheoryData<int>();
+				public static TheoryData<int> TestData2(int n, int? k) => new TheoryData<int>();
+
+				[Theory]
+				[MemberData(nameof(TestData1), 42, null)]
+				public void TestMethod1(int a) { }
+
+				[Theory]
+				[MemberData(nameof(TestData2), 42, null)]
+				public void TestMethod2(int a) { }
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, MemberDataShouldReferenceValidMember_NullShouldNotBeUsedForIncompatibleParameterFixer.Key_MakeParameterNullable);
+	}
+
+	[Fact]
 	public async Task MakesParameterNullable()
 	{
 		var before = /* lang=c#-test */ """

--- a/src/xunit.analyzers.tests/Fixes/X1000/MemberDataShouldReferenceValidMember_ParamsForNonMethodFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/MemberDataShouldReferenceValidMember_ParamsForNonMethodFixerTests.cs
@@ -6,7 +6,7 @@ using Verify = CSharpVerifier<Xunit.Analyzers.MemberDataShouldReferenceValidMemb
 public class MemberDataShouldReferenceValidMember_ParamsForNonMethodFixerTests
 {
 	[Fact]
-	public async Task RemovesParametersFromNonMethodMemberData()
+	public async Task FixAll_RemovesParametersFromNonMethodMemberData()
 	{
 		var before = /* lang=c#-test */ """
 			using System;
@@ -15,11 +15,16 @@ public class MemberDataShouldReferenceValidMember_ParamsForNonMethodFixerTests
 
 			public class TestClass
 			{
-				public static TheoryData<int> DataSource = new TheoryData<int>();
+				public static TheoryData<int> DataSource1 = new TheoryData<int>();
+				public static TheoryData<string> DataSource2 = new TheoryData<string>();
 
 				[Theory]
-				[MemberData(nameof(DataSource), {|xUnit1021:"abc", 123|})]
-				public void TestMethod(int a) { }
+				[MemberData(nameof(DataSource1), {|xUnit1021:"abc", 123|})]
+				public void TestMethod1(int a) { }
+
+				[Theory]
+				[MemberData(nameof(DataSource2), {|xUnit1021:"xyz"|})]
+				public void TestMethod2(string b) { }
 			}
 			""";
 		var after = /* lang=c#-test */ """
@@ -29,14 +34,19 @@ public class MemberDataShouldReferenceValidMember_ParamsForNonMethodFixerTests
 
 			public class TestClass
 			{
-				public static TheoryData<int> DataSource = new TheoryData<int>();
+				public static TheoryData<int> DataSource1 = new TheoryData<int>();
+				public static TheoryData<string> DataSource2 = new TheoryData<string>();
 
 				[Theory]
-				[MemberData(nameof(DataSource))]
-				public void TestMethod(int a) { }
+				[MemberData(nameof(DataSource1))]
+				public void TestMethod1(int a) { }
+
+				[Theory]
+				[MemberData(nameof(DataSource2))]
+				public void TestMethod2(string b) { }
 			}
 			""";
 
-		await Verify.VerifyCodeFix(before, after, MemberDataShouldReferenceValidMember_ParamsForNonMethodFixer.Key_RemoveArgumentsFromMemberData);
+		await Verify.VerifyCodeFixFixAll(before, after, MemberDataShouldReferenceValidMember_ParamsForNonMethodFixer.Key_RemoveArgumentsFromMemberData);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/MemberDataShouldReferenceValidMember_ReturnTypeFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/MemberDataShouldReferenceValidMember_ReturnTypeFixerTests.cs
@@ -6,6 +6,47 @@ using Verify = CSharpVerifier<Xunit.Analyzers.MemberDataShouldReferenceValidMemb
 public class MemberDataShouldReferenceValidMember_ReturnTypeFixerTests
 {
 	[Fact]
+	public async Task FixAll_ChangesReturnTypeOnMultipleMembers()
+	{
+		var before = /* lang=c#-test */ """
+			using System.Collections.Generic;
+			using Xunit;
+
+			public class TestClass {
+				public static IEnumerable<object> Data1 => null;
+				public static IEnumerable<object> Data2 => null;
+
+				[Theory]
+				[{|xUnit1019:MemberData(nameof(Data1))|}]
+				public void TestMethod1(int a) { }
+
+				[Theory]
+				[{|xUnit1019:MemberData(nameof(Data2))|}]
+				public void TestMethod2(int a) { }
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using System.Collections.Generic;
+			using Xunit;
+
+			public class TestClass {
+				public static IEnumerable<object[]> Data1 => null;
+				public static IEnumerable<object[]> Data2 => null;
+
+				[Theory]
+				[{|xUnit1042:MemberData(nameof(Data1))|}]
+				public void TestMethod1(int a) { }
+
+				[Theory]
+				[{|xUnit1042:MemberData(nameof(Data2))|}]
+				public void TestMethod2(int a) { }
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, MemberDataShouldReferenceValidMember_ReturnTypeFixer.Key_ChangeMemberReturnType_ObjectArray);
+	}
+
+	[Fact]
 	public async Task ChangesReturnType_ObjectArray()
 	{
 		var before = /* lang=c#-test */ """

--- a/src/xunit.analyzers.tests/Fixes/X1000/MemberDataShouldReferenceValidMember_StaticFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/MemberDataShouldReferenceValidMember_StaticFixerTests.cs
@@ -6,6 +6,47 @@ using Verify = CSharpVerifier<Xunit.Analyzers.MemberDataShouldReferenceValidMemb
 public class MemberDataShouldReferenceValidMember_StaticFixerTests
 {
 	[Fact]
+	public async Task FixAll_MarksMultipleDataMembersAsStatic()
+	{
+		var before = /* lang=c#-test */ """
+			using System.Collections.Generic;
+			using Xunit;
+
+			public class TestClass {
+				public TheoryData<int> TestData1 => null;
+				public TheoryData<string> TestData2 => null;
+
+				[Theory]
+				[{|xUnit1017:MemberData(nameof(TestData1))|}]
+				public void TestMethod1(int x) { }
+
+				[Theory]
+				[{|xUnit1017:MemberData(nameof(TestData2))|}]
+				public void TestMethod2(string x) { }
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using System.Collections.Generic;
+			using Xunit;
+
+			public class TestClass {
+				public static TheoryData<int> TestData1 => null;
+				public static TheoryData<string> TestData2 => null;
+
+				[Theory]
+				[MemberData(nameof(TestData1))]
+				public void TestMethod1(int x) { }
+
+				[Theory]
+				[MemberData(nameof(TestData2))]
+				public void TestMethod2(string x) { }
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, MemberDataShouldReferenceValidMember_StaticFixer.Key_MakeMemberStatic);
+	}
+
+	[Fact]
 	public async Task MarksDataMemberAsStatic()
 	{
 		var before = /* lang=c#-test */ """

--- a/src/xunit.analyzers.tests/Fixes/X1000/MemberDataShouldReferenceValidMember_VisibilityFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/MemberDataShouldReferenceValidMember_VisibilityFixerTests.cs
@@ -5,6 +5,48 @@ using Verify = CSharpVerifier<Xunit.Analyzers.MemberDataShouldReferenceValidMemb
 
 public class MemberDataShouldReferenceValidMember_VisibilityFixerTests
 {
+	[Fact]
+	public async Task FixAll_SetsPublicModifierOnMultipleMembers()
+	{
+		var before = /* lang=c#-test */ """
+			using System.Collections.Generic;
+			using Xunit;
+
+			public class TestClass {
+				static TheoryData<int> TestData1 => null;
+				internal static TheoryData<string> TestData2 => null;
+
+				[Theory]
+				[{|xUnit1016:MemberData(nameof(TestData1))|}]
+				public void TestMethod1(int x) { }
+
+				[Theory]
+				[{|xUnit1016:MemberData(nameof(TestData2))|}]
+				public void TestMethod2(string x) { }
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using System.Collections.Generic;
+			using Xunit;
+
+			public class TestClass {
+				public static TheoryData<int> TestData1 => null;
+
+				public static TheoryData<string> TestData2 => null;
+
+				[Theory]
+				[MemberData(nameof(TestData1))]
+				public void TestMethod1(int x) { }
+
+				[Theory]
+				[MemberData(nameof(TestData2))]
+				public void TestMethod2(string x) { }
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, MemberDataShouldReferenceValidMember_VisibilityFixer.Key_MakeMemberPublic);
+	}
+
 	[Theory]
 	[InlineData("")]
 	[InlineData("protected ")]

--- a/src/xunit.analyzers.tests/Fixes/X1000/MemberDataShouldReferenceValidMember_VisibilityFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/MemberDataShouldReferenceValidMember_VisibilityFixerTests.cs
@@ -25,6 +25,26 @@ public class MemberDataShouldReferenceValidMember_VisibilityFixerTests
 				public void TestMethod2(string x) { }
 			}
 			""";
+		// Roslyn 3.11 inserts a blank line after a member whose accessibility modifiers are changed
+#if ROSLYN_LATEST
+		var after = /* lang=c#-test */ """
+			using System.Collections.Generic;
+			using Xunit;
+
+			public class TestClass {
+				public static TheoryData<int> TestData1 => null;
+				public static TheoryData<string> TestData2 => null;
+
+				[Theory]
+				[MemberData(nameof(TestData1))]
+				public void TestMethod1(int x) { }
+
+				[Theory]
+				[MemberData(nameof(TestData2))]
+				public void TestMethod2(string x) { }
+			}
+			""";
+#else
 		var after = /* lang=c#-test */ """
 			using System.Collections.Generic;
 			using Xunit;
@@ -43,6 +63,7 @@ public class MemberDataShouldReferenceValidMember_VisibilityFixerTests
 				public void TestMethod2(string x) { }
 			}
 			""";
+#endif
 
 		await Verify.VerifyCodeFixFixAll(before, after, MemberDataShouldReferenceValidMember_VisibilityFixer.Key_MakeMemberPublic);
 	}

--- a/src/xunit.analyzers.tests/Fixes/X1000/PublicMethodShouldBeMarkedAsTestFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/PublicMethodShouldBeMarkedAsTestFixerTests.cs
@@ -5,30 +5,21 @@ using Verify = CSharpVerifier<Xunit.Analyzers.PublicMethodShouldBeMarkedAsTest>;
 
 public class PublicMethodShouldBeMarkedAsTestFixerTests
 {
-	const string beforeNoParams = /* lang=c#-test */ """
-		using Xunit;
-
-		public class TestClass {
-			[Fact]
-			public void TestMethod() { }
-
-			public void [|TestMethod2|]() { }
-		}
-		""";
-	const string beforeWithParams = /* lang=c#-test */ """
-		using Xunit;
-
-		public class TestClass {
-			[Fact]
-			public void TestMethod() { }
-
-			public void [|TestMethod2|](int _) { }
-		}
-		""";
-
 	[Fact]
-	public async Task AddsFactToPublicMethodWithoutParameters()
+	public async Task FixAll_AddsFactToAllPublicMethodsWithoutParameters()
 	{
+		var before = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() { }
+
+				public void [|TestMethod2|]() { }
+
+				public void [|TestMethod3|]() { }
+			}
+			""";
 		var after = /* lang=c#-test */ """
 			using Xunit;
 
@@ -38,15 +29,30 @@ public class PublicMethodShouldBeMarkedAsTestFixerTests
 
 				[Fact]
 				public void TestMethod2() { }
+
+				[Fact]
+				public void TestMethod3() { }
 			}
 			""";
 
-		await Verify.VerifyCodeFix(beforeNoParams, after, PublicMethodShouldBeMarkedAsTestFixer.Key_ConvertToFact);
+		await Verify.VerifyCodeFixFixAll(before, after, PublicMethodShouldBeMarkedAsTestFixer.Key_ConvertToFact);
 	}
 
 	[Fact]
-	public async Task AddsFactToPublicMethodWithParameters()
+	public async Task FixAll_AddsTheoryToAllPublicMethodsWithParameters()
 	{
+		var before = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() { }
+
+				public void [|TestMethod2|](int _) { }
+
+				public void [|TestMethod3|](string _) { }
+			}
+			""";
 		var after = /* lang=c#-test */ """
 			using Xunit;
 
@@ -56,19 +62,43 @@ public class PublicMethodShouldBeMarkedAsTestFixerTests
 
 				[Theory]
 				public void TestMethod2(int _) { }
+
+				[Theory]
+				public void TestMethod3(string _) { }
 			}
 			""";
 
-		await Verify.VerifyCodeFix(beforeWithParams, after, PublicMethodShouldBeMarkedAsTestFixer.Key_ConvertToTheory);
+		await Verify.VerifyCodeFixFixAll(before, after, PublicMethodShouldBeMarkedAsTestFixer.Key_ConvertToTheory);
 	}
 
-	[Theory]
-	[InlineData(beforeNoParams)]
-	[InlineData(beforeWithParams)]
-	public async Task MarksMethodAsInternal(string before)
+	[Fact]
+	public async Task FixAll_MakesAllMethodsInternal()
 	{
-		var after = before.Replace(/* lang=c#-test */ "public void [|TestMethod2|]", /* lang=c#-test */ "internal void TestMethod2");
+		var before = /* lang=c#-test */ """
+			using Xunit;
 
-		await Verify.VerifyCodeFix(before, after, PublicMethodShouldBeMarkedAsTestFixer.Key_MakeMethodInternal);
+			public class TestClass {
+				[Fact]
+				public void TestMethod() { }
+
+				public void [|TestMethod2|]() { }
+
+				public void [|TestMethod3|]() { }
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() { }
+
+				internal void TestMethod2() { }
+
+				internal void TestMethod3() { }
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, PublicMethodShouldBeMarkedAsTestFixer.Key_MakeMethodInternal);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/TestClassMustBePublicFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/TestClassMustBePublicFixerTests.cs
@@ -5,25 +5,33 @@ using Verify = CSharpVerifier<Xunit.Analyzers.TestClassMustBePublic>;
 
 public class TestClassMustBePublicFixerTests
 {
-	[Theory]
-	[InlineData("")]
-	[InlineData("internal ")]
-	public async Task MakesClassPublic(string nonPublicAccessModifier)
+	[Fact]
+	public async Task FixAll_MakesAllClassesPublic()
 	{
-		var before = string.Format(/* lang=c#-test */ """
-			{0}class [|TestClass|] {{
+		var before = /* lang=c#-test */ """
+			class [|TestClass1|] {
 				[Xunit.Fact]
-				public void TestMethod() {{ }}
-			}}
-			""", nonPublicAccessModifier);
+				public void TestMethod() { }
+			}
+
+			internal class [|TestClass2|] {
+				[Xunit.Fact]
+				public void TestMethod() { }
+			}
+			""";
 		var after = /* lang=c#-test */ """
-			public class TestClass {
+			public class TestClass1 {
+				[Xunit.Fact]
+				public void TestMethod() { }
+			}
+
+			public class TestClass2 {
 				[Xunit.Fact]
 				public void TestMethod() { }
 			}
 			""";
 
-		await Verify.VerifyCodeFix(before, after, TestClassMustBePublicFixer.Key_MakeTestClassPublic);
+		await Verify.VerifyCodeFixFixAll(before, after, TestClassMustBePublicFixer.Key_MakeTestClassPublic);
 	}
 
 	[Fact]

--- a/src/xunit.analyzers.tests/Fixes/X1000/TestMethodMustNotHaveMultipleFactAttributesFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/TestMethodMustNotHaveMultipleFactAttributesFixerTests.cs
@@ -6,7 +6,7 @@ using Verify = CSharpVerifier<Xunit.Analyzers.TestMethodMustNotHaveMultipleFactA
 public class TestMethodMustNotHaveMultipleFactAttributesFixerTests
 {
 	[Fact]
-	public async Task RemovesSecondAttribute()
+	public async Task FixAll_RemovesDuplicateAttributes()
 	{
 		var before = /* lang=c#-test */ """
 			using Xunit;
@@ -16,7 +16,11 @@ public class TestMethodMustNotHaveMultipleFactAttributesFixerTests
 			public class TestClass {
 				[Fact]
 				[{|CS0579:Fact|}]
-				public void [|TestMethod|]() { }
+				public void [|TestMethod1|]() { }
+
+				[Fact]
+				[{|CS0579:Fact|}]
+				public void [|TestMethod2|]() { }
 			}
 			""";
 		var after = /* lang=c#-test */ """
@@ -26,10 +30,13 @@ public class TestMethodMustNotHaveMultipleFactAttributesFixerTests
 
 			public class TestClass {
 				[Fact]
-				public void TestMethod() { }
+				public void TestMethod1() { }
+
+				[Fact]
+				public void TestMethod2() { }
 			}
 			""";
 
-		await Verify.VerifyCodeFix(before, after, TestMethodMustNotHaveMultipleFactAttributesFixer.Key_KeepAttribute("Fact"));
+		await Verify.VerifyCodeFixFixAll(before, after, TestMethodMustNotHaveMultipleFactAttributesFixer.Key_KeepAttribute("Fact"));
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/TestMethodShouldNotBeSkippedFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/TestMethodShouldNotBeSkippedFixerTests.cs
@@ -6,14 +6,17 @@ using Verify = CSharpVerifier<Xunit.Analyzers.TestMethodShouldNotBeSkipped>;
 public class TestMethodShouldNotBeSkippedFixerTests
 {
 	[Fact]
-	public async Task RemovesSkipProperty()
+	public async Task FixAll_RemovesSkipFromAllMethods()
 	{
 		var before = /* lang=c#-test */ """
 			using Xunit;
 
 			public class TestClass {
 				[Fact([|Skip = "Don't run this"|])]
-				public void TestMethod() { }
+				public void TestMethod1() { }
+
+				[Fact([|Skip = "Also skipped"|])]
+				public void TestMethod2() { }
 			}
 			""";
 		var after = /* lang=c#-test */ """
@@ -21,10 +24,13 @@ public class TestMethodShouldNotBeSkippedFixerTests
 
 			public class TestClass {
 				[Fact]
-				public void TestMethod() { }
+				public void TestMethod1() { }
+
+				[Fact]
+				public void TestMethod2() { }
 			}
 			""";
 
-		await Verify.VerifyCodeFix(before, after, TestMethodShouldNotBeSkippedFixer.Key_RemoveSkipArgument);
+		await Verify.VerifyCodeFixFixAll(before, after, TestMethodShouldNotBeSkippedFixer.Key_RemoveSkipArgument);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X1000/TheoryDataShouldNotUseTheoryDataRowFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/TheoryDataShouldNotUseTheoryDataRowFixerTests.cs
@@ -22,7 +22,7 @@ public class TheoryDataShouldNotUseTheoryDataRowFixerTests
 		""";
 
 	[Fact]
-	public async Task AcceptanceTest_Fixable()
+	public async Task FixAll_ConvertsFixableTheoryDataToIEnumerable()
 	{
 		var before = /* lang=c#-test */ """
 			using System;
@@ -63,7 +63,7 @@ public class TheoryDataShouldNotUseTheoryDataRowFixerTests
 			}
 			""" + myRowSource;
 
-		await Verify.VerifyCodeFixV3(LanguageVersion.CSharp9, before, after, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
+		await Verify.VerifyCodeFixV3FixAll(LanguageVersion.CSharp9, before, after, TheoryDataShouldNotUseTheoryDataRowFixer.Key_UseIEnumerable);
 	}
 
 	[Fact]

--- a/src/xunit.analyzers.tests/Fixes/X1000/TheoryMethodCannotHaveDefaultParameterFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X1000/TheoryMethodCannotHaveDefaultParameterFixerTests.cs
@@ -9,15 +9,19 @@ using Verify_v2_Pre220 = CSharpVerifier<TheoryMethodCannotHaveDefaultParameterFi
 public class TheoryMethodCannotHaveDefaultParameterFixerTests
 {
 	[Fact]
-	public async Task RemovesDefaultParameterValue()
+	public async Task FixAll_RemovesDefaultParameterValues()
 	{
 		var before = /* lang=c#-test */ """
 			using Xunit;
 
 			public class TestClass {
 				[Theory]
-				[InlineData(1)]
-				public void TestMethod(int _ [|= 0|]) { }
+				[InlineData(1, "a")]
+				public void TestMethod1(int x [|= 0|], string y [|= "default"|]) { }
+
+				[Theory]
+				[InlineData(true)]
+				public void TestMethod2(bool b [|= false|]) { }
 			}
 			""";
 		var after = /* lang=c#-test */ """
@@ -25,12 +29,16 @@ public class TheoryMethodCannotHaveDefaultParameterFixerTests
 
 			public class TestClass {
 				[Theory]
-				[InlineData(1)]
-				public void TestMethod(int _) { }
+				[InlineData(1, "a")]
+				public void TestMethod1(int x, string y) { }
+
+				[Theory]
+				[InlineData(true)]
+				public void TestMethod2(bool b) { }
 			}
 			""";
 
-		await Verify_v2_Pre220.VerifyCodeFix(before, after, TheoryMethodCannotHaveDefaultParameterFixer.Key_RemoveParameterDefault);
+		await Verify_v2_Pre220.VerifyCodeFixV2FixAll(before, after, TheoryMethodCannotHaveDefaultParameterFixer.Key_RemoveParameterDefault);
 	}
 
 	internal class Analyzer : TheoryMethodCannotHaveDefaultParameter

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertCollectionContainsShouldNotUseBoolCheckFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertCollectionContainsShouldNotUseBoolCheckFixerTests.cs
@@ -5,47 +5,40 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertCollectionContainsShouldNotU
 
 public class AssertCollectionContainsShouldNotUseBoolCheckFixerTests
 {
-	const string template = /* lang=c#-test */ """
-		using System;
-		using System.Linq;
-		using Xunit;
-
-		public class TestClass {{
-			[Fact]
-			public void TestMethod() {{
-				var items = new[] {{ "a", "b", "c" }};
-
-				{0};
-			}}
-		}}
-		""";
-
-	[Theory]
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.True(items.Contains(""b""))|]",
-		/* lang=c#-test */ @"Assert.Contains(""b"", items)")]
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.True(items.Contains(""b"", StringComparer.Ordinal))|]",
-		/* lang=c#-test */ @"Assert.Contains(""b"", items, StringComparer.Ordinal)")]
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.True(items.Contains(""b"", null))|]",
-		/* lang=c#-test */ @"Assert.Contains(""b"", items)")]
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.False(items.Contains(""b""))|]",
-		/* lang=c#-test */ @"Assert.DoesNotContain(""b"", items)")]
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.False(items.Contains(""b"", StringComparer.Ordinal))|]",
-		/* lang=c#-test */ @"Assert.DoesNotContain(""b"", items, StringComparer.Ordinal)")]
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.False(items.Contains(""b"", null))|]",
-		/* lang=c#-test */ @"Assert.DoesNotContain(""b"", items)")]
-	public async Task ReplacesBooleanAssert(
-		string beforeAssert,
-		string afterAssert)
+	[Fact]
+	public async Task FixAll_ReplacesAllBooleanAsserts()
 	{
-		var before = string.Format(template, beforeAssert);
-		var after = string.Format(template, afterAssert);
+		var before = /* lang=c#-test */ """
+			using System;
+			using System.Linq;
+			using Xunit;
 
-		await Verify.VerifyCodeFix(before, after, AssertCollectionContainsShouldNotUseBoolCheckFixer.Key_UseAlternateAssert);
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var items = new[] { "a", "b", "c" };
+
+					[|Assert.True(items.Contains("b"))|];
+					[|Assert.False(items.Contains("b"))|];
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using System;
+			using System.Linq;
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var items = new[] { "a", "b", "c" };
+
+					Assert.Contains("b", items);
+					Assert.DoesNotContain("b", items);
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, AssertCollectionContainsShouldNotUseBoolCheckFixer.Key_UseAlternateAssert);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertCollectionContainsShouldNotUseBoolCheckFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertCollectionContainsShouldNotUseBoolCheckFixerTests.cs
@@ -5,6 +5,50 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertCollectionContainsShouldNotU
 
 public class AssertCollectionContainsShouldNotUseBoolCheckFixerTests
 {
+	const string template = /* lang=c#-test */ """
+		using System;
+		using System.Linq;
+		using Xunit;
+
+		public class TestClass {{
+			[Fact]
+			public void TestMethod() {{
+				var items = new[] {{ "a", "b", "c" }};
+
+				{0};
+			}}
+		}}
+		""";
+
+	[Theory]
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.True(items.Contains(""b""))|]",
+		/* lang=c#-test */ @"Assert.Contains(""b"", items)")]
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.True(items.Contains(""b"", StringComparer.Ordinal))|]",
+		/* lang=c#-test */ @"Assert.Contains(""b"", items, StringComparer.Ordinal)")]
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.True(items.Contains(""b"", null))|]",
+		/* lang=c#-test */ @"Assert.Contains(""b"", items)")]
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.False(items.Contains(""b""))|]",
+		/* lang=c#-test */ @"Assert.DoesNotContain(""b"", items)")]
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.False(items.Contains(""b"", StringComparer.Ordinal))|]",
+		/* lang=c#-test */ @"Assert.DoesNotContain(""b"", items, StringComparer.Ordinal)")]
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.False(items.Contains(""b"", null))|]",
+		/* lang=c#-test */ @"Assert.DoesNotContain(""b"", items)")]
+	public async Task ReplacesBooleanAssert(
+		string beforeAssert,
+		string afterAssert)
+	{
+		var before = string.Format(template, beforeAssert);
+		var after = string.Format(template, afterAssert);
+
+		await Verify.VerifyCodeFix(before, after, AssertCollectionContainsShouldNotUseBoolCheckFixer.Key_UseAlternateAssert);
+	}
+
 	[Fact]
 	public async Task FixAll_ReplacesAllBooleanAsserts()
 	{

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertEmptyCollectionCheckShouldNotBeUsedFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertEmptyCollectionCheckShouldNotBeUsedFixerTests.cs
@@ -5,54 +5,73 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertEmptyCollectionCheckShouldNo
 
 public class AssertEmptyCollectionCheckShouldNotBeUsedFixerTests
 {
-	const string before = /* lang=c#-test */ """
-		using Xunit;
-
-		public class TestClass {
-			[Fact]
-			public void TestMethod() {
-				var collection = new[] { 1, 2, 3 };
-
-				[|Assert.Collection(collection)|];
-			}
-		}
-		""";
-
 	[Fact]
-	public async Task UseEmptyCheck()
+	public async Task FixAll_UsesEmptyCheck()
 	{
+		var before = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var collection1 = new[] { 1, 2, 3 };
+					var collection2 = new[] { 4, 5, 6 };
+
+					[|Assert.Collection(collection1)|];
+					[|Assert.Collection(collection2)|];
+				}
+			}
+			""";
 		var after = /* lang=c#-test */ """
 			using Xunit;
 
 			public class TestClass {
 				[Fact]
 				public void TestMethod() {
-					var collection = new[] { 1, 2, 3 };
+					var collection1 = new[] { 1, 2, 3 };
+					var collection2 = new[] { 4, 5, 6 };
 
-					Assert.Empty(collection);
+					Assert.Empty(collection1);
+					Assert.Empty(collection2);
 				}
 			}
 			""";
 
-		await Verify.VerifyCodeFix(before, after, AssertEmptyCollectionCheckShouldNotBeUsedFixer.Key_UseAssertEmpty);
+		await Verify.VerifyCodeFixFixAll(before, after, AssertEmptyCollectionCheckShouldNotBeUsedFixer.Key_UseAssertEmpty);
 	}
 
 	[Fact]
-	public async Task AddElementInspector()
+	public async Task FixAll_AddsElementInspector()
 	{
+		var before = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var collection1 = new[] { 1, 2, 3 };
+					var collection2 = new[] { 4, 5, 6 };
+
+					[|Assert.Collection(collection1)|];
+					[|Assert.Collection(collection2)|];
+				}
+			}
+			""";
 		var after = /* lang=c#-test */ """
 			using Xunit;
 
 			public class TestClass {
 				[Fact]
 				public void TestMethod() {
-					var collection = new[] { 1, 2, 3 };
+					var collection1 = new[] { 1, 2, 3 };
+					var collection2 = new[] { 4, 5, 6 };
 
-					Assert.Collection(collection, x => { });
+					Assert.Collection(collection1, x => { });
+					Assert.Collection(collection2, x => { });
 				}
 			}
 			""";
 
-		await Verify.VerifyCodeFix(before, after, AssertEmptyCollectionCheckShouldNotBeUsedFixer.Key_AddElementInspector);
+		await Verify.VerifyCodeFixFixAll(before, after, AssertEmptyCollectionCheckShouldNotBeUsedFixer.Key_AddElementInspector);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertEmptyOrNotEmptyShouldNotBeUsedForContainsChecksFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertEmptyOrNotEmptyShouldNotBeUsedForContainsChecksFixerTests.cs
@@ -5,60 +5,73 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertEmptyOrNotEmptyShouldNotBeUs
 
 public class AssertEmptyOrNotEmptyShouldNotBeUsedForContainsChecksFixerTests
 {
-	const string template = /* lang=c#-test */ """
-		using System.Linq;
-		using Xunit;
-
-		public class TestClass {{
-			[Fact]
-			public void TestMethod() {{
-				var list = new[] {{ -1, 0, 1, 2 }};
-
-				{0};
-			}}
-
-			public bool IsEven(int num) => num % 2 == 0;
-		}}
-		""";
-
-	[Theory]
-	[InlineData(
-		/* lang=c#-test */ "{|xUnit2029:Assert.Empty(list.Where(f => f > 0))|}",
-		/* lang=c#-test */ "Assert.DoesNotContain(list, f => f > 0)")]
-	[InlineData(
-		/* lang=c#-test */ "{|xUnit2029:Assert.Empty(list.Where(n => n == 1))|}",
-		/* lang=c#-test */ "Assert.DoesNotContain(list, n => n == 1)")]
-	[InlineData(
-		/* lang=c#-test */ "{|xUnit2029:Assert.Empty(list.Where(IsEven))|}",
-		/* lang=c#-test */ "Assert.DoesNotContain(list, IsEven)")]
-	public async Task FixerReplacesAssertEmptyWithAssertDoesNotContain(
-		string beforeAssert,
-		string afterAssert)
+	[Fact]
+	public async Task FixAll_ReplacesAssertEmptyWithDoesNotContain()
 	{
-		var before = string.Format(template, beforeAssert);
-		var after = string.Format(template, afterAssert);
+		var before = /* lang=c#-test */ """
+			using System.Linq;
+			using Xunit;
 
-		await Verify.VerifyCodeFix(before, after, AssertEmptyOrNotEmptyShouldNotBeUsedForContainsChecksFixer.Key_UseDoesNotContain);
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var list = new[] { -1, 0, 1, 2 };
+
+					{|xUnit2029:Assert.Empty(list.Where(f => f > 0))|};
+					{|xUnit2029:Assert.Empty(list.Where(n => n == 1))|};
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using System.Linq;
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var list = new[] { -1, 0, 1, 2 };
+
+					Assert.DoesNotContain(list, f => f > 0);
+					Assert.DoesNotContain(list, n => n == 1);
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, AssertEmptyOrNotEmptyShouldNotBeUsedForContainsChecksFixer.Key_UseDoesNotContain);
 	}
 
-	[Theory]
-	[InlineData(
-		/* lang=c#-test */ "{|xUnit2030:Assert.NotEmpty(list.Where(f => f > 0))|}",
-		/* lang=c#-test */ "Assert.Contains(list, f => f > 0)")]
-	[InlineData(
-		/* lang=c#-test */ "{|xUnit2030:Assert.NotEmpty(list.Where(n => n == 1))|}",
-		/* lang=c#-test */ "Assert.Contains(list, n => n == 1)")]
-	[InlineData(
-		/* lang=c#-test */ "{|xUnit2030:Assert.NotEmpty(list.Where(IsEven))|}",
-		/* lang=c#-test */ "Assert.Contains(list, IsEven)")]
-
-	public async Task FixerReplacesAssertNotEmptyWithAssertContains(
-		string beforeAssert,
-		string afterAssert)
+	[Fact]
+	public async Task FixAll_ReplacesAssertNotEmptyWithContains()
 	{
-		var before = string.Format(template, beforeAssert);
-		var after = string.Format(template, afterAssert);
+		var before = /* lang=c#-test */ """
+			using System.Linq;
+			using Xunit;
 
-		await Verify.VerifyCodeFix(before, after, AssertEmptyOrNotEmptyShouldNotBeUsedForContainsChecksFixer.Key_UseContains);
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var list = new[] { -1, 0, 1, 2 };
+
+					{|xUnit2030:Assert.NotEmpty(list.Where(f => f > 0))|};
+					{|xUnit2030:Assert.NotEmpty(list.Where(n => n == 1))|};
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using System.Linq;
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var list = new[] { -1, 0, 1, 2 };
+
+					Assert.Contains(list, f => f > 0);
+					Assert.Contains(list, n => n == 1);
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, AssertEmptyOrNotEmptyShouldNotBeUsedForContainsChecksFixer.Key_UseContains);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertEmptyOrNotEmptyShouldNotBeUsedForContainsChecksFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertEmptyOrNotEmptyShouldNotBeUsedForContainsChecksFixerTests.cs
@@ -5,6 +5,62 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertEmptyOrNotEmptyShouldNotBeUs
 
 public class AssertEmptyOrNotEmptyShouldNotBeUsedForContainsChecksFixerTests
 {
+	const string template = /* lang=c#-test */ """
+		using System.Linq;
+		using Xunit;
+
+		public class TestClass {{
+			[Fact]
+			public void TestMethod() {{
+				var list = new[] {{ -1, 0, 1, 2 }};
+
+				{0};
+			}}
+
+			public bool IsEven(int num) => num % 2 == 0;
+		}}
+		""";
+
+	[Theory]
+	[InlineData(
+		/* lang=c#-test */ "{|xUnit2029:Assert.Empty(list.Where(f => f > 0))|}",
+		/* lang=c#-test */ "Assert.DoesNotContain(list, f => f > 0)")]
+	[InlineData(
+		/* lang=c#-test */ "{|xUnit2029:Assert.Empty(list.Where(n => n == 1))|}",
+		/* lang=c#-test */ "Assert.DoesNotContain(list, n => n == 1)")]
+	[InlineData(
+		/* lang=c#-test */ "{|xUnit2029:Assert.Empty(list.Where(IsEven))|}",
+		/* lang=c#-test */ "Assert.DoesNotContain(list, IsEven)")]
+	public async Task FixerReplacesAssertEmptyWithAssertDoesNotContain(
+		string beforeAssert,
+		string afterAssert)
+	{
+		var before = string.Format(template, beforeAssert);
+		var after = string.Format(template, afterAssert);
+
+		await Verify.VerifyCodeFix(before, after, AssertEmptyOrNotEmptyShouldNotBeUsedForContainsChecksFixer.Key_UseDoesNotContain);
+	}
+
+	[Theory]
+	[InlineData(
+		/* lang=c#-test */ "{|xUnit2030:Assert.NotEmpty(list.Where(f => f > 0))|}",
+		/* lang=c#-test */ "Assert.Contains(list, f => f > 0)")]
+	[InlineData(
+		/* lang=c#-test */ "{|xUnit2030:Assert.NotEmpty(list.Where(n => n == 1))|}",
+		/* lang=c#-test */ "Assert.Contains(list, n => n == 1)")]
+	[InlineData(
+		/* lang=c#-test */ "{|xUnit2030:Assert.NotEmpty(list.Where(IsEven))|}",
+		/* lang=c#-test */ "Assert.Contains(list, IsEven)")]
+	public async Task FixerReplacesAssertNotEmptyWithAssertContains(
+		string beforeAssert,
+		string afterAssert)
+	{
+		var before = string.Format(template, beforeAssert);
+		var after = string.Format(template, afterAssert);
+
+		await Verify.VerifyCodeFix(before, after, AssertEmptyOrNotEmptyShouldNotBeUsedForContainsChecksFixer.Key_UseContains);
+	}
+
 	[Fact]
 	public async Task FixAll_ReplacesAssertEmptyWithDoesNotContain()
 	{

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertEnumerableAnyCheckShouldNotBeUsedForCollectionContainsCheckFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertEnumerableAnyCheckShouldNotBeUsedForCollectionContainsCheckFixerTests.cs
@@ -5,34 +5,38 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertEnumerableAnyCheckShouldNotB
 
 public class AssertEnumerableAnyCheckShouldNotBeUsedForCollectionContainsCheckFixerTests
 {
-	const string template = /* lang=c#-test */ """
-		using System.Linq;
-		using Xunit;
-
-		public class TestClass {{
-			[Fact]
-			public void TestMethod() {{
-				var collection = new[] {{ 1, 2, 3 }};
-
-				{0};
-			}}
-		}}
-		""";
-
-	[Theory]
-	[InlineData(
-		/* lang=c#-test */ "[|Assert.True(collection.Any(x => x == 2))|]",
-		/* lang=c#-test */ "Assert.Contains(collection, x => x == 2)")]
-	[InlineData(
-		/* lang=c#-test */ "[|Assert.False(collection.Any(x => x == 2))|]",
-		/* lang=c#-test */ "Assert.DoesNotContain(collection, x => x == 2)")]
-	public async Task ReplacesAssert(
-		string beforeAssert,
-		string afterAssert)
+	[Fact]
+	public async Task FixAll_ReplacesAllAsserts()
 	{
-		var before = string.Format(template, beforeAssert);
-		var after = string.Format(template, afterAssert);
+		var before = /* lang=c#-test */ """
+			using System.Linq;
+			using Xunit;
 
-		await Verify.VerifyCodeFix(before, after, AssertEnumerableAnyCheckShouldNotBeUsedForCollectionContainsCheckFixer.Key_UseAlternateAssert);
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var collection = new[] { 1, 2, 3 };
+
+					[|Assert.True(collection.Any(x => x == 2))|];
+					[|Assert.False(collection.Any(x => x == 2))|];
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using System.Linq;
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var collection = new[] { 1, 2, 3 };
+
+					Assert.Contains(collection, x => x == 2);
+					Assert.DoesNotContain(collection, x => x == 2);
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, AssertEnumerableAnyCheckShouldNotBeUsedForCollectionContainsCheckFixer.Key_UseAlternateAssert);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualGenericShouldNotBeUsedForStringValueFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualGenericShouldNotBeUsedForStringValueFixerTests.cs
@@ -1,32 +1,42 @@
 using System.Threading.Tasks;
 using Xunit;
-using Xunit.Analyzers;
 using Xunit.Analyzers.Fixes;
 using Verify = CSharpVerifier<Xunit.Analyzers.AssertEqualGenericShouldNotBeUsedForStringValue>;
 
 public class AssertEqualGenericShouldNotBeUsedForStringValueFixerTests
 {
-	const string template = /* lang=c#-test */ """
-		using Xunit;
-
-		public class TestClass {{
-			[Fact]
-			public void TestMethod() {{
-				string result = "foo";
-
-				{0};
-			}}
-		}}
-		""";
-
-	[Theory]
-	[InlineData(Constants.Asserts.Equal)]
-	[InlineData(Constants.Asserts.StrictEqual)]
-	public async Task RemovesGeneric(string assert)
+	[Fact]
+	public async Task FixAll_RemovesGenericFromAllAsserts()
 	{
-		var before = string.Format(template, $@"[|Assert.{assert}<string>(""foo"", result)|]");
-		var after = string.Format(template, @"Assert.Equal(""foo"", result)");
+		var before = /* lang=c#-test */ """
+			using Xunit;
 
-		await Verify.VerifyCodeFix(before, after, AssertEqualGenericShouldNotBeUsedForStringValueFixer.Key_UseStringAssertEqual);
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					string result1 = "foo";
+					string result2 = "bar";
+
+					[|Assert.Equal<string>("foo", result1)|];
+					[|Assert.StrictEqual<string>("bar", result2)|];
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					string result1 = "foo";
+					string result2 = "bar";
+
+					Assert.Equal("foo", result1);
+					Assert.Equal("bar", result2);
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, AssertEqualGenericShouldNotBeUsedForStringValueFixer.Key_UseStringAssertEqual);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualLiteralValueShouldBeFirstFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualLiteralValueShouldBeFirstFixerTests.cs
@@ -1,10 +1,57 @@
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 using Xunit.Analyzers.Fixes;
 using Verify = CSharpVerifier<Xunit.Analyzers.AssertEqualLiteralValueShouldBeFirst>;
 
 public class AssertEqualLiteralValueShouldBeFirstFixerTests
 {
+	const string Template = /* lang=c#-test */ """
+		using System.Collections.Generic;
+
+		public class TestClass {{
+			[Xunit.Fact]
+			public void TestMethod() {{
+				var i = 0;
+				[|Xunit.{0}|];
+			}}
+		}}
+		""";
+
+	[Theory]
+	[InlineData(
+		/* lang=c#-test */ "Assert.Equal(i, 0)",
+		/* lang=c#-test */ "Assert.Equal(0, i)")]
+	[InlineData(
+		/* lang=c#-test */ "Assert.Equal(actual: 0, expected: i)",
+		/* lang=c#-test */ "Assert.Equal(actual: i, expected: 0)")]
+	[InlineData(
+		/* lang=c#-test */ "Assert.Equal(expected: i, actual: 0)",
+		/* lang=c#-test */ "Assert.Equal(expected: 0, actual: i)")]
+	[InlineData(
+		/* lang=c#-test */ "Assert.Equal(comparer: default(IEqualityComparer<int>), actual: 0, expected: i)",
+		/* lang=c#-test */ "Assert.Equal(comparer: default(IEqualityComparer<int>), actual: i, expected: 0)")]
+	[InlineData(
+		/* lang=c#-test */ "Assert.Equal(comparer: (x, y) => true, actual: 0, expected: i)",
+		/* lang=c#-test */ "Assert.Equal(comparer: (x, y) => true, actual: i, expected: 0)")]
+	[InlineData(
+		/* lang=c#-test */ "Assert.Equal(expected: i, 0)",
+		/* lang=c#-test */ "Assert.Equal(expected: 0, i)",
+		LanguageVersion.CSharp7_2)]
+	public async Task SwapArguments(
+		string beforeAssert,
+		string afterAssert,
+		LanguageVersion? languageVersion = null)
+	{
+		var before = string.Format(Template, beforeAssert);
+		var after = string.Format(Template, afterAssert);
+
+		if (languageVersion.HasValue)
+			await Verify.VerifyCodeFix(languageVersion.Value, before, after, AssertEqualLiteralValueShouldBeFirstFixer.Key_SwapArguments);
+		else
+			await Verify.VerifyCodeFix(before, after, AssertEqualLiteralValueShouldBeFirstFixer.Key_SwapArguments);
+	}
+
 	[Fact]
 	public async Task FixAll_SwapsAllArguments()
 	{

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualLiteralValueShouldBeFirstFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualLiteralValueShouldBeFirstFixerTests.cs
@@ -1,54 +1,38 @@
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 using Xunit.Analyzers.Fixes;
 using Verify = CSharpVerifier<Xunit.Analyzers.AssertEqualLiteralValueShouldBeFirst>;
 
 public class AssertEqualLiteralValueShouldBeFirstFixerTests
 {
-	const string Template = /* lang=c#-test */ """
-		using System.Collections.Generic;
-
-		public class TestClass {{
-			[Xunit.Fact]
-			public void TestMethod() {{
-				var i = 0;
-				[|Xunit.{0}|];
-			}}
-		}}
-		""";
-
-	[Theory]
-	[InlineData(
-		/* lang=c#-test */ "Assert.Equal(i, 0)",
-		/* lang=c#-test */ "Assert.Equal(0, i)")]
-	[InlineData(
-		/* lang=c#-test */ "Assert.Equal(actual: 0, expected: i)",
-		/* lang=c#-test */ "Assert.Equal(actual: i, expected: 0)")]
-	[InlineData(
-		/* lang=c#-test */ "Assert.Equal(expected: i, actual: 0)",
-		/* lang=c#-test */ "Assert.Equal(expected: 0, actual: i)")]
-	[InlineData(
-		/* lang=c#-test */ "Assert.Equal(comparer: default(IEqualityComparer<int>), actual: 0, expected: i)",
-		/* lang=c#-test */ "Assert.Equal(comparer: default(IEqualityComparer<int>), actual: i, expected: 0)")]
-	[InlineData(
-		/* lang=c#-test */ "Assert.Equal(comparer: (x, y) => true, actual: 0, expected: i)",
-		/* lang=c#-test */ "Assert.Equal(comparer: (x, y) => true, actual: i, expected: 0)")]
-	[InlineData(
-		/* lang=c#-test */ "Assert.Equal(expected: i, 0)",
-		/* lang=c#-test */ "Assert.Equal(expected: 0, i)",
-		LanguageVersion.CSharp7_2)]
-	public async Task SwapArguments(
-		string beforeAssert,
-		string afterAssert,
-		LanguageVersion? languageVersion = null)
+	[Fact]
+	public async Task FixAll_SwapsAllArguments()
 	{
-		var before = string.Format(Template, beforeAssert);
-		var after = string.Format(Template, afterAssert);
+		var before = /* lang=c#-test */ """
+			public class TestClass {
+				[Xunit.Fact]
+				public void TestMethod() {
+					var i = 0;
+					var j = 1;
 
-		if (languageVersion.HasValue)
-			await Verify.VerifyCodeFix(languageVersion.Value, before, after, AssertEqualLiteralValueShouldBeFirstFixer.Key_SwapArguments);
-		else
-			await Verify.VerifyCodeFix(before, after, AssertEqualLiteralValueShouldBeFirstFixer.Key_SwapArguments);
+					[|Xunit.Assert.Equal(i, 0)|];
+					[|Xunit.Assert.Equal(j, 1)|];
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			public class TestClass {
+				[Xunit.Fact]
+				public void TestMethod() {
+					var i = 0;
+					var j = 1;
+
+					Xunit.Assert.Equal(0, i);
+					Xunit.Assert.Equal(1, j);
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, AssertEqualLiteralValueShouldBeFirstFixer.Key_SwapArguments);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualPrecisionShouldBeInRangeFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualPrecisionShouldBeInRangeFixerTests.cs
@@ -5,39 +5,32 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertEqualPrecisionShouldBeInRang
 
 public class AssertEqualPrecisionShouldBeInRangeFixerTests
 {
-	const string template = /* lang=c#-test */ """
-		using Xunit;
-
-		public class TestClass {{
-			[Fact]
-			public void TestMethod() {{
-				{0};
-			}}
-		}}
-		""";
-
-	[Theory]
-	// double = [0..15]
-	[InlineData(
-		/* lang=c#-test */ "Assert.Equal(10.1d, 10.2d, [|-1|])",
-		/* lang=c#-test */ "Assert.Equal(10.1d, 10.2d, 0)")]
-	[InlineData(
-		/* lang=c#-test */ "Assert.Equal(10.1d, 10.2d, [|16|])",
-		/* lang=c#-test */ "Assert.Equal(10.1d, 10.2d, 15)")]
-	// decimal = [0..28]
-	[InlineData(
-		/* lang=c#-test */ "Assert.Equal(10.1m, 10.2m, [|-1|])",
-		/* lang=c#-test */ "Assert.Equal(10.1m, 10.2m, 0)")]
-	[InlineData(
-		/* lang=c#-test */ "Assert.Equal(10.1m, 10.2m, [|29|])",
-		/* lang=c#-test */ "Assert.Equal(10.1m, 10.2m, 28)")]
-	public async Task ChangesPrecisionToZero(
-		string beforeAssert,
-		string afterAssert)
+	[Fact]
+	public async Task FixAll_ChangesPrecisionToValidRange()
 	{
-		var before = string.Format(template, beforeAssert);
-		var after = string.Format(template, afterAssert);
+		var before = /* lang=c#-test */ """
+			using Xunit;
 
-		await Verify.VerifyCodeFix(before, after, AssertEqualPrecisionShouldBeInRangeFixer.Key_UsePrecision);
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					Assert.Equal(10.1d, 10.2d, [|-1|]);
+					Assert.Equal(10.1m, 10.2m, [|29|]);
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					Assert.Equal(10.1d, 10.2d, 0);
+					Assert.Equal(10.1m, 10.2m, 28);
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, AssertEqualPrecisionShouldBeInRangeFixer.Key_UsePrecision);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualShouldNotBeUsedForBoolLiteralCheckFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualShouldNotBeUsedForBoolLiteralCheckFixerTests.cs
@@ -5,51 +5,36 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertEqualShouldNotBeUsedForBoolL
 
 public class AssertEqualShouldNotBeUsedForBoolLiteralCheckFixerTests
 {
-	const string template = /* lang=c#-test */ """
-		using Xunit;
-
-		public class TestClass {{
-			[Fact]
-			public void TestMethod() {{
-				var actual = true;
-
-				{0};
-			}}
-		}}
-		""";
-
-	[Theory]
-	[InlineData(
-		/* lang=c#-test */ "[|Assert.Equal(false, actual)|]",
-		/* lang=c#-test */ "Assert.False(actual)")]
-	[InlineData(
-		/* lang=c#-test */ "[|Assert.Equal(true, actual)|]",
-		/* lang=c#-test */ "Assert.True(actual)")]
-	[InlineData(
-		/* lang=c#-test */ "[|Assert.StrictEqual(false, actual)|]",
-		/* lang=c#-test */ "Assert.False(actual)")]
-	[InlineData(
-		/* lang=c#-test */ "[|Assert.StrictEqual(true, actual)|]",
-		/* lang=c#-test */ "Assert.True(actual)")]
-	[InlineData(
-		/* lang=c#-test */ "[|Assert.NotEqual(false, actual)|]",
-		/* lang=c#-test */ "Assert.True(actual)")]
-	[InlineData(
-		/* lang=c#-test */ "[|Assert.NotEqual(true, actual)|]",
-		/* lang=c#-test */ "Assert.False(actual)")]
-	[InlineData(
-		/* lang=c#-test */ "[|Assert.NotStrictEqual(false, actual)|]",
-		/* lang=c#-test */ "Assert.True(actual)")]
-	[InlineData(
-		/* lang=c#-test */ "[|Assert.NotStrictEqual(true, actual)|]",
-		/* lang=c#-test */ "Assert.False(actual)")]
-	public async Task ConvertsToBooleanAssert(
-		string beforeAssert,
-		string afterAssert)
+	[Fact]
+	public async Task FixAll_ConvertsAllToBooleanAsserts()
 	{
-		var before = string.Format(template, beforeAssert);
-		var after = string.Format(template, afterAssert);
+		var before = /* lang=c#-test */ """
+			using Xunit;
 
-		await Verify.VerifyCodeFix(before, after, AssertEqualShouldNotBeUsedForBoolLiteralCheckFixer.Key_UseAlternateAssert);
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var actual = true;
+
+					[|Assert.Equal(false, actual)|];
+					[|Assert.Equal(true, actual)|];
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var actual = true;
+
+					Assert.False(actual);
+					Assert.True(actual);
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, AssertEqualShouldNotBeUsedForBoolLiteralCheckFixer.Key_UseAlternateAssert);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualShouldNotBeUsedForBoolLiteralCheckFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualShouldNotBeUsedForBoolLiteralCheckFixerTests.cs
@@ -5,6 +5,54 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertEqualShouldNotBeUsedForBoolL
 
 public class AssertEqualShouldNotBeUsedForBoolLiteralCheckFixerTests
 {
+	const string template = /* lang=c#-test */ """
+		using Xunit;
+
+		public class TestClass {{
+			[Fact]
+			public void TestMethod() {{
+				var actual = true;
+
+				{0};
+			}}
+		}}
+		""";
+
+	[Theory]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.Equal(false, actual)|]",
+		/* lang=c#-test */ "Assert.False(actual)")]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.Equal(true, actual)|]",
+		/* lang=c#-test */ "Assert.True(actual)")]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.StrictEqual(false, actual)|]",
+		/* lang=c#-test */ "Assert.False(actual)")]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.StrictEqual(true, actual)|]",
+		/* lang=c#-test */ "Assert.True(actual)")]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.NotEqual(false, actual)|]",
+		/* lang=c#-test */ "Assert.True(actual)")]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.NotEqual(true, actual)|]",
+		/* lang=c#-test */ "Assert.False(actual)")]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.NotStrictEqual(false, actual)|]",
+		/* lang=c#-test */ "Assert.True(actual)")]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.NotStrictEqual(true, actual)|]",
+		/* lang=c#-test */ "Assert.False(actual)")]
+	public async Task ConvertsToBooleanAssert(
+		string beforeAssert,
+		string afterAssert)
+	{
+		var before = string.Format(template, beforeAssert);
+		var after = string.Format(template, afterAssert);
+
+		await Verify.VerifyCodeFix(before, after, AssertEqualShouldNotBeUsedForBoolLiteralCheckFixer.Key_UseAlternateAssert);
+	}
+
 	[Fact]
 	public async Task FixAll_ConvertsAllToBooleanAsserts()
 	{

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualShouldNotBeUsedForCollectionSizeCheckFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualShouldNotBeUsedForCollectionSizeCheckFixerTests.cs
@@ -5,6 +5,40 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertEqualShouldNotBeUsedForColle
 
 public class AssertEqualShouldNotBeUsedForCollectionSizeCheckFixerTests
 {
+	const string template = /* lang=c#-test */ """
+		using System.Linq;
+		using Xunit;
+
+		public class TestClass {{
+			[Fact]
+			public void TestMethod() {{
+				var data = new[] {{ 1, 2, 3 }};
+
+				{0};
+			}}
+		}}
+		""";
+
+	[Theory]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.Equal(1, data.Count())|]",
+		/* lang=c#-test */ "Assert.Single(data)")]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.Equal(0, data.Count())|]",
+		/* lang=c#-test */ "Assert.Empty(data)")]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.NotEqual(0, data.Count())|]",
+		/* lang=c#-test */ "Assert.NotEmpty(data)")]
+	public async Task ReplacesCollectionCountWithAppropriateAssert(
+		string beforeAssert,
+		string afterAssert)
+	{
+		var before = string.Format(template, beforeAssert);
+		var after = string.Format(template, afterAssert);
+
+		await Verify.VerifyCodeFix(before, after, AssertEqualShouldNotBeUsedForCollectionSizeCheckFixer.Key_UseAlternateAssert);
+	}
+
 	[Fact]
 	public async Task FixAll_ReplacesAllCollectionSizeChecks()
 	{

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualShouldNotBeUsedForNullCheckFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualShouldNotBeUsedForNullCheckFixerTests.cs
@@ -5,6 +5,42 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertEqualShouldNotBeUsedForNullC
 
 public class AssertEqualShouldNotBeUsedForNullCheckFixerTests
 {
+	const string template = /* lang=c#-test */ """
+		using Xunit;
+
+		public class TestClass {{
+			[Fact]
+			public void TestMethod() {{
+				int? data = 1;
+
+				{0};
+			}}
+		}}
+		""";
+
+	[Theory]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.Equal(null, data)|]",
+		/* lang=c#-test */ "Assert.Null(data)")]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.StrictEqual(null, data)|]",
+		/* lang=c#-test */ "Assert.Null(data)")]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.NotEqual(null, data)|]",
+		/* lang=c#-test */ "Assert.NotNull(data)")]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.NotStrictEqual(null, data)|]",
+		/* lang=c#-test */ "Assert.NotNull(data)")]
+	public async Task ConvertsToAppropriateNullAssert(
+		string beforeAssert,
+		string afterAssert)
+	{
+		var before = string.Format(template, beforeAssert);
+		var after = string.Format(template, afterAssert);
+
+		await Verify.VerifyCodeFix(before, after, AssertEqualShouldNotBeUsedForNullCheckFixer.Key_UseAlternateAssert);
+	}
+
 	[Fact]
 	public async Task FixAll_ReplacesAllNullChecks()
 	{

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualShouldNotBeUsedForNullCheckFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualShouldNotBeUsedForNullCheckFixerTests.cs
@@ -5,39 +5,36 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertEqualShouldNotBeUsedForNullC
 
 public class AssertEqualShouldNotBeUsedForNullCheckFixerTests
 {
-	const string template = /* lang=c#-test */ """
-		using Xunit;
-
-		public class TestClass {{
-			[Fact]
-			public void TestMethod() {{
-				int? data = 1;
-
-				{0};
-			}}
-		}}
-		""";
-
-	[Theory]
-	[InlineData(
-		/* lang=c#-test */ "[|Assert.Equal(null, data)|]",
-		/* lang=c#-test */ "Assert.Null(data)")]
-	[InlineData(
-		/* lang=c#-test */ "[|Assert.StrictEqual(null, data)|]",
-		/* lang=c#-test */ "Assert.Null(data)")]
-	[InlineData(
-		/* lang=c#-test */ "[|Assert.NotEqual(null, data)|]",
-		/* lang=c#-test */ "Assert.NotNull(data)")]
-	[InlineData(
-		/* lang=c#-test */ "[|Assert.NotStrictEqual(null, data)|]",
-		/* lang=c#-test */ "Assert.NotNull(data)")]
-	public async Task ConvertsToAppropriateNullAssert(
-		string beforeAssert,
-		string afterAssert)
+	[Fact]
+	public async Task FixAll_ReplacesAllNullChecks()
 	{
-		var before = string.Format(template, beforeAssert);
-		var after = string.Format(template, afterAssert);
+		var before = /* lang=c#-test */ """
+			using Xunit;
 
-		await Verify.VerifyCodeFix(before, after, AssertEqualShouldNotBeUsedForNullCheckFixer.Key_UseAlternateAssert);
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					int? data = 1;
+
+					[|Assert.Equal(null, data)|];
+					[|Assert.NotEqual(null, data)|];
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					int? data = 1;
+
+					Assert.Null(data);
+					Assert.NotNull(data);
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, AssertEqualShouldNotBeUsedForNullCheckFixer.Key_UseAlternateAssert);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualsShouldNotBeUsedFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertEqualsShouldNotBeUsedFixerTests.cs
@@ -5,33 +5,36 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertEqualsShouldNotBeUsed>;
 
 public class AssertEqualsShouldNotBeUsedFixerTests
 {
-	const string template = /* lang=c#-test */ """
-		using Xunit;
-
-		public class TestClass {{
-			[Fact]
-			public void TestMethod() {{
-				var data = 1;
-
-				{0};
-			}}
-		}}
-		""";
-
-	[Theory]
-	[InlineData(
-		/* lang=c#-test */ "{|CS0619:[|Assert.Equals(1, data)|]|}",
-		/* lang=c#-test */ "Assert.Equal(1, data)")]
-	[InlineData(
-		/* lang=c#-test */ "{|CS0619:[|Assert.ReferenceEquals(1, data)|]|}",
-		/* lang=c#-test */ "Assert.Same(1, data)")]
-	public async Task ConvertsObjectCallToAssert(
-		string beforeAssert,
-		string afterAssert)
+	[Fact]
+	public async Task FixAll_ReplacesAllEqualsAndReferenceEqualsCalls()
 	{
-		var before = string.Format(template, beforeAssert);
-		var after = string.Format(template, afterAssert);
+		var before = /* lang=c#-test */ """
+			using Xunit;
 
-		await Verify.VerifyCodeFix(before, after, AssertEqualsShouldNotBeUsedFixer.Key_UseAlternateAssert);
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var data = 1;
+
+					{|CS0619:[|Assert.Equals(1, data)|]|};
+					{|CS0619:[|Assert.ReferenceEquals(1, data)|]|};
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var data = 1;
+
+					Assert.Equal(1, data);
+					Assert.Same(1, data);
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, AssertEqualsShouldNotBeUsedFixer.Key_UseAlternateAssert);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertIsTypeShouldNotBeUsedForAbstractTypeFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertIsTypeShouldNotBeUsedForAbstractTypeFixerTests.cs
@@ -1,17 +1,12 @@
-using System;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Xunit;
-using Xunit.Analyzers;
 using Xunit.Analyzers.Fixes;
 using Verify = CSharpVerifier<Xunit.Analyzers.AssertIsTypeShouldNotBeUsedForAbstractType>;
-using Verify_v2_Pre2_9_3 = CSharpVerifier<AssertIsTypeShouldNotBeUsedForAbstractTypeFixerTests.Analyzer_v2_Pre2_9_3>;
-using Verify_v3_Pre0_6_0 = CSharpVerifier<AssertIsTypeShouldNotBeUsedForAbstractTypeFixerTests.Analyzer_v3_Pre0_6_0>;
 
 public class AssertIsTypeShouldNotBeUsedForAbstractTypeFixerTests
 {
 	[Fact]
-	public async Task Conversions_WithoutExactMatch()
+	public async Task FixAll_ReplacesAllAbstractTypeChecks()
 	{
 		var before = /* lang=c#-test */ """
 			using System;
@@ -21,58 +16,10 @@ public class AssertIsTypeShouldNotBeUsedForAbstractTypeFixerTests
 				[Fact]
 				public void TestMethod() {
 					var data = new object();
-			
+
 					[|Assert.IsType<IDisposable>(data)|];
-					[|Assert.IsType<TestClass>(data)|];
-					[|Assert.IsNotType<IDisposable>(data)|];
-					[|Assert.IsNotType<TestClass>(data)|];
-				}
-			}
-			""";
-		var after = /* lang=c#-test */ """
-			using System;
-			using Xunit;
-
-			public abstract class TestClass {
-				[Fact]
-				public void TestMethod() {
-					var data = new object();
-
-					Assert.IsAssignableFrom<IDisposable>(data);
-					Assert.IsAssignableFrom<TestClass>(data);
-					Assert.IsNotAssignableFrom<IDisposable>(data);
-					Assert.IsNotAssignableFrom<TestClass>(data);
-				}
-			}
-			""";
-
-		await Verify_v2_Pre2_9_3.VerifyCodeFix(before, after, AssertIsTypeShouldNotBeUsedForAbstractTypeFixer.Key_UseAlternateAssert);
-		await Verify_v3_Pre0_6_0.VerifyCodeFix(before, after, AssertIsTypeShouldNotBeUsedForAbstractTypeFixer.Key_UseAlternateAssert);
-	}
-
-	[Fact]
-	public async Task Conversions_WithExactMatch()
-	{
-		var before = /* lang=c#-test */ """
-			using System;
-			using Xunit;
-
-			public abstract class TestClass {
-				[Fact]
-				public void TestMethod() {
-					var data = new object();
-			
-					[|Assert.IsType<IDisposable>(data)|];
-					[|Assert.IsType<IDisposable>(data, true)|];
-					[|Assert.IsType<IDisposable>(data, exactMatch: true)|];
-					[|Assert.IsType<TestClass>(data)|];
 					[|Assert.IsType<TestClass>(data, true)|];
-					[|Assert.IsType<TestClass>(data, exactMatch: true)|];
 					[|Assert.IsNotType<IDisposable>(data)|];
-					[|Assert.IsNotType<IDisposable>(data, true)|];
-					[|Assert.IsNotType<IDisposable>(data, exactMatch: true)|];
-					[|Assert.IsNotType<TestClass>(data)|];
-					[|Assert.IsNotType<TestClass>(data, true)|];
 					[|Assert.IsNotType<TestClass>(data, exactMatch: true)|];
 				}
 			}
@@ -87,33 +34,13 @@ public class AssertIsTypeShouldNotBeUsedForAbstractTypeFixerTests
 					var data = new object();
 
 					Assert.IsType<IDisposable>(data, exactMatch: false);
-					Assert.IsType<IDisposable>(data, exactMatch: false);
-					Assert.IsType<IDisposable>(data, exactMatch: false);
-					Assert.IsType<TestClass>(data, exactMatch: false);
-					Assert.IsType<TestClass>(data, exactMatch: false);
 					Assert.IsType<TestClass>(data, exactMatch: false);
 					Assert.IsNotType<IDisposable>(data, exactMatch: false);
-					Assert.IsNotType<IDisposable>(data, exactMatch: false);
-					Assert.IsNotType<IDisposable>(data, exactMatch: false);
-					Assert.IsNotType<TestClass>(data, exactMatch: false);
-					Assert.IsNotType<TestClass>(data, exactMatch: false);
 					Assert.IsNotType<TestClass>(data, exactMatch: false);
 				}
 			}
 			""";
 
-		await Verify.VerifyCodeFix(before, after, AssertIsTypeShouldNotBeUsedForAbstractTypeFixer.Key_UseAlternateAssert);
-	}
-
-	internal class Analyzer_v2_Pre2_9_3 : AssertIsTypeShouldNotBeUsedForAbstractType
-	{
-		protected override XunitContext CreateXunitContext(Compilation compilation) =>
-			XunitContext.ForV2(compilation, new Version(2, 9, 2));
-	}
-
-	internal class Analyzer_v3_Pre0_6_0 : AssertIsTypeShouldNotBeUsedForAbstractType
-	{
-		protected override XunitContext CreateXunitContext(Compilation compilation) =>
-			XunitContext.ForV3(compilation, new Version(0, 5, 999));
+		await Verify.VerifyCodeFixFixAll(before, after, AssertIsTypeShouldNotBeUsedForAbstractTypeFixer.Key_UseAlternateAssert);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertIsTypeShouldNotBeUsedForAbstractTypeFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertIsTypeShouldNotBeUsedForAbstractTypeFixerTests.cs
@@ -1,10 +1,110 @@
+using System;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Xunit;
+using Xunit.Analyzers;
 using Xunit.Analyzers.Fixes;
 using Verify = CSharpVerifier<Xunit.Analyzers.AssertIsTypeShouldNotBeUsedForAbstractType>;
+using Verify_v2_Pre2_9_3 = CSharpVerifier<AssertIsTypeShouldNotBeUsedForAbstractTypeFixerTests.Analyzer_v2_Pre2_9_3>;
+using Verify_v3_Pre0_6_0 = CSharpVerifier<AssertIsTypeShouldNotBeUsedForAbstractTypeFixerTests.Analyzer_v3_Pre0_6_0>;
 
 public class AssertIsTypeShouldNotBeUsedForAbstractTypeFixerTests
 {
+	[Fact]
+	public async Task Conversions_WithoutExactMatch()
+	{
+		var before = /* lang=c#-test */ """
+			using System;
+			using Xunit;
+
+			public abstract class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var data = new object();
+
+					[|Assert.IsType<IDisposable>(data)|];
+					[|Assert.IsType<TestClass>(data)|];
+					[|Assert.IsNotType<IDisposable>(data)|];
+					[|Assert.IsNotType<TestClass>(data)|];
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using System;
+			using Xunit;
+
+			public abstract class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var data = new object();
+
+					Assert.IsAssignableFrom<IDisposable>(data);
+					Assert.IsAssignableFrom<TestClass>(data);
+					Assert.IsNotAssignableFrom<IDisposable>(data);
+					Assert.IsNotAssignableFrom<TestClass>(data);
+				}
+			}
+			""";
+
+		await Verify_v2_Pre2_9_3.VerifyCodeFix(before, after, AssertIsTypeShouldNotBeUsedForAbstractTypeFixer.Key_UseAlternateAssert);
+		await Verify_v3_Pre0_6_0.VerifyCodeFix(before, after, AssertIsTypeShouldNotBeUsedForAbstractTypeFixer.Key_UseAlternateAssert);
+	}
+
+	[Fact]
+	public async Task Conversions_WithExactMatch()
+	{
+		var before = /* lang=c#-test */ """
+			using System;
+			using Xunit;
+
+			public abstract class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var data = new object();
+
+					[|Assert.IsType<IDisposable>(data)|];
+					[|Assert.IsType<IDisposable>(data, true)|];
+					[|Assert.IsType<IDisposable>(data, exactMatch: true)|];
+					[|Assert.IsType<TestClass>(data)|];
+					[|Assert.IsType<TestClass>(data, true)|];
+					[|Assert.IsType<TestClass>(data, exactMatch: true)|];
+					[|Assert.IsNotType<IDisposable>(data)|];
+					[|Assert.IsNotType<IDisposable>(data, true)|];
+					[|Assert.IsNotType<IDisposable>(data, exactMatch: true)|];
+					[|Assert.IsNotType<TestClass>(data)|];
+					[|Assert.IsNotType<TestClass>(data, true)|];
+					[|Assert.IsNotType<TestClass>(data, exactMatch: true)|];
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using System;
+			using Xunit;
+
+			public abstract class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var data = new object();
+
+					Assert.IsType<IDisposable>(data, exactMatch: false);
+					Assert.IsType<IDisposable>(data, exactMatch: false);
+					Assert.IsType<IDisposable>(data, exactMatch: false);
+					Assert.IsType<TestClass>(data, exactMatch: false);
+					Assert.IsType<TestClass>(data, exactMatch: false);
+					Assert.IsType<TestClass>(data, exactMatch: false);
+					Assert.IsNotType<IDisposable>(data, exactMatch: false);
+					Assert.IsNotType<IDisposable>(data, exactMatch: false);
+					Assert.IsNotType<IDisposable>(data, exactMatch: false);
+					Assert.IsNotType<TestClass>(data, exactMatch: false);
+					Assert.IsNotType<TestClass>(data, exactMatch: false);
+					Assert.IsNotType<TestClass>(data, exactMatch: false);
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFix(before, after, AssertIsTypeShouldNotBeUsedForAbstractTypeFixer.Key_UseAlternateAssert);
+	}
+
 	[Fact]
 	public async Task FixAll_ReplacesAllAbstractTypeChecks()
 	{
@@ -42,5 +142,17 @@ public class AssertIsTypeShouldNotBeUsedForAbstractTypeFixerTests
 			""";
 
 		await Verify.VerifyCodeFixFixAll(before, after, AssertIsTypeShouldNotBeUsedForAbstractTypeFixer.Key_UseAlternateAssert);
+	}
+
+	internal class Analyzer_v2_Pre2_9_3 : AssertIsTypeShouldNotBeUsedForAbstractType
+	{
+		protected override XunitContext CreateXunitContext(Compilation compilation) =>
+			XunitContext.ForV2(compilation, new Version(2, 9, 2));
+	}
+
+	internal class Analyzer_v3_Pre0_6_0 : AssertIsTypeShouldNotBeUsedForAbstractType
+	{
+		protected override XunitContext CreateXunitContext(Compilation compilation) =>
+			XunitContext.ForV3(compilation, new Version(0, 5, 999));
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertNullShouldNotBeCalledOnValueTypesFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertNullShouldNotBeCalledOnValueTypesFixerTests.cs
@@ -6,74 +6,34 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertNullShouldNotBeCalledOnValue
 public class AssertNullShouldNotBeCalledOnValueTypesFixerTests
 {
 	[Fact]
-	public async Task ForValueTypeNullAssert_RemovesAssertion()
+	public async Task FixAll_RemovesAllValueTypeNullAssertions()
 	{
-		const string before = /* lang=c#-test */ """
+		var before = /* lang=c#-test */ """
 			using Xunit;
 
-			public class Tests {
+			public class TestClass {
 				[Fact]
 				public void TestMethod() {
 					int i = 1;
+					bool b = true;
 
 					[|Assert.NotNull(i)|];
+					[|Assert.NotNull(b)|];
 				}
 			}
 			""";
-		const string after = /* lang=c#-test */ """
+		var after = /* lang=c#-test */ """
 			using Xunit;
 
-			public class Tests {
+			public class TestClass {
 				[Fact]
 				public void TestMethod() {
 					int i = 1;
+					bool b = true;
 				}
 			}
 			""";
 
-		await Verify.VerifyCodeFix(before, after, AssertNullShouldNotBeCalledOnValueTypesFixer.Key_RemoveAssert);
-	}
-
-	// https://github.com/xunit/xunit/issues/1753
-	[Fact]
-	public async Task ForAssertionWithTrivia_RemovesAssertionAndLeavesLeadingTriviaInPlace()
-	{
-		const string before = /* lang=c#-test */ """
-			using System;
-			using Xunit;
-
-			namespace XUnitTestProject1 {
-				public class UnitTest1 {
-					[Fact]
-					public void Test1() {
-						int i = 1;
-
-						// I am a comment which gets deleted by the quick fix
-						// Assert
-						[|Assert.NotNull(i)|];
-						Assert.Null(null);
-					}
-				}
-			}
-			""";
-		const string after = /* lang=c#-test */ """
-			using System;
-			using Xunit;
-
-			namespace XUnitTestProject1 {
-				public class UnitTest1 {
-					[Fact]
-					public void Test1() {
-						int i = 1;
-
-						// I am a comment which gets deleted by the quick fix
-						// Assert
-						Assert.Null(null);
-					}
-				}
-			}
-			""";
-
-		await Verify.VerifyCodeFix(before, after, AssertNullShouldNotBeCalledOnValueTypesFixer.Key_RemoveAssert);
+		await Verify.VerifyCodeFixFixAll(before, after, AssertNullShouldNotBeCalledOnValueTypesFixer.Key_RemoveAssert);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertNullShouldNotBeCalledOnValueTypesFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertNullShouldNotBeCalledOnValueTypesFixerTests.cs
@@ -6,6 +6,78 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertNullShouldNotBeCalledOnValue
 public class AssertNullShouldNotBeCalledOnValueTypesFixerTests
 {
 	[Fact]
+	public async Task ForValueTypeNullAssert_RemovesAssertion()
+	{
+		const string before = /* lang=c#-test */ """
+			using Xunit;
+
+			public class Tests {
+				[Fact]
+				public void TestMethod() {
+					int i = 1;
+
+					[|Assert.NotNull(i)|];
+				}
+			}
+			""";
+		const string after = /* lang=c#-test */ """
+			using Xunit;
+
+			public class Tests {
+				[Fact]
+				public void TestMethod() {
+					int i = 1;
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFix(before, after, AssertNullShouldNotBeCalledOnValueTypesFixer.Key_RemoveAssert);
+	}
+
+	// https://github.com/xunit/xunit/issues/1753
+	[Fact]
+	public async Task ForAssertionWithTrivia_RemovesAssertionAndLeavesLeadingTriviaInPlace()
+	{
+		const string before = /* lang=c#-test */ """
+			using System;
+			using Xunit;
+
+			namespace XUnitTestProject1 {
+				public class UnitTest1 {
+					[Fact]
+					public void Test1() {
+						int i = 1;
+
+						// I am a comment which gets deleted by the quick fix
+						// Assert
+						[|Assert.NotNull(i)|];
+						Assert.Null(null);
+					}
+				}
+			}
+			""";
+		const string after = /* lang=c#-test */ """
+			using System;
+			using Xunit;
+
+			namespace XUnitTestProject1 {
+				public class UnitTest1 {
+					[Fact]
+					public void Test1() {
+						int i = 1;
+
+						// I am a comment which gets deleted by the quick fix
+						// Assert
+						Assert.Null(null);
+					}
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFix(before, after, AssertNullShouldNotBeCalledOnValueTypesFixer.Key_RemoveAssert);
+	}
+
+	[Fact]
 	public async Task FixAll_RemovesAllValueTypeNullAssertions()
 	{
 		var before = /* lang=c#-test */ """

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertSameShouldNotBeCalledOnValueTypesFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertSameShouldNotBeCalledOnValueTypesFixerTests.cs
@@ -5,33 +5,36 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertSameShouldNotBeCalledOnValue
 
 public class AssertSameShouldNotBeCalledOnValueTypesFixerTests
 {
-	const string template = /* lang=c#-test */ """
-		using Xunit;
-
-		public class TestClass {{
-			[Fact]
-			public void TestMethod() {{
-				var data = 1;
-
-				{0};
-			}}
-		}}
-		""";
-
-	[Theory]
-	[InlineData(
-		/* lang=c#-test */ "[|Assert.Same(1, data)|]",
-		/* lang=c#-test */ "Assert.Equal(1, data)")]
-	[InlineData(
-		/* lang=c#-test */ "[|Assert.NotSame(1, data)|]",
-		/* lang=c#-test */ "Assert.NotEqual(1, data)")]
-	public async Task ConvertsSameToEqual(
-		string beforeAssert,
-		string afterAssert)
+	[Fact]
+	public async Task FixAll_ReplacesAllSameCallsWithEqual()
 	{
-		var before = string.Format(template, beforeAssert);
-		var after = string.Format(template, afterAssert);
+		var before = /* lang=c#-test */ """
+			using Xunit;
 
-		await Verify.VerifyCodeFix(before, after, AssertSameShouldNotBeCalledOnValueTypesFixer.Key_UseAlternateAssert);
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var data = 1;
+
+					[|Assert.Same(1, data)|];
+					[|Assert.NotSame(1, data)|];
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var data = 1;
+
+					Assert.Equal(1, data);
+					Assert.NotEqual(1, data);
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, AssertSameShouldNotBeCalledOnValueTypesFixer.Key_UseAlternateAssert);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertSingleShouldUseTwoArgumentCallFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertSingleShouldUseTwoArgumentCallFixerTests.cs
@@ -5,39 +5,38 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertSingleShouldUseTwoArgumentCa
 
 public class AssertSingleShouldUseTwoArgumentCallFixerTests
 {
-	const string template = /* lang=c#-test */ """
-		using System.Linq;
-		using Xunit;
-
-		public class TestClass {{
-			[Fact]
-			public void TestMethod() {{
-				var list = new[] {{ -1, 0, 1, 2 }};
-
-				{0};
-			}}
-
-			public bool IsEven(int num) => num % 2 == 0;
-		}}
-		""";
-
-	[Theory]
-	[InlineData(
-		/* lang=c#-test */ "[|Assert.Single(list.Where(f => f > 0))|]",
-		/* lang=c#-test */ "Assert.Single(list, f => f > 0)")]
-	[InlineData(
-		/* lang=c#-test */ "[|Assert.Single(list.Where(n => n == 1))|]",
-		/* lang=c#-test */ "Assert.Single(list, n => n == 1)")]
-	[InlineData(
-		/* lang=c#-test */ "[|Assert.Single(list.Where(IsEven))|]",
-		/* lang=c#-test */ "Assert.Single(list, IsEven)")]
-	public async Task FixerReplacesAssertSingleOneArgumentToTwoArgumentCall(
-		string beforeAssert,
-		string afterAssert)
+	[Fact]
+	public async Task FixAll_ReplacesAllSingleOneArgumentCalls()
 	{
-		var before = string.Format(template, beforeAssert);
-		var after = string.Format(template, afterAssert);
+		var before = /* lang=c#-test */ """
+			using System.Linq;
+			using Xunit;
 
-		await Verify.VerifyCodeFix(before, after, AssertSingleShouldUseTwoArgumentCallFixer.Key_UseTwoArguments);
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var list = new[] { -1, 0, 1, 2 };
+
+					[|Assert.Single(list.Where(f => f > 0))|];
+					[|Assert.Single(list.Where(n => n == 1))|];
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using System.Linq;
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var list = new[] { -1, 0, 1, 2 };
+
+					Assert.Single(list, f => f > 0);
+					Assert.Single(list, n => n == 1);
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, AssertSingleShouldUseTwoArgumentCallFixer.Key_UseTwoArguments);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertSingleShouldUseTwoArgumentCallFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertSingleShouldUseTwoArgumentCallFixerTests.cs
@@ -5,6 +5,42 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertSingleShouldUseTwoArgumentCa
 
 public class AssertSingleShouldUseTwoArgumentCallFixerTests
 {
+	const string template = /* lang=c#-test */ """
+		using System.Linq;
+		using Xunit;
+
+		public class TestClass {{
+			[Fact]
+			public void TestMethod() {{
+				var list = new[] {{ -1, 0, 1, 2 }};
+
+				{0};
+			}}
+
+			public bool IsEven(int num) => num % 2 == 0;
+		}}
+		""";
+
+	[Theory]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.Single(list.Where(f => f > 0))|]",
+		/* lang=c#-test */ "Assert.Single(list, f => f > 0)")]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.Single(list.Where(n => n == 1))|]",
+		/* lang=c#-test */ "Assert.Single(list, n => n == 1)")]
+	[InlineData(
+		/* lang=c#-test */ "[|Assert.Single(list.Where(IsEven))|]",
+		/* lang=c#-test */ "Assert.Single(list, IsEven)")]
+	public async Task FixerReplacesAssertSingleOneArgumentToTwoArgumentCall(
+		string beforeAssert,
+		string afterAssert)
+	{
+		var before = string.Format(template, beforeAssert);
+		var after = string.Format(template, afterAssert);
+
+		await Verify.VerifyCodeFix(before, after, AssertSingleShouldUseTwoArgumentCallFixer.Key_UseTwoArguments);
+	}
+
 	[Fact]
 	public async Task FixAll_ReplacesAllSingleOneArgumentCalls()
 	{

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertStringEqualityCheckShouldNotUseBoolCheckFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertStringEqualityCheckShouldNotUseBoolCheckFixerTests.cs
@@ -5,56 +5,38 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertStringEqualityCheckShouldNot
 
 public class AssertStringEqualityCheckShouldNotUseBoolCheckFixerTests
 {
-	const string template = /* lang=c#-test */ """
-		using System;
-		using Xunit;
-
-		public class TestClass {{
-			[Fact]
-			public void TestMethod() {{
-				var data = "foo bar baz";
-
-				{0};
-			}}
-		}}
-		""";
-
-	[Theory]
-	// Instance Equals (true)
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.True(""foo bar baz"".Equals(data))|]",
-		/* lang=c#-test */ @"Assert.Equal(""foo bar baz"", data)")]
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.True(""foo bar baz"".Equals(data, StringComparison.Ordinal))|]",
-		/* lang=c#-test */ @"Assert.Equal(""foo bar baz"", data)")]
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.True(""foo bar baz"".Equals(data, StringComparison.OrdinalIgnoreCase))|]",
-		/* lang=c#-test */ @"Assert.Equal(""foo bar baz"", data, ignoreCase: true)")]
-	// Static Equals (true)
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.True(string.Equals(""foo bar baz"", data))|]",
-		/* lang=c#-test */ @"Assert.Equal(""foo bar baz"", data)")]
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.True(string.Equals(""foo bar baz"", data, StringComparison.Ordinal))|]",
-		/* lang=c#-test */ @"Assert.Equal(""foo bar baz"", data)")]
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.True(string.Equals(""foo bar baz"", data, StringComparison.OrdinalIgnoreCase))|]",
-		/* lang=c#-test */ @"Assert.Equal(""foo bar baz"", data, ignoreCase: true)")]
-	// Instance Equals (false)
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.False(""foo bar baz"".Equals(data))|]",
-		/* lang=c#-test */ @"Assert.NotEqual(""foo bar baz"", data)")]
-	// Static Equals (false)
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.False(string.Equals(""foo bar baz"", data))|]",
-		/* lang=c#-test */ @"Assert.NotEqual(""foo bar baz"", data)")]
-	public async Task ConvertsBooleanAssertToEqualityAssert(
-		string beforeAssert,
-		string afterAssert)
+	[Fact]
+	public async Task FixAll_ReplacesAllBooleanStringEqualityChecks()
 	{
-		var before = string.Format(template, beforeAssert);
-		var after = string.Format(template, afterAssert);
+		var before = /* lang=c#-test */ """
+			using System;
+			using Xunit;
 
-		await Verify.VerifyCodeFix(before, after, AssertStringEqualityCheckShouldNotUseBoolCheckFixer.Key_UseAlternateAssert);
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var data = "foo bar baz";
+
+					[|Assert.True("foo bar baz".Equals(data))|];
+					[|Assert.False("foo bar baz".Equals(data))|];
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using System;
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var data = "foo bar baz";
+
+					Assert.Equal("foo bar baz", data);
+					Assert.NotEqual("foo bar baz", data);
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, AssertStringEqualityCheckShouldNotUseBoolCheckFixer.Key_UseAlternateAssert);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertStringEqualityCheckShouldNotUseBoolCheckFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertStringEqualityCheckShouldNotUseBoolCheckFixerTests.cs
@@ -5,6 +5,59 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertStringEqualityCheckShouldNot
 
 public class AssertStringEqualityCheckShouldNotUseBoolCheckFixerTests
 {
+	const string template = /* lang=c#-test */ """
+		using System;
+		using Xunit;
+
+		public class TestClass {{
+			[Fact]
+			public void TestMethod() {{
+				var data = "foo bar baz";
+
+				{0};
+			}}
+		}}
+		""";
+
+	[Theory]
+	// Instance Equals (true)
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.True(""foo bar baz"".Equals(data))|]",
+		/* lang=c#-test */ @"Assert.Equal(""foo bar baz"", data)")]
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.True(""foo bar baz"".Equals(data, StringComparison.Ordinal))|]",
+		/* lang=c#-test */ @"Assert.Equal(""foo bar baz"", data)")]
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.True(""foo bar baz"".Equals(data, StringComparison.OrdinalIgnoreCase))|]",
+		/* lang=c#-test */ @"Assert.Equal(""foo bar baz"", data, ignoreCase: true)")]
+	// Static Equals (true)
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.True(string.Equals(""foo bar baz"", data))|]",
+		/* lang=c#-test */ @"Assert.Equal(""foo bar baz"", data)")]
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.True(string.Equals(""foo bar baz"", data, StringComparison.Ordinal))|]",
+		/* lang=c#-test */ @"Assert.Equal(""foo bar baz"", data)")]
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.True(string.Equals(""foo bar baz"", data, StringComparison.OrdinalIgnoreCase))|]",
+		/* lang=c#-test */ @"Assert.Equal(""foo bar baz"", data, ignoreCase: true)")]
+	// Instance Equals (false)
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.False(""foo bar baz"".Equals(data))|]",
+		/* lang=c#-test */ @"Assert.NotEqual(""foo bar baz"", data)")]
+	// Static Equals (false)
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.False(string.Equals(""foo bar baz"", data))|]",
+		/* lang=c#-test */ @"Assert.NotEqual(""foo bar baz"", data)")]
+	public async Task ConvertsBooleanAssertToEqualityAssert(
+		string beforeAssert,
+		string afterAssert)
+	{
+		var before = string.Format(template, beforeAssert);
+		var after = string.Format(template, afterAssert);
+
+		await Verify.VerifyCodeFix(before, after, AssertStringEqualityCheckShouldNotUseBoolCheckFixer.Key_UseAlternateAssert);
+	}
+
 	[Fact]
 	public async Task FixAll_ReplacesAllBooleanStringEqualityChecks()
 	{

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertSubstringCheckShouldNotUseBoolCheckFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertSubstringCheckShouldNotUseBoolCheckFixerTests.cs
@@ -5,46 +5,38 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertSubstringCheckShouldNotUseBo
 
 public class AssertSubstringCheckShouldNotUseBoolCheckFixerTests
 {
-	const string template = /* lang=c#-test */ """
-		using System;
-		using Xunit;
-
-		public class TestClass {{
-			[Fact]
-			public void TestMethod() {{
-				var data = "foo bar baz";
-
-				{0};
-			}}
-		}}
-		""";
-
-	[Theory]
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.True(data.Contains(""foo""))|]",
-		/* lang=c#-test */ @"Assert.Contains(""foo"", data)")]
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.True(data.StartsWith(""foo""))|]",
-		/* lang=c#-test */ @"Assert.StartsWith(""foo"", data)")]
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.True(data.StartsWith(""foo"", StringComparison.Ordinal))|]",
-		/* lang=c#-test */ @"Assert.StartsWith(""foo"", data, StringComparison.Ordinal)")]
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.True(data.EndsWith(""foo""))|]",
-		/* lang=c#-test */ @"Assert.EndsWith(""foo"", data)")]
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.True(data.EndsWith(""foo"", StringComparison.OrdinalIgnoreCase))|]",
-		/* lang=c#-test */ @"Assert.EndsWith(""foo"", data, StringComparison.OrdinalIgnoreCase)")]
-	[InlineData(
-		/* lang=c#-test */ @"[|Assert.False(data.Contains(""foo""))|]",
-		/* lang=c#-test */ @"Assert.DoesNotContain(""foo"", data)")]
-	public async Task ConvertsBooleanAssertToStringSpecificAssert(
-		string beforeAssert,
-		string afterAssert)
+	[Fact]
+	public async Task FixAll_ReplacesAllBooleanSubstringChecks()
 	{
-		var before = string.Format(template, beforeAssert);
-		var after = string.Format(template, afterAssert);
+		var before = /* lang=c#-test */ """
+			using System;
+			using Xunit;
 
-		await Verify.VerifyCodeFix(before, after, AssertSubstringCheckShouldNotUseBoolCheckFixer.Key_UseAlternateAssert);
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var data = "foo bar baz";
+
+					[|Assert.True(data.Contains("foo"))|];
+					[|Assert.False(data.Contains("foo"))|];
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using System;
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var data = "foo bar baz";
+
+					Assert.Contains("foo", data);
+					Assert.DoesNotContain("foo", data);
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, AssertSubstringCheckShouldNotUseBoolCheckFixer.Key_UseAlternateAssert);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertSubstringCheckShouldNotUseBoolCheckFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertSubstringCheckShouldNotUseBoolCheckFixerTests.cs
@@ -5,6 +5,49 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertSubstringCheckShouldNotUseBo
 
 public class AssertSubstringCheckShouldNotUseBoolCheckFixerTests
 {
+	const string template = /* lang=c#-test */ """
+		using System;
+		using Xunit;
+
+		public class TestClass {{
+			[Fact]
+			public void TestMethod() {{
+				var data = "foo bar baz";
+
+				{0};
+			}}
+		}}
+		""";
+
+	[Theory]
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.True(data.Contains(""foo""))|]",
+		/* lang=c#-test */ @"Assert.Contains(""foo"", data)")]
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.True(data.StartsWith(""foo""))|]",
+		/* lang=c#-test */ @"Assert.StartsWith(""foo"", data)")]
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.True(data.StartsWith(""foo"", StringComparison.Ordinal))|]",
+		/* lang=c#-test */ @"Assert.StartsWith(""foo"", data, StringComparison.Ordinal)")]
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.True(data.EndsWith(""foo""))|]",
+		/* lang=c#-test */ @"Assert.EndsWith(""foo"", data)")]
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.True(data.EndsWith(""foo"", StringComparison.OrdinalIgnoreCase))|]",
+		/* lang=c#-test */ @"Assert.EndsWith(""foo"", data, StringComparison.OrdinalIgnoreCase)")]
+	[InlineData(
+		/* lang=c#-test */ @"[|Assert.False(data.Contains(""foo""))|]",
+		/* lang=c#-test */ @"Assert.DoesNotContain(""foo"", data)")]
+	public async Task ConvertsBooleanAssertToStringSpecificAssert(
+		string beforeAssert,
+		string afterAssert)
+	{
+		var before = string.Format(template, beforeAssert);
+		var after = string.Format(template, afterAssert);
+
+		await Verify.VerifyCodeFix(before, after, AssertSubstringCheckShouldNotUseBoolCheckFixer.Key_UseAlternateAssert);
+	}
+
 	[Fact]
 	public async Task FixAll_ReplacesAllBooleanSubstringChecks()
 	{

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssignableFromAssertionIsConfusinglyNamedFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssignableFromAssertionIsConfusinglyNamedFixerTests.cs
@@ -6,7 +6,7 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssignableFromAssertionIsConfusing
 public class AssignableFromAssertionIsConfusinglyNamedFixerTests
 {
 	[Fact]
-	public async Task Conversions()
+	public async Task FixAll_ReplacesAllAssignableFromAssertions()
 	{
 		var before = /* lang=c#-test */ """
 			using System;
@@ -16,7 +16,7 @@ public class AssignableFromAssertionIsConfusinglyNamedFixerTests
 				[Fact]
 				public void TestMethod() {
 					var data = "Hello world";
-			
+
 					[|Assert.IsAssignableFrom(typeof(object), data)|];
 					[|Assert.IsAssignableFrom<object>(data)|];
 				}
@@ -37,6 +37,6 @@ public class AssignableFromAssertionIsConfusinglyNamedFixerTests
 			}
 			""";
 
-		await Verify.VerifyCodeFix(before, after, AssignableFromAssertionIsConfusinglyNamedFixer.Key_UseIsType);
+		await Verify.VerifyCodeFixFixAll(before, after, AssignableFromAssertionIsConfusinglyNamedFixer.Key_UseIsType);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/BooleanAssertsShouldNotBeNegatedFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/BooleanAssertsShouldNotBeNegatedFixerTests.cs
@@ -6,6 +6,105 @@ using Verify = CSharpVerifier<Xunit.Analyzers.BooleanAssertsShouldNotBeNegated>;
 public class BooleanAssertsShouldNotBeNegatedFixerTests
 {
 	[Fact]
+	public async Task AcceptanceTest()
+	{
+		var before = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					bool condition = true;
+
+					// Not negated
+					Assert.True(false);
+					Assert.False(false);
+					Assert.True(condition);
+					Assert.False(condition);
+
+					// Negated
+					[|Assert.True(!false)|];
+					[|Assert.False(!false)|];
+					[|Assert.True(!condition)|];
+					[|Assert.False(!condition)|];
+
+					// Not negated, with message
+					Assert.True(false, "test message");
+					Assert.False(false, "test message");
+					Assert.True(condition, "test message");
+					Assert.False(condition, "test message");
+
+					// Negated, with message
+					[|Assert.True(!false, "test message")|];
+					[|Assert.False(!false, "test message")|];
+					[|Assert.True(!condition, "test message")|];
+					[|Assert.False(!condition, "test message")|];
+
+					// Not negated, with named parameter message
+					Assert.True(false, userMessage: "test message");
+					Assert.False(false, userMessage: "test message");
+					Assert.True(condition, userMessage: "test message");
+					Assert.False(condition, userMessage: "test message");
+
+					// Negated, with named parameter message
+					[|Assert.True(!false, userMessage: "test message")|];
+					[|Assert.False(!false, userMessage: "test message")|];
+					[|Assert.True(!condition, userMessage: "test message")|];
+					[|Assert.False(!condition, userMessage: "test message")|];
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					bool condition = true;
+
+					// Not negated
+					Assert.True(false);
+					Assert.False(false);
+					Assert.True(condition);
+					Assert.False(condition);
+
+					// Negated
+					Assert.False(false);
+					Assert.True(false);
+					Assert.False(condition);
+					Assert.True(condition);
+
+					// Not negated, with message
+					Assert.True(false, "test message");
+					Assert.False(false, "test message");
+					Assert.True(condition, "test message");
+					Assert.False(condition, "test message");
+
+					// Negated, with message
+					Assert.False(false, "test message");
+					Assert.True(false, "test message");
+					Assert.False(condition, "test message");
+					Assert.True(condition, "test message");
+
+					// Not negated, with named parameter message
+					Assert.True(false, userMessage: "test message");
+					Assert.False(false, userMessage: "test message");
+					Assert.True(condition, userMessage: "test message");
+					Assert.False(condition, userMessage: "test message");
+
+					// Negated, with named parameter message
+					Assert.False(false, userMessage: "test message");
+					Assert.True(false, userMessage: "test message");
+					Assert.False(condition, userMessage: "test message");
+					Assert.True(condition, userMessage: "test message");
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFix(before, after, BooleanAssertsShouldNotBeNegatedFixer.Key_UseSuggestedAssert);
+	}
+
+	[Fact]
 	public async Task FixAll_ReplacesAllNegatedBooleanAsserts()
 	{
 		var before = /* lang=c#-test */ """

--- a/src/xunit.analyzers.tests/Fixes/X2000/BooleanAssertsShouldNotBeNegatedFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/BooleanAssertsShouldNotBeNegatedFixerTests.cs
@@ -6,7 +6,7 @@ using Verify = CSharpVerifier<Xunit.Analyzers.BooleanAssertsShouldNotBeNegated>;
 public class BooleanAssertsShouldNotBeNegatedFixerTests
 {
 	[Fact]
-	public async Task AcceptanceTest()
+	public async Task FixAll_ReplacesAllNegatedBooleanAsserts()
 	{
 		var before = /* lang=c#-test */ """
 			using Xunit;
@@ -16,41 +16,8 @@ public class BooleanAssertsShouldNotBeNegatedFixerTests
 				public void TestMethod() {
 					bool condition = true;
 
-					// Not negated
-					Assert.True(false);
-					Assert.False(false);
-					Assert.True(condition);
-					Assert.False(condition);
-
-					// Negated
-					[|Assert.True(!false)|];
-					[|Assert.False(!false)|];
 					[|Assert.True(!condition)|];
 					[|Assert.False(!condition)|];
-
-					// Not negated, with message
-					Assert.True(false, "test message");
-					Assert.False(false, "test message");
-					Assert.True(condition, "test message");
-					Assert.False(condition, "test message");
-
-					// Negated, with message
-					[|Assert.True(!false, "test message")|];
-					[|Assert.False(!false, "test message")|];
-					[|Assert.True(!condition, "test message")|];
-					[|Assert.False(!condition, "test message")|];
-
-					// Not negated, with named parameter message
-					Assert.True(false, userMessage: "test message");
-					Assert.False(false, userMessage: "test message");
-					Assert.True(condition, userMessage: "test message");
-					Assert.False(condition, userMessage: "test message");
-
-					// Negated, with named parameter message
-					[|Assert.True(!false, userMessage: "test message")|];
-					[|Assert.False(!false, userMessage: "test message")|];
-					[|Assert.True(!condition, userMessage: "test message")|];
-					[|Assert.False(!condition, userMessage: "test message")|];
 				}
 			}
 			""";
@@ -62,45 +29,12 @@ public class BooleanAssertsShouldNotBeNegatedFixerTests
 				public void TestMethod() {
 					bool condition = true;
 
-					// Not negated
-					Assert.True(false);
-					Assert.False(false);
-					Assert.True(condition);
-					Assert.False(condition);
-
-					// Negated
-					Assert.False(false);
-					Assert.True(false);
 					Assert.False(condition);
 					Assert.True(condition);
-
-					// Not negated, with message
-					Assert.True(false, "test message");
-					Assert.False(false, "test message");
-					Assert.True(condition, "test message");
-					Assert.False(condition, "test message");
-
-					// Negated, with message
-					Assert.False(false, "test message");
-					Assert.True(false, "test message");
-					Assert.False(condition, "test message");
-					Assert.True(condition, "test message");
-
-					// Not negated, with named parameter message
-					Assert.True(false, userMessage: "test message");
-					Assert.False(false, userMessage: "test message");
-					Assert.True(condition, userMessage: "test message");
-					Assert.False(condition, userMessage: "test message");
-
-					// Negated, with named parameter message
-					Assert.False(false, userMessage: "test message");
-					Assert.True(false, userMessage: "test message");
-					Assert.False(condition, userMessage: "test message");
-					Assert.True(condition, userMessage: "test message");
 				}
 			}
 			""";
 
-		await Verify.VerifyCodeFix(before, after, BooleanAssertsShouldNotBeNegatedFixer.Key_UseSuggestedAssert);
+		await Verify.VerifyCodeFixFixAll(before, after, BooleanAssertsShouldNotBeNegatedFixer.Key_UseSuggestedAssert);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckBooleanFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckBooleanFixerTests.cs
@@ -5,65 +5,36 @@ using Verify = CSharpVerifier<Xunit.Analyzers.BooleanAssertsShouldNotBeUsedForSi
 
 public class BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckBooleanFixerTests
 {
-	const string template = /* lang=c#-test */ """
-		using Xunit;
-
-		public class TestClass {{
-			[Fact]
-			public void TestMethod() {{
-				bool condition = true;
-
-				{0};
-			}}
-		}}
-		""";
-
-	public static TheoryData<string, string, string> AssertExpressionReplacement = new()
+	[Fact]
+	public async Task FixAll_SimplifiesAllBooleanAsserts()
 	{
-		/* lang=c#-test */ { "True", "condition == true", "True" },
-		/* lang=c#-test */ { "True", "condition != true", "False" },
-		/* lang=c#-test */ { "True", "true == condition", "True" },
-		/* lang=c#-test */ { "True", "true != condition", "False" },
+		var before = /* lang=c#-test */ """
+			using Xunit;
 
-		/* lang=c#-test */ { "True", "condition == false", "False" },
-		/* lang=c#-test */ { "True", "condition != false", "True" },
-		/* lang=c#-test */ { "True", "false == condition", "False" },
-		/* lang=c#-test */ { "True", "false != condition", "True" },
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					bool condition = true;
 
-		/* lang=c#-test */ { "False", "condition == true", "False" },
-		/* lang=c#-test */ { "False", "condition != true", "True" },
-		/* lang=c#-test */ { "False", "true == condition", "False" },
-		/* lang=c#-test */ { "False", "true != condition", "True" },
+					{|xUnit2025:Assert.True(condition == true)|};
+					{|xUnit2025:Assert.True(condition == false)|};
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using Xunit;
 
-		/* lang=c#-test */ { "False", "condition == false", "True" },
-		/* lang=c#-test */ { "False", "condition != false", "False" },
-		/* lang=c#-test */ { "False", "false == condition", "True" },
-		/* lang=c#-test */ { "False", "false != condition", "False" },
-	};
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					bool condition = true;
 
-	[Theory]
-	[MemberData(nameof(AssertExpressionReplacement))]
-	public async Task SimplifiesBooleanAssert(
-		string assertion,
-		string expression,
-		string replacement)
-	{
-		var before = string.Format(template, $"{{|xUnit2025:Assert.{assertion}({expression})|}}");
-		var after = string.Format(template, $"Assert.{replacement}(condition)");
+					Assert.True(condition);
+					Assert.False(condition);
+				}
+			}
+			""";
 
-		await Verify.VerifyCodeFix(before, after, BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckBooleanFixer.Key_UseSuggestedAssert);
-	}
-
-	[Theory]
-	[MemberData(nameof(AssertExpressionReplacement))]
-	public async Task SimplifiesBooleanAssertWithMessage(
-		string assertion,
-		string expression,
-		string replacement)
-	{
-		var before = string.Format(template, $"{{|xUnit2025:Assert.{assertion}({expression}, \"message\")|}}");
-		var after = string.Format(template, $"Assert.{replacement}(condition, \"message\")");
-
-		await Verify.VerifyCodeFix(before, after, BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckBooleanFixer.Key_UseSuggestedAssert);
+		await Verify.VerifyCodeFixFixAll(before, after, BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckBooleanFixer.Key_UseSuggestedAssert);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckBooleanFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckBooleanFixerTests.cs
@@ -5,6 +5,68 @@ using Verify = CSharpVerifier<Xunit.Analyzers.BooleanAssertsShouldNotBeUsedForSi
 
 public class BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckBooleanFixerTests
 {
+	const string template = /* lang=c#-test */ """
+		using Xunit;
+
+		public class TestClass {{
+			[Fact]
+			public void TestMethod() {{
+				bool condition = true;
+
+				{0};
+			}}
+		}}
+		""";
+
+	public static TheoryData<string, string, string> AssertExpressionReplacement = new()
+	{
+		/* lang=c#-test */ { "True", "condition == true", "True" },
+		/* lang=c#-test */ { "True", "condition != true", "False" },
+		/* lang=c#-test */ { "True", "true == condition", "True" },
+		/* lang=c#-test */ { "True", "true != condition", "False" },
+
+		/* lang=c#-test */ { "True", "condition == false", "False" },
+		/* lang=c#-test */ { "True", "condition != false", "True" },
+		/* lang=c#-test */ { "True", "false == condition", "False" },
+		/* lang=c#-test */ { "True", "false != condition", "True" },
+
+		/* lang=c#-test */ { "False", "condition == true", "False" },
+		/* lang=c#-test */ { "False", "condition != true", "True" },
+		/* lang=c#-test */ { "False", "true == condition", "False" },
+		/* lang=c#-test */ { "False", "true != condition", "True" },
+
+		/* lang=c#-test */ { "False", "condition == false", "True" },
+		/* lang=c#-test */ { "False", "condition != false", "False" },
+		/* lang=c#-test */ { "False", "false == condition", "True" },
+		/* lang=c#-test */ { "False", "false != condition", "False" },
+	};
+
+	[Theory]
+	[MemberData(nameof(AssertExpressionReplacement))]
+	public async Task SimplifiesBooleanAssert(
+		string assertion,
+		string expression,
+		string replacement)
+	{
+		var before = string.Format(template, $"{{|xUnit2025:Assert.{assertion}({expression})|}}");
+		var after = string.Format(template, $"Assert.{replacement}(condition)");
+
+		await Verify.VerifyCodeFix(before, after, BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckBooleanFixer.Key_UseSuggestedAssert);
+	}
+
+	[Theory]
+	[MemberData(nameof(AssertExpressionReplacement))]
+	public async Task SimplifiesBooleanAssertWithMessage(
+		string assertion,
+		string expression,
+		string replacement)
+	{
+		var before = string.Format(template, $"{{|xUnit2025:Assert.{assertion}({expression}, \"message\")|}}");
+		var after = string.Format(template, $"Assert.{replacement}(condition, \"message\")");
+
+		await Verify.VerifyCodeFix(before, after, BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckBooleanFixer.Key_UseSuggestedAssert);
+	}
+
 	[Fact]
 	public async Task FixAll_SimplifiesAllBooleanAsserts()
 	{

--- a/src/xunit.analyzers.tests/Fixes/X2000/BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixerTests.cs
@@ -1,98 +1,40 @@
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
-using Xunit.Analyzers;
 using Xunit.Analyzers.Fixes;
 using Verify = CSharpVerifier<Xunit.Analyzers.BooleanAssertsShouldNotBeUsedForSimpleEqualityCheck>;
 
 public class BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixerTests
 {
-	const string template = /* lang=c#-test */ """
-		using Xunit;
-
-		public enum MyEnum {{ None, Bacon, Veggie }}
-
-		public class TestClass {{
-			[Fact]
-			public void TestMethod() {{
-				{0} value = {1};
-
-				{2};
-			}}
-		}}
-		""";
-
-	public static MatrixTheoryData<string, string, string> MethodOperatorValue =
-		new(
-			[Constants.Asserts.True, Constants.Asserts.False],
-			["==", "!="],
-			["\"bacon\"", "'5'", "5", "5l", "5.0d", "5.0f", "5.0m", "MyEnum.Bacon"]
-		);
-
-	[Theory]
-	[MemberData(nameof(MethodOperatorValue))]
-	public async Task BooleanAssertAgainstLiteralValue_ReplaceWithEquality(
-		string method,
-		string @operator,
-		string value)
+	[Fact]
+	public async Task FixAll_ReplacesAllNonBooleanEqualityChecks()
 	{
-		var replacement =
-			(method, @operator) switch
-			{
-				(Constants.Asserts.True, "==") or (Constants.Asserts.False, "!=") => Constants.Asserts.Equal,
-				(_, _) => Constants.Asserts.NotEqual,
-			};
+		var before = /* lang=c#-test */ """
+			using Xunit;
 
-		// Literal on the right
-		await Verify.VerifyCodeFix(
-			string.Format(template, "var", value, $"{{|xUnit2024:Assert.{method}(value {@operator} {value})|}}"),
-			string.Format(template, "var", value, $"Assert.{replacement}({value}, value)"),
-			BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixer.Key_UseSuggestedAssert
-		);
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var value = 5;
 
-		// Literal on the left
-		await Verify.VerifyCodeFix(
-			string.Format(template, "var", value, $"{{|xUnit2024:Assert.{method}({value} {@operator} value)|}}"),
-			string.Format(template, "var", value, $"Assert.{replacement}({value}, value)"),
-			BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixer.Key_UseSuggestedAssert
-		);
-	}
+					{|xUnit2024:Assert.True(value == 5)|};
+					{|xUnit2024:Assert.True(value != 5)|};
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using Xunit;
 
-	public static MatrixTheoryData<string, string, string> MethodOperatorType =
-		new(
-			[Constants.Asserts.True, Constants.Asserts.False],
-			["==", "!="],
-			["string", "int", "object", "MyEnum"]
-		);
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var value = 5;
 
-	[Theory]
-	[MemberData(nameof(MethodOperatorType))]
-	public async Task BooleanAssertAgainstNull_ReplaceWithNull(
-		string method,
-		string @operator,
-		string type)
-	{
-		var replacement =
-			(method, @operator) switch
-			{
-				(Constants.Asserts.True, "==") or (Constants.Asserts.False, "!=") => Constants.Asserts.Null,
-				(_, _) => Constants.Asserts.NotNull,
-			};
+					Assert.Equal(5, value);
+					Assert.NotEqual(5, value);
+				}
+			}
+			""";
 
-		// Null on the right
-		await Verify.VerifyCodeFix(
-			LanguageVersion.CSharp8,
-			string.Format(template, type + "?", "null", $"{{|xUnit2024:Assert.{method}(value {@operator} null)|}}"),
-			string.Format(template, type + "?", "null", $"Assert.{replacement}(value)"),
-			BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixer.Key_UseSuggestedAssert
-		);
-
-		// Null on the left
-		await Verify.VerifyCodeFix(
-			LanguageVersion.CSharp8,
-			string.Format(template, type + "?", "null", $"{{|xUnit2024:Assert.{method}(null {@operator} value)|}}"),
-			string.Format(template, type + "?", "null", $"Assert.{replacement}(value)"),
-			BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixer.Key_UseSuggestedAssert
-		);
+		await Verify.VerifyCodeFixFixAll(before, after, BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixer.Key_UseSuggestedAssert);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixerTests.cs
@@ -1,10 +1,101 @@
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
+using Xunit.Analyzers;
 using Xunit.Analyzers.Fixes;
 using Verify = CSharpVerifier<Xunit.Analyzers.BooleanAssertsShouldNotBeUsedForSimpleEqualityCheck>;
 
 public class BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixerTests
 {
+	const string template = /* lang=c#-test */ """
+		using Xunit;
+
+		public enum MyEnum {{ None, Bacon, Veggie }}
+
+		public class TestClass {{
+			[Fact]
+			public void TestMethod() {{
+				{0} value = {1};
+
+				{2};
+			}}
+		}}
+		""";
+
+	public static MatrixTheoryData<string, string, string> MethodOperatorValue =
+		new(
+			[Constants.Asserts.True, Constants.Asserts.False],
+			["==", "!="],
+			["\"bacon\"", "'5'", "5", "5l", "5.0d", "5.0f", "5.0m", "MyEnum.Bacon"]
+		);
+
+	[Theory]
+	[MemberData(nameof(MethodOperatorValue))]
+	public async Task BooleanAssertAgainstLiteralValue_ReplaceWithEquality(
+		string method,
+		string @operator,
+		string value)
+	{
+		var replacement =
+			(method, @operator) switch
+			{
+				(Constants.Asserts.True, "==") or (Constants.Asserts.False, "!=") => Constants.Asserts.Equal,
+				(_, _) => Constants.Asserts.NotEqual,
+			};
+
+		// Literal on the right
+		await Verify.VerifyCodeFix(
+			string.Format(template, "var", value, $"{{|xUnit2024:Assert.{method}(value {@operator} {value})|}}"),
+			string.Format(template, "var", value, $"Assert.{replacement}({value}, value)"),
+			BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixer.Key_UseSuggestedAssert
+		);
+
+		// Literal on the left
+		await Verify.VerifyCodeFix(
+			string.Format(template, "var", value, $"{{|xUnit2024:Assert.{method}({value} {@operator} value)|}}"),
+			string.Format(template, "var", value, $"Assert.{replacement}({value}, value)"),
+			BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixer.Key_UseSuggestedAssert
+		);
+	}
+
+	public static MatrixTheoryData<string, string, string> MethodOperatorType =
+		new(
+			[Constants.Asserts.True, Constants.Asserts.False],
+			["==", "!="],
+			["string", "int", "object", "MyEnum"]
+		);
+
+	[Theory]
+	[MemberData(nameof(MethodOperatorType))]
+	public async Task BooleanAssertAgainstNull_ReplaceWithNull(
+		string method,
+		string @operator,
+		string type)
+	{
+		var replacement =
+			(method, @operator) switch
+			{
+				(Constants.Asserts.True, "==") or (Constants.Asserts.False, "!=") => Constants.Asserts.Null,
+				(_, _) => Constants.Asserts.NotNull,
+			};
+
+		// Null on the right
+		await Verify.VerifyCodeFix(
+			LanguageVersion.CSharp8,
+			string.Format(template, type + "?", "null", $"{{|xUnit2024:Assert.{method}(value {@operator} null)|}}"),
+			string.Format(template, type + "?", "null", $"Assert.{replacement}(value)"),
+			BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixer.Key_UseSuggestedAssert
+		);
+
+		// Null on the left
+		await Verify.VerifyCodeFix(
+			LanguageVersion.CSharp8,
+			string.Format(template, type + "?", "null", $"{{|xUnit2024:Assert.{method}(null {@operator} value)|}}"),
+			string.Format(template, type + "?", "null", $"Assert.{replacement}(value)"),
+			BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixer.Key_UseSuggestedAssert
+		);
+	}
+
 	[Fact]
 	public async Task FixAll_ReplacesAllNonBooleanEqualityChecks()
 	{

--- a/src/xunit.analyzers.tests/Fixes/X2000/UseAssertFailInsteadOfBooleanAssertFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/UseAssertFailInsteadOfBooleanAssertFixerTests.cs
@@ -5,26 +5,32 @@ using Verify = CSharpVerifier<Xunit.Analyzers.UseAssertFailInsteadOfBooleanAsser
 
 public class UseAssertFailInsteadOfBooleanAssertFixerTests
 {
-	const string template = /* lang=c#-test */ """
-
-		using Xunit;
-
-		public class TestClass {{
-			[Fact]
-			public void TestMethod() {{
-				{0};
-			}}
-		}}
-		""";
-
-	[Theory]
-	[InlineData(/* lang=c#-test */ @"[|Assert.True(false, ""message"")|]")]
-	[InlineData(/* lang=c#-test */ @"[|Assert.False(true, ""message"")|]")]
-	public async Task ReplacesBooleanAssert(string badAssert)
+	[Fact]
+	public async Task FixAll_ReplacesAllBooleanAssertsWithFail()
 	{
-		var before = string.Format(template, badAssert);
-		var after = string.Format(template, @"Assert.Fail(""message"")");
+		var before = /* lang=c#-test */ """
+			using Xunit;
 
-		await Verify.VerifyCodeFix(before, after, UseAssertFailInsteadOfBooleanAssertFixer.Key_UseAssertFail);
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					[|Assert.True(false, "message one")|];
+					[|Assert.False(true, "message two")|];
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					Assert.Fail("message one");
+					Assert.Fail("message two");
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFixFixAll(before, after, UseAssertFailInsteadOfBooleanAssertFixer.Key_UseAssertFail);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/UseGenericOverloadFixTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/UseGenericOverloadFixTests.cs
@@ -2,12 +2,11 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Analyzers.Fixes;
 using Verify_X2007 = CSharpVerifier<Xunit.Analyzers.AssertIsTypeShouldUseGenericOverloadType>;
-using Verify_X2015 = CSharpVerifier<Xunit.Analyzers.AssertThrowsShouldUseGenericOverloadCheck>;
 
 public class UseGenericOverloadFixTests
 {
 	[Fact]
-	public async Task X2007_SwitchesToGenericIsAssignableFrom()
+	public async Task FixAll_SwitchesAllToGenericOverloads()
 	{
 		var before = /* lang=c#-test */ """
 			using Xunit;
@@ -17,6 +16,7 @@ public class UseGenericOverloadFixTests
 				public void TestMethod() {
 					var result = 123;
 
+					[|Assert.IsType(typeof(int), result)|];
 					[|Assert.IsAssignableFrom(typeof(int), result)|];
 				}
 			}
@@ -29,78 +29,12 @@ public class UseGenericOverloadFixTests
 				public void TestMethod() {
 					var result = 123;
 
+					Assert.IsType<int>(result);
 					Assert.IsAssignableFrom<int>(result);
 				}
 			}
 			""";
 
-		await Verify_X2007.VerifyCodeFix(before, after, UseGenericOverloadFix.Key_UseAlternateAssert);
-	}
-
-	[Theory]
-	[InlineData("result")]
-	[InlineData("result, true")]
-	[InlineData("result, false")]
-	public async Task X2007_SwitchesToGenericIsType(string arguments)
-	{
-		var before = string.Format(/* lang=c#-test */ """
-			using Xunit;
-
-			public class TestClass {{
-				[Fact]
-				public void TestMethod() {{
-					var result = 123;
-
-					[|Assert.IsType(typeof(int), {0})|];
-				}}
-			}}
-			""", arguments);
-		var after = string.Format(/* lang=c#-test */ """
-			using Xunit;
-
-			public class TestClass {{
-				[Fact]
-				public void TestMethod() {{
-					var result = 123;
-
-					Assert.IsType<int>({0});
-				}}
-			}}
-			""", arguments);
-
-		await Verify_X2007.VerifyCodeFix(before, after, UseGenericOverloadFix.Key_UseAlternateAssert);
-	}
-
-	[Fact]
-	public async Task X2015_SwitchesToGenericThrows()
-	{
-		var before = /* lang=c#-test */ """
-			using System;
-			using Xunit;
-
-			public class TestClass {
-				[Fact]
-				public void TestMethod() {
-					Action func = () => { };
-
-					[|Assert.Throws(typeof(DivideByZeroException), func)|];
-				}
-			}
-			""";
-		var after = /* lang=c#-test */ """
-			using System;
-			using Xunit;
-
-			public class TestClass {
-				[Fact]
-				public void TestMethod() {
-					Action func = () => { };
-
-					Assert.Throws<DivideByZeroException>(func);
-				}
-			}
-			""";
-
-		await Verify_X2015.VerifyCodeFix(before, after, UseGenericOverloadFix.Key_UseAlternateAssert);
+		await Verify_X2007.VerifyCodeFixFixAll(before, after, UseGenericOverloadFix.Key_UseAlternateAssert);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/UseGenericOverloadFixTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/UseGenericOverloadFixTests.cs
@@ -2,9 +2,108 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Analyzers.Fixes;
 using Verify_X2007 = CSharpVerifier<Xunit.Analyzers.AssertIsTypeShouldUseGenericOverloadType>;
+using Verify_X2015 = CSharpVerifier<Xunit.Analyzers.AssertThrowsShouldUseGenericOverloadCheck>;
 
 public class UseGenericOverloadFixTests
 {
+	[Fact]
+	public async Task X2007_SwitchesToGenericIsAssignableFrom()
+	{
+		var before = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var result = 123;
+
+					[|Assert.IsAssignableFrom(typeof(int), result)|];
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var result = 123;
+
+					Assert.IsAssignableFrom<int>(result);
+				}
+			}
+			""";
+
+		await Verify_X2007.VerifyCodeFix(before, after, UseGenericOverloadFix.Key_UseAlternateAssert);
+	}
+
+	[Theory]
+	[InlineData("result")]
+	[InlineData("result, true")]
+	[InlineData("result, false")]
+	public async Task X2007_SwitchesToGenericIsType(string arguments)
+	{
+		var before = string.Format(/* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {{
+				[Fact]
+				public void TestMethod() {{
+					var result = 123;
+
+					[|Assert.IsType(typeof(int), {0})|];
+				}}
+			}}
+			""", arguments);
+		var after = string.Format(/* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {{
+				[Fact]
+				public void TestMethod() {{
+					var result = 123;
+
+					Assert.IsType<int>({0});
+				}}
+			}}
+			""", arguments);
+
+		await Verify_X2007.VerifyCodeFix(before, after, UseGenericOverloadFix.Key_UseAlternateAssert);
+	}
+
+	[Fact]
+	public async Task X2015_SwitchesToGenericThrows()
+	{
+		var before = /* lang=c#-test */ """
+			using System;
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					Action func = () => { };
+
+					[|Assert.Throws(typeof(DivideByZeroException), func)|];
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using System;
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					Action func = () => { };
+
+					Assert.Throws<DivideByZeroException>(func);
+				}
+			}
+			""";
+
+		await Verify_X2015.VerifyCodeFix(before, after, UseGenericOverloadFix.Key_UseAlternateAssert);
+	}
+
 	[Fact]
 	public async Task FixAll_SwitchesAllToGenericOverloads()
 	{

--- a/src/xunit.analyzers.tests/Fixes/X3000/CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X3000/CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectFixerTests.cs
@@ -49,6 +49,27 @@ public class CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectFixerTests
 			public class {0}: {1} {{ }}
 			""";
 
+		[Fact]
+		public async Task FixAll_AddsBaseClassToMultipleClasses()
+		{
+			var before = /* lang=c#-test */ """
+				using Xunit;
+				using Xunit.Abstractions;
+
+				public class [|MyClass1|]: IMessageSink { }
+				public class [|MyClass2|]: IMessageSink { }
+				""";
+			var after = /* lang=c#-test */ """
+				using Xunit;
+				using Xunit.Abstractions;
+
+				public class MyClass1: LongLivedMarshalByRefObject, IMessageSink { }
+				public class MyClass2: LongLivedMarshalByRefObject, IMessageSink { }
+				""";
+
+			await Verify_WithExecution.VerifyCodeFixV2FixAll(before, after, CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectFixer.Key_SetBaseType);
+		}
+
 		[Theory]
 		[MemberData(nameof(CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectTests.WithExecution.Interfaces), MemberType = typeof(CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectTests.WithExecution))]
 		public async Task WithNoBaseClass_WithoutUsing_AddsBaseClass(string @interface)

--- a/src/xunit.analyzers.tests/Fixes/X3000/CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X3000/CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectFixerTests.cs
@@ -56,15 +56,23 @@ public class CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectFixerTests
 				using Xunit;
 				using Xunit.Abstractions;
 
-				public class [|MyClass1|]: IMessageSink { }
-				public class [|MyClass2|]: IMessageSink { }
+				public class [|MyClass1|]: IMessageSink {
+					public bool OnMessage(IMessageSinkMessage message) => true;
+				}
+				public class [|MyClass2|]: IMessageSink {
+					public bool OnMessage(IMessageSinkMessage message) => true;
+				}
 				""";
 			var after = /* lang=c#-test */ """
 				using Xunit;
 				using Xunit.Abstractions;
 
-				public class MyClass1: LongLivedMarshalByRefObject, IMessageSink { }
-				public class MyClass2: LongLivedMarshalByRefObject, IMessageSink { }
+				public class MyClass1: LongLivedMarshalByRefObject, IMessageSink {
+					public bool OnMessage(IMessageSinkMessage message) => true;
+				}
+				public class MyClass2: LongLivedMarshalByRefObject, IMessageSink {
+					public bool OnMessage(IMessageSinkMessage message) => true;
+				}
 				""";
 
 			await Verify_WithExecution.VerifyCodeFixV2FixAll(before, after, CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectFixer.Key_SetBaseType);

--- a/src/xunit.analyzers.tests/Utility/CSharpVerifier.CodeFixes.cs
+++ b/src/xunit.analyzers.tests/Utility/CSharpVerifier.CodeFixes.cs
@@ -5,6 +5,46 @@ using Microsoft.CodeAnalysis.Testing;
 
 public partial class CSharpVerifier<TAnalyzer>
 {
+	// ----- Fix All -----
+
+	/// <summary>
+	/// Verify that "Fix All" correctly applies fixes to all diagnostics in a document.
+	/// Runs against xUnit.net v3, using C# 6.
+	/// </summary>
+	/// <param name="before">The code before the fix (should contain multiple diagnostics)</param>
+	/// <param name="after">The expected code after all fixes are applied</param>
+	/// <param name="fixerActionKey">The key of the fix to run</param>
+	public static Task VerifyCodeFixV3FixAll(
+		string before,
+		string after,
+		string fixerActionKey) =>
+			VerifyCodeFixV3FixAll(LanguageVersion.CSharp6, before, after, fixerActionKey);
+
+	/// <summary>
+	/// Verify that "Fix All" correctly applies fixes to all diagnostics in a document.
+	/// Runs against xUnit.net v3, using the provided version of C#.
+	/// </summary>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="before">The code before the fix (should contain multiple diagnostics)</param>
+	/// <param name="after">The expected code after all fixes are applied</param>
+	/// <param name="fixerActionKey">The key of the fix to run</param>
+	public static Task VerifyCodeFixV3FixAll(
+		LanguageVersion languageVersion,
+		string before,
+		string after,
+		string fixerActionKey)
+	{
+		var newLine = FormattingOptions.NewLine.DefaultValue;
+		var test = new TestV3(languageVersion)
+		{
+			TestCode = before.Replace("\n", newLine),
+			CodeActionEquivalenceKey = fixerActionKey,
+		};
+		test.FixedState.Sources.Add(after.Replace("\n", newLine));
+		test.BatchFixedState.Sources.Add(after.Replace("\n", newLine));
+		return test.RunAsync();
+	}
+
 	// ----- Multi-version -----
 
 	/// <summary>

--- a/src/xunit.analyzers.tests/Utility/CSharpVerifier.CodeFixes.cs
+++ b/src/xunit.analyzers.tests/Utility/CSharpVerifier.CodeFixes.cs
@@ -9,6 +9,78 @@ public partial class CSharpVerifier<TAnalyzer>
 
 	/// <summary>
 	/// Verify that "Fix All" correctly applies fixes to all diagnostics in a document.
+	/// Runs against xUnit.net v2 and v3, using C# 6.
+	/// </summary>
+	/// <param name="before">The code before the fix (should contain multiple diagnostics)</param>
+	/// <param name="after">The expected code after all fixes are applied</param>
+	/// <param name="fixerActionKey">The key of the fix to run</param>
+	public static async Task VerifyCodeFixFixAll(
+		string before,
+		string after,
+		string fixerActionKey)
+	{
+		await VerifyCodeFixV2FixAll(LanguageVersion.CSharp6, before, after, fixerActionKey);
+		await VerifyCodeFixV3FixAll(LanguageVersion.CSharp6, before, after, fixerActionKey);
+	}
+
+	/// <summary>
+	/// Verify that "Fix All" correctly applies fixes to all diagnostics in a document.
+	/// Runs against xUnit.net v2 and v3, using the provided version of C#.
+	/// </summary>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="before">The code before the fix (should contain multiple diagnostics)</param>
+	/// <param name="after">The expected code after all fixes are applied</param>
+	/// <param name="fixerActionKey">The key of the fix to run</param>
+	public static async Task VerifyCodeFixFixAll(
+		LanguageVersion languageVersion,
+		string before,
+		string after,
+		string fixerActionKey)
+	{
+		await VerifyCodeFixV2FixAll(languageVersion, before, after, fixerActionKey);
+		await VerifyCodeFixV3FixAll(languageVersion, before, after, fixerActionKey);
+	}
+
+	/// <summary>
+	/// Verify that "Fix All" correctly applies fixes to all diagnostics in a document.
+	/// Runs against xUnit.net v2, using C# 6.
+	/// </summary>
+	/// <param name="before">The code before the fix (should contain multiple diagnostics)</param>
+	/// <param name="after">The expected code after all fixes are applied</param>
+	/// <param name="fixerActionKey">The key of the fix to run</param>
+	public static Task VerifyCodeFixV2FixAll(
+		string before,
+		string after,
+		string fixerActionKey) =>
+			VerifyCodeFixV2FixAll(LanguageVersion.CSharp6, before, after, fixerActionKey);
+
+	/// <summary>
+	/// Verify that "Fix All" correctly applies fixes to all diagnostics in a document.
+	/// Runs against xUnit.net v2, using the provided version of C#.
+	/// </summary>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="before">The code before the fix (should contain multiple diagnostics)</param>
+	/// <param name="after">The expected code after all fixes are applied</param>
+	/// <param name="fixerActionKey">The key of the fix to run</param>
+	public static Task VerifyCodeFixV2FixAll(
+		LanguageVersion languageVersion,
+		string before,
+		string after,
+		string fixerActionKey)
+	{
+		var newLine = FormattingOptions.NewLine.DefaultValue;
+		var test = new TestV2(languageVersion)
+		{
+			TestCode = before.Replace("\n", newLine),
+			CodeActionEquivalenceKey = fixerActionKey,
+		};
+		test.FixedState.Sources.Add(after.Replace("\n", newLine));
+		test.BatchFixedState.Sources.Add(after.Replace("\n", newLine));
+		return test.RunAsync();
+	}
+
+	/// <summary>
+	/// Verify that "Fix All" correctly applies fixes to all diagnostics in a document.
 	/// Runs against xUnit.net v3, using C# 6.
 	/// </summary>
 	/// <param name="before">The code before the fix (should contain multiple diagnostics)</param>


### PR DESCRIPTION
Enables Fix All functionality across the analyser suite. The standard `WellKnownFixAllProviders.BatchFixer` can be safely used for fixers where each diagnostic fix is independent and won't conflict with other fixes in batch mode.

The base class `XunitCodeFixProvider.GetFixAllProvider()` has been changed from `sealed override` to `override`, allowing individual fixers to opt in to batch fix support.

## Fixers with Fix All enabled (53)

### X1000 — Usage

- `CollectionDefinitionClassesMustBePublicFixer` (X1027)
- `ConvertToFactFix` (X1003, X1006)
- `ConvertToTheoryFix` (X1001, X1005)
- `DataAttributeShouldBeUsedOnATheoryFixer` (X1008)
- `DoNotUseAsyncVoidForTestMethodsFixer` (X1048, X1049)
- `DoNotUseConfigureAwaitFixer` (X1030)
- `FactMethodMustNotHaveParametersFixer` (X1002)
- `FactMethodShouldNotHaveTestDataFixer` (X1004)
- `InlineDataMustMatchTheoryParameters_ExtraValueFixer` (X1011)
- `InlineDataMustMatchTheoryParameters_NullShouldNotBeUsedForIncompatibleParameterFixer` (X1012)
- `InlineDataMustMatchTheoryParameters_TooFewValuesFixer` (X1009)
- `InlineDataShouldBeUniqueWithinTheoryFixer` (X1025)
- `LocalFunctionsCannotBeTestFunctionsFixer` (X1031)
- `MemberDataShouldReferenceValidMember_ExtraValueFixer` (X1036)
- `MemberDataShouldReferenceValidMember_NameOfFixer` (X1014)
- `MemberDataShouldReferenceValidMember_NullShouldNotBeUsedForIncompatibleParameterFixer` (X1034)
- `MemberDataShouldReferenceValidMember_ParamsForNonMethodFixer` (X1021)
- `MemberDataShouldReferenceValidMember_ReturnTypeFixer` (X1019)
- `MemberDataShouldReferenceValidMember_StaticFixer` (X1017)
- `MemberDataShouldReferenceValidMember_VisibilityFixer` (X1016)
- `PublicMethodShouldBeMarkedAsTestFixer` (X1013)
- `TestClassMustBePublicFixer` (X1000)
- `TestMethodMustNotHaveMultipleFactAttributesFixer` (X1010)
- `TestMethodShouldNotBeSkippedFixer` (X1029)
- `TheoryDataShouldNotUseTheoryDataRowFixer` (X1052)
- `TheoryMethodCannotHaveDefaultParameterFixer` (X1023)
- `UseCancellationTokenFixer` (X1051)

### X2000 — Assertions

- `AssertCollectionContainsShouldNotUseBoolCheckFixer` (X2017)
- `AssertEmptyCollectionCheckShouldNotBeUsedFixer` (X2011)
- `AssertEmptyOrNotEmptyShouldNotBeUsedForContainsChecksFixer` (X2029)
- `AssertEnumerableAnyCheckShouldNotBeUsedForCollectionContainsCheckFixer` (X2012)
- `AssertEqualGenericShouldNotBeUsedForStringValueFixer` (X2006)
- `AssertEqualLiteralValueShouldBeFirstFixer` (X2000)
- `AssertEqualPrecisionShouldBeInRangeFixer` (X2016)
- `AssertEqualShouldNotBeUsedForBoolLiteralCheckFixer` (X2004)
- `AssertEqualShouldNotBeUsedForCollectionSizeCheckFixer` (X2013)
- `AssertEqualShouldNotBeUsedForNullCheckFixer` (X2003)
- `AssertEqualsShouldNotBeUsedFixer` (X2001)
- `AssertIsTypeShouldNotBeUsedForAbstractTypeFixer` (X2018)
- `AssertNullShouldNotBeCalledOnValueTypesFixer` (X2002)
- `AssertRegexMatchShouldNotUseBoolLiteralCheckFixer` (X2008)
- `AssertSameShouldNotBeCalledOnValueTypesFixer` (X2005)
- `AssertSingleShouldUseTwoArgumentCallFixer` (X2022)
- `AssertStringEqualityCheckShouldNotUseBoolCheckFixer` (X2010)
- `AssertSubstringCheckShouldNotUseBoolCheckFixer` (X2009)
- `AssignableFromAssertionIsConfusinglyNamedFixer` (X2015)
- `BooleanAssertsShouldNotBeNegatedFixer` (X2025)
- `BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckBooleanFixer` (X2024)
- `BooleanAssertsShouldNotBeUsedForSimpleEqualityCheckNonBooleanFixer` (X2024)
- `UseAssertFailInsteadOfBooleanAssertFixer` (X2020)
- `UseGenericOverloadFix` (X2007)

### X3000 — Advanced

- `CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectFixer` (X3000)
- `SerializableClassMustHaveParameterlessConstructorFixer` (X3001)

## Fixers left without Fix All (7)

These fixers need further investigation before the standard `BatchFixer` can be safely applied — they involve solution-level edits, complex ancestor node modifications, or potential conflicts when multiple diagnostics target the same method/class:

- `ClassDataAttributeMustPointAtValidClassFixer` (X1007)
- `RemoveMethodParameterFix` (X1022, X1026)
- `TestClassCannotBeNestedInGenericClassFixer` (X1032)
- `TestClassShouldHaveTFixtureArgumentFixer` (X1033)
- `AssertSingleShouldBeUsedForSingleParameterFixer` (X2023)
- `AssertThrowsShouldNotBeUsedForAsyncThrowsCheckFixer` (X2014)
- `AsyncAssertsShouldBeAwaitedFixer` (X2021)