### PR TITLE
Fix xUnit1042 false positive: Increase TheoryData arity limit to 20

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
@@ -1452,6 +1452,30 @@ public class MemberDataShouldReferenceValidMemberTests
 		}
 
 		[Fact]
+		public async ValueTask TheoryData_With11Parameters_ShouldNotTrigger1042()
+		{
+			var source = /* lang=c#-test */ """
+				#pragma warning disable xUnit1053
+				using Xunit;
+
+				// IMPORTANT: namespace Xunit block should be used so that the Factory can find it!
+				namespace Xunit 
+				{
+					public class TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : TheoryData { }
+				}
+
+				public class TestClass {
+					public static TheoryData<int, int, int, int, int, int, int, int, int, int, int> Data11;
+
+					[MemberData(nameof(Data11))]
+					public void TestMethod(int a, int b, int c, int d, int e, int f, int g, int h, int i, int j, int k) { }
+				}
+				""";
+
+			await Verify.VerifyAnalyzer(source);
+		}
+
+		[Fact]
 		public async Task V3_only()
 		{
 			var source = /* lang=c#-test */ """

--- a/src/xunit.analyzers/Utility/TypeSymbolFactory.cs
+++ b/src/xunit.analyzers/Utility/TypeSymbolFactory.cs
@@ -380,7 +380,7 @@ public static class TypeSymbolFactory
 		if (type is not null)
 			result[0] = type;
 
-		for (var i = 1; i <= 10; i++)
+		for (var i = 1; i <= 20; i++)
 		{
 			type = compilation.GetTypeByMetadataName(Constants.Types.Xunit.TheoryData + "`" + i.ToString(CultureInfo.InvariantCulture));
 			if (type is not null)
@@ -403,7 +403,7 @@ public static class TypeSymbolFactory
 		if (type is not null)
 			result[0] = type;
 
-		for (var i = 1; i <= 10; i++)
+		for (var i = 1; i <= 20; i++)
 		{
 			type = compilation.GetTypeByMetadataName(Constants.Types.Xunit.TheoryDataRow_V3 + "`" + i.ToString(CultureInfo.InvariantCulture));
 			if (type is not null)


### PR DESCRIPTION
## Description
This PR resolves an issue where the analyzer would incorrectly report `xUnit1042` and `xUnit1037` for `TheoryData` implementations utilizing more than 10 generic arguments.

The `TypeSymbolFactory` was previously hardcoded to verify `TheoryData` and `TheoryDataRow` generic arity only up to 10. I have increased this limit to 20 to support larger datasets, consistent with modern C# capabilities.

## Related Issue
Fixes xunit/xunit#3485

## Changes
- Updated `TypeSymbolFactory.TheoryData_ByGenericArgumentCount` loop limit to 20.
- Updated `TypeSymbolFactory.TheoryDataRow_ByGenericArgumentCount_V3` loop limit to 20.
- Added a regression test in `MemberDataShouldReferenceValidMemberTests` to verify 11 parameters are now accepted.