### PR TITLE
xunit/xunit#3423: Suppress CS8618 for members set in InitializeAsync

### DIFF
--- a/src/xunit.analyzers.tests/Suppressors/NonNullableFieldInitializationSuppressorTests.cs
+++ b/src/xunit.analyzers.tests/Suppressors/NonNullableFieldInitializationSuppressorTests.cs
@@ -1,0 +1,163 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Verify = CSharpVerifier<Xunit.Suppressors.NonNullableFieldInitializationSuppressor>;
+
+public sealed class NonNullableFieldInitializationSuppressorTests
+{
+	[Fact]
+	public async Task NonAsyncLifetimeClass_DoesNotSuppress()
+	{
+		var code = /* lang=c#-test */ """
+			#nullable enable
+			#pragma warning disable CS0414, CS0169, CS1591
+
+			public class NonTestClass {
+				private string {|CS8618:_field|};
+			}
+			""";
+
+		await Verify.VerifyCompilerWarningSuppressorV3(LanguageVersion.CSharp8, [code]);
+	}
+
+	[Fact]
+	public async Task FieldInitializedInInitializeAsync_Suppresses()
+	{
+		var code = /* lang=c#-test */ """
+			#nullable enable
+			#pragma warning disable CS0414, CS0169, CS1591
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass : IAsyncLifetime {
+				private string {|#0:_field|};
+
+				public Task InitializeAsync() {
+					_field = "hello";
+					return Task.CompletedTask;
+				}
+
+				public Task DisposeAsync() => Task.CompletedTask;
+
+				[Fact]
+				public void Test1() { }
+			}
+			""";
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+
+		await Verify.VerifyCompilerWarningSuppressorV2(LanguageVersion.CSharp8, [code], expected);
+	}
+
+	[Fact]
+	public async Task PropertyInitializedInInitializeAsync_Suppresses()
+	{
+		var code = /* lang=c#-test */ """
+			#nullable enable
+			#pragma warning disable CS0414, CS0169, CS1591
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass : IAsyncLifetime {
+				public string {|#0:Prop|} { get; set; }
+
+				public Task InitializeAsync() {
+					Prop = "hello";
+					return Task.CompletedTask;
+				}
+
+				public Task DisposeAsync() => Task.CompletedTask;
+
+				[Fact]
+				public void Test1() { }
+			}
+			""";
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+
+		await Verify.VerifyCompilerWarningSuppressorV2(LanguageVersion.CSharp8, [code], expected);
+	}
+
+	[Fact]
+	public async Task FieldNotInitializedInInitializeAsync_DoesNotSuppress()
+	{
+		var code = /* lang=c#-test */ """
+			#nullable enable
+			#pragma warning disable CS0414, CS0169, CS1591
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass : IAsyncLifetime {
+				private string {|CS8618:_field|};
+
+				public Task InitializeAsync() {
+					return Task.CompletedTask;
+				}
+
+				public Task DisposeAsync() => Task.CompletedTask;
+
+				[Fact]
+				public void Test1() { }
+			}
+			""";
+
+		await Verify.VerifyCompilerWarningSuppressorV2(LanguageVersion.CSharp8, [code]);
+	}
+
+	[Fact]
+	public async Task FieldInitializedWithThis_Suppresses()
+	{
+		var code = /* lang=c#-test */ """
+			#nullable enable
+			#pragma warning disable CS0414, CS0169, CS1591
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass : IAsyncLifetime {
+				private string {|#0:_field|};
+
+				public Task InitializeAsync() {
+					this._field = "hello";
+					return Task.CompletedTask;
+				}
+
+				public Task DisposeAsync() => Task.CompletedTask;
+
+				[Fact]
+				public void Test1() { }
+			}
+			""";
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+
+		await Verify.VerifyCompilerWarningSuppressorV2(LanguageVersion.CSharp8, [code], expected);
+	}
+
+	[Fact]
+	public async Task MultipleFields_OnlyInitializedOnesSuppressed()
+	{
+		var code = /* lang=c#-test */ """
+			#nullable enable
+			#pragma warning disable CS0414, CS0169, CS1591
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass : IAsyncLifetime {
+				private string {|#0:_initialized|};
+				private string {|CS8618:_notInitialized|};
+
+				public Task InitializeAsync() {
+					_initialized = "hello";
+					return Task.CompletedTask;
+				}
+
+				public Task DisposeAsync() => Task.CompletedTask;
+
+				[Fact]
+				public void Test1() { }
+			}
+			""";
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+
+		await Verify.VerifyCompilerWarningSuppressorV2(LanguageVersion.CSharp8, [code], expected);
+	}
+}

--- a/src/xunit.analyzers.tests/Suppressors/NonNullableFieldInitializationSuppressorTests.cs
+++ b/src/xunit.analyzers.tests/Suppressors/NonNullableFieldInitializationSuppressorTests.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
@@ -7,8 +6,10 @@ using Verify = CSharpVerifier<Xunit.Suppressors.NonNullableFieldInitializationSu
 
 public sealed class NonNullableFieldInitializationSuppressorTests
 {
+	// ----- v2 (Task-based IAsyncLifetime) -----
+
 	[Fact]
-	public async Task NonAsyncLifetimeClass_DoesNotSuppress()
+	public async Task NonAsyncLifetimeClass_V2_DoesNotSuppress()
 	{
 		var code = /* lang=c#-test */ """
 			#nullable enable
@@ -19,11 +20,11 @@ public sealed class NonNullableFieldInitializationSuppressorTests
 			}
 			""";
 
-		await Verify.VerifyCompilerWarningSuppressorV3(LanguageVersion.CSharp8, [code]);
+		await Verify.VerifyCompilerWarningSuppressorV2(LanguageVersion.CSharp8, [code]);
 	}
 
 	[Fact]
-	public async Task FieldInitializedInInitializeAsync_Suppresses()
+	public async Task FieldInitializedInInitializeAsync_V2_Suppresses()
 	{
 		var code = /* lang=c#-test */ """
 			#nullable enable
@@ -51,7 +52,7 @@ public sealed class NonNullableFieldInitializationSuppressorTests
 	}
 
 	[Fact]
-	public async Task PropertyInitializedInInitializeAsync_Suppresses()
+	public async Task PropertyInitializedInInitializeAsync_V2_Suppresses()
 	{
 		var code = /* lang=c#-test */ """
 			#nullable enable
@@ -79,7 +80,7 @@ public sealed class NonNullableFieldInitializationSuppressorTests
 	}
 
 	[Fact]
-	public async Task FieldNotInitializedInInitializeAsync_DoesNotSuppress()
+	public async Task FieldNotInitializedInInitializeAsync_V2_DoesNotSuppress()
 	{
 		var code = /* lang=c#-test */ """
 			#nullable enable
@@ -105,7 +106,7 @@ public sealed class NonNullableFieldInitializationSuppressorTests
 	}
 
 	[Fact]
-	public async Task FieldInitializedWithThis_Suppresses()
+	public async Task FieldInitializedWithThis_V2_Suppresses()
 	{
 		var code = /* lang=c#-test */ """
 			#nullable enable
@@ -133,7 +134,7 @@ public sealed class NonNullableFieldInitializationSuppressorTests
 	}
 
 	[Fact]
-	public async Task MultipleFields_OnlyInitializedOnesSuppressed()
+	public async Task MultipleFields_OnlyInitializedOnesSuppressed_V2()
 	{
 		var code = /* lang=c#-test */ """
 			#nullable enable
@@ -159,5 +160,270 @@ public sealed class NonNullableFieldInitializationSuppressorTests
 		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
 
 		await Verify.VerifyCompilerWarningSuppressorV2(LanguageVersion.CSharp8, [code], expected);
+	}
+
+	[Fact]
+	public async Task FieldAssignedWithExplicitConstructor_V2_Suppresses()
+	{
+		var code = /* lang=c#-test */ """
+			#nullable enable
+			#pragma warning disable CS0414, CS0169, CS1591
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass : IAsyncLifetime {
+				private string _field;
+				public {|#0:TestClass|}() { }
+
+				public Task InitializeAsync() {
+					_field = "hello";
+					return Task.CompletedTask;
+				}
+
+				public Task DisposeAsync() => Task.CompletedTask;
+
+				[Fact]
+				public void Test1() { }
+			}
+			""";
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+
+		await Verify.VerifyCompilerWarningSuppressorV2(LanguageVersion.CSharp8, [code], expected);
+	}
+
+	[Fact]
+	public async Task FieldNotAssignedWithExplicitConstructor_V2_DoesNotSuppress()
+	{
+		var code = /* lang=c#-test */ """
+			#nullable enable
+			#pragma warning disable CS0414, CS0169, CS1591
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass : IAsyncLifetime {
+				private string _field;
+				public {|CS8618:TestClass|}() { }
+
+				public Task InitializeAsync() {
+					return Task.CompletedTask;
+				}
+
+				public Task DisposeAsync() => Task.CompletedTask;
+
+				[Fact]
+				public void Test1() { }
+			}
+			""";
+
+		await Verify.VerifyCompilerWarningSuppressorV2(LanguageVersion.CSharp8, [code]);
+	}
+
+	[Fact]
+	public async Task PropertyAssignedWithExplicitConstructor_V2_Suppresses()
+	{
+		var code = /* lang=c#-test */ """
+			#nullable enable
+			#pragma warning disable CS0414, CS0169, CS1591
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass : IAsyncLifetime {
+				public string MyProp { get; set; }
+				public {|#0:TestClass|}() { }
+
+				public Task InitializeAsync() {
+					MyProp = "hello";
+					return Task.CompletedTask;
+				}
+
+				public Task DisposeAsync() => Task.CompletedTask;
+
+				[Fact]
+				public void Test1() { }
+			}
+			""";
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+
+		await Verify.VerifyCompilerWarningSuppressorV2(LanguageVersion.CSharp8, [code], expected);
+	}
+
+	// ----- v3 (ValueTask-based IAsyncLifetime) -----
+
+	[Fact]
+	public async Task NonAsyncLifetimeClass_V3_DoesNotSuppress()
+	{
+		var code = /* lang=c#-test */ """
+			#nullable enable
+			#pragma warning disable CS0414, CS0169, CS1591
+
+			public class NonTestClass {
+				private string {|CS8618:_field|};
+			}
+			""";
+
+		await Verify.VerifyCompilerWarningSuppressorV3(LanguageVersion.CSharp8, [code]);
+	}
+
+	[Fact]
+	public async Task FieldInitializedInInitializeAsync_V3_Suppresses()
+	{
+		var code = /* lang=c#-test */ """
+			#nullable enable
+			#pragma warning disable CS0414, CS0169, CS1591
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass : IAsyncLifetime {
+				private string {|#0:_field|};
+
+				public ValueTask InitializeAsync() {
+					_field = "hello";
+					return default;
+				}
+
+				public ValueTask DisposeAsync() => default;
+
+				[Fact]
+				public void Test1() { }
+			}
+			""";
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+
+		await Verify.VerifyCompilerWarningSuppressorV3(LanguageVersion.CSharp8, [code], expected);
+	}
+
+	[Fact]
+	public async Task PropertyInitializedInInitializeAsync_V3_Suppresses()
+	{
+		var code = /* lang=c#-test */ """
+			#nullable enable
+			#pragma warning disable CS0414, CS0169, CS1591
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass : IAsyncLifetime {
+				public string {|#0:Prop|} { get; set; }
+
+				public ValueTask InitializeAsync() {
+					Prop = "hello";
+					return default;
+				}
+
+				public ValueTask DisposeAsync() => default;
+
+				[Fact]
+				public void Test1() { }
+			}
+			""";
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+
+		await Verify.VerifyCompilerWarningSuppressorV3(LanguageVersion.CSharp8, [code], expected);
+	}
+
+	[Fact]
+	public async Task FieldNotInitializedInInitializeAsync_V3_DoesNotSuppress()
+	{
+		var code = /* lang=c#-test */ """
+			#nullable enable
+			#pragma warning disable CS0414, CS0169, CS1591
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass : IAsyncLifetime {
+				private string {|CS8618:_field|};
+
+				public ValueTask InitializeAsync() => default;
+
+				public ValueTask DisposeAsync() => default;
+
+				[Fact]
+				public void Test1() { }
+			}
+			""";
+
+		await Verify.VerifyCompilerWarningSuppressorV3(LanguageVersion.CSharp8, [code]);
+	}
+
+	[Fact]
+	public async Task FieldAssignedWithExplicitConstructor_V3_Suppresses()
+	{
+		var code = /* lang=c#-test */ """
+			#nullable enable
+			#pragma warning disable CS0414, CS0169, CS1591
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass : IAsyncLifetime {
+				private string _field;
+				public {|#0:TestClass|}() { }
+
+				public ValueTask InitializeAsync() {
+					_field = "hello";
+					return default;
+				}
+
+				public ValueTask DisposeAsync() => default;
+
+				[Fact]
+				public void Test1() { }
+			}
+			""";
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+
+		await Verify.VerifyCompilerWarningSuppressorV3(LanguageVersion.CSharp8, [code], expected);
+	}
+
+	[Fact]
+	public async Task FieldNotAssignedWithExplicitConstructor_V3_DoesNotSuppress()
+	{
+		var code = /* lang=c#-test */ """
+			#nullable enable
+			#pragma warning disable CS0414, CS0169, CS1591
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass : IAsyncLifetime {
+				private string _field;
+				public {|CS8618:TestClass|}() { }
+
+				public ValueTask InitializeAsync() => default;
+
+				public ValueTask DisposeAsync() => default;
+
+				[Fact]
+				public void Test1() { }
+			}
+			""";
+
+		await Verify.VerifyCompilerWarningSuppressorV3(LanguageVersion.CSharp8, [code]);
+	}
+
+	[Fact]
+	public async Task PropertyAssignedWithExplicitConstructor_V3_Suppresses()
+	{
+		var code = /* lang=c#-test */ """
+			#nullable enable
+			#pragma warning disable CS0414, CS0169, CS1591
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass : IAsyncLifetime {
+				public string MyProp { get; set; }
+				public {|#0:TestClass|}() { }
+
+				public ValueTask InitializeAsync() {
+					MyProp = "hello";
+					return default;
+				}
+
+				public ValueTask DisposeAsync() => default;
+
+				[Fact]
+				public void Test1() { }
+			}
+			""";
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+
+		await Verify.VerifyCompilerWarningSuppressorV3(LanguageVersion.CSharp8, [code], expected);
 	}
 }

--- a/src/xunit.analyzers.tests/Suppressors/NonNullableFieldInitializationSuppressorTests.cs
+++ b/src/xunit.analyzers.tests/Suppressors/NonNullableFieldInitializationSuppressorTests.cs
@@ -46,7 +46,7 @@ public sealed class NonNullableFieldInitializationSuppressorTests
 				public void Test1() { }
 			}
 			""";
-		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true).WithOptions(DiagnosticOptions.IgnoreAdditionalLocations);
 
 		await Verify.VerifyCompilerWarningSuppressorV2(LanguageVersion.CSharp8, [code], expected);
 	}
@@ -74,7 +74,7 @@ public sealed class NonNullableFieldInitializationSuppressorTests
 				public void Test1() { }
 			}
 			""";
-		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true).WithOptions(DiagnosticOptions.IgnoreAdditionalLocations);
 
 		await Verify.VerifyCompilerWarningSuppressorV2(LanguageVersion.CSharp8, [code], expected);
 	}
@@ -128,7 +128,7 @@ public sealed class NonNullableFieldInitializationSuppressorTests
 				public void Test1() { }
 			}
 			""";
-		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true).WithOptions(DiagnosticOptions.IgnoreAdditionalLocations);
 
 		await Verify.VerifyCompilerWarningSuppressorV2(LanguageVersion.CSharp8, [code], expected);
 	}
@@ -157,7 +157,7 @@ public sealed class NonNullableFieldInitializationSuppressorTests
 				public void Test1() { }
 			}
 			""";
-		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true).WithOptions(DiagnosticOptions.IgnoreAdditionalLocations);
 
 		await Verify.VerifyCompilerWarningSuppressorV2(LanguageVersion.CSharp8, [code], expected);
 	}
@@ -186,7 +186,7 @@ public sealed class NonNullableFieldInitializationSuppressorTests
 				public void Test1() { }
 			}
 			""";
-		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true).WithOptions(DiagnosticOptions.IgnoreAdditionalLocations);
 
 		await Verify.VerifyCompilerWarningSuppressorV2(LanguageVersion.CSharp8, [code], expected);
 	}
@@ -242,7 +242,7 @@ public sealed class NonNullableFieldInitializationSuppressorTests
 				public void Test1() { }
 			}
 			""";
-		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true).WithOptions(DiagnosticOptions.IgnoreAdditionalLocations);
 
 		await Verify.VerifyCompilerWarningSuppressorV2(LanguageVersion.CSharp8, [code], expected);
 	}
@@ -287,7 +287,7 @@ public sealed class NonNullableFieldInitializationSuppressorTests
 				public void Test1() { }
 			}
 			""";
-		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true).WithOptions(DiagnosticOptions.IgnoreAdditionalLocations);
 
 		await Verify.VerifyCompilerWarningSuppressorV3(LanguageVersion.CSharp8, [code], expected);
 	}
@@ -315,7 +315,7 @@ public sealed class NonNullableFieldInitializationSuppressorTests
 				public void Test1() { }
 			}
 			""";
-		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true).WithOptions(DiagnosticOptions.IgnoreAdditionalLocations);
 
 		await Verify.VerifyCompilerWarningSuppressorV3(LanguageVersion.CSharp8, [code], expected);
 	}
@@ -368,7 +368,7 @@ public sealed class NonNullableFieldInitializationSuppressorTests
 				public void Test1() { }
 			}
 			""";
-		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true).WithOptions(DiagnosticOptions.IgnoreAdditionalLocations);
 
 		await Verify.VerifyCompilerWarningSuppressorV3(LanguageVersion.CSharp8, [code], expected);
 	}
@@ -422,7 +422,7 @@ public sealed class NonNullableFieldInitializationSuppressorTests
 				public void Test1() { }
 			}
 			""";
-		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true);
+		var expected = DiagnosticResult.CompilerWarning("CS8618").WithLocation(0).WithIsSuppressed(true).WithOptions(DiagnosticOptions.IgnoreAdditionalLocations);
 
 		await Verify.VerifyCompilerWarningSuppressorV3(LanguageVersion.CSharp8, [code], expected);
 	}

--- a/src/xunit.analyzers/Suppressors/NonNullableFieldInitializationSuppressor.cs
+++ b/src/xunit.analyzers/Suppressors/NonNullableFieldInitializationSuppressor.cs
@@ -1,0 +1,81 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit.Analyzers;
+
+namespace Xunit.Suppressors;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class NonNullableFieldInitializationSuppressor : XunitDiagnosticSuppressor
+{
+	public NonNullableFieldInitializationSuppressor() :
+		base(Descriptors.CS8618_Suppression)
+	{ }
+
+	protected override bool ShouldSuppress(
+		Diagnostic diagnostic,
+		SuppressionAnalysisContext context,
+		XunitContext xunitContext)
+	{
+		if (diagnostic.Location.SourceTree is null)
+			return false;
+
+		var asyncLifetimeType = TypeSymbolFactory.IAsyncLifetime(context.Compilation);
+		if (asyncLifetimeType is null)
+			return false;
+
+		var root = diagnostic.Location.SourceTree.GetRoot(context.CancellationToken);
+		var node = root?.FindNode(diagnostic.Location.SourceSpan);
+		if (node is null)
+			return false;
+
+		var semanticModel = context.GetSemanticModel(diagnostic.Location.SourceTree);
+
+		// CS8618 can target field variable declarators or property declarations
+		ISymbol? memberSymbol = node switch
+		{
+			VariableDeclaratorSyntax variableDeclarator => semanticModel.GetDeclaredSymbol(variableDeclarator),
+			PropertyDeclarationSyntax propertyDeclaration => semanticModel.GetDeclaredSymbol(propertyDeclaration),
+			_ => null,
+		};
+
+		if (memberSymbol is null)
+			return false;
+
+		var containingType = memberSymbol.ContainingType;
+		if (containingType is null)
+			return false;
+
+		if (!containingType.AllInterfaces.Contains(asyncLifetimeType, SymbolEqualityComparer.Default))
+			return false;
+
+		// Find the InitializeAsync method implementation
+		var initializeAsyncInterfaceMethod = asyncLifetimeType.GetMembers("InitializeAsync").FirstOrDefault();
+		if (initializeAsyncInterfaceMethod is null)
+			return false;
+
+		var initializeAsyncImpl = containingType.FindImplementationForInterfaceMember(initializeAsyncInterfaceMethod);
+		if (initializeAsyncImpl is null)
+			return false;
+
+		// Check if the member is assigned in InitializeAsync
+		foreach (var syntaxRef in initializeAsyncImpl.DeclaringSyntaxReferences)
+		{
+			var methodSyntax = syntaxRef.GetSyntax(context.CancellationToken);
+			if (methodSyntax is not MethodDeclarationSyntax methodDecl)
+				continue;
+
+			var methodSemanticModel = context.GetSemanticModel(methodSyntax.SyntaxTree);
+
+			foreach (var assignment in methodDecl.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+			{
+				var assignedSymbol = methodSemanticModel.GetSymbolInfo(assignment.Left).Symbol;
+				if (assignedSymbol is not null && SymbolEqualityComparer.Default.Equals(assignedSymbol, memberSymbol))
+					return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/src/xunit.analyzers/Utility/Descriptors.Suppressors.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.Suppressors.cs
@@ -10,6 +10,9 @@ public static partial class Descriptors
 	public static SuppressionDescriptor CA2007_Suppression { get; } =
 		Suppression("CA2007", "xUnit.net test methods should not call ConfigureAwait");
 
+	public static SuppressionDescriptor CS8618_Suppression { get; } =
+		Suppression("CS8618", "Non-nullable member is initialized in IAsyncLifetime.InitializeAsync");
+
 	public static SuppressionDescriptor VSTHRD200_Suppression { get; } =
 		Suppression("VSTHRD200", "xUnit.net test methods are not directly callable and do not benefit from this naming rule");
 }


### PR DESCRIPTION
## Summary

Adds a `DiagnosticSuppressor` that suppresses CS8618 ("Non-nullable field/property must contain a non-null value when exiting constructor") when the member is directly assigned in an `IAsyncLifetime.InitializeAsync` implementation. Fixes xunit/xunit#3423.

## Changes

- Added `NonNullableFieldInitializationSuppressor` — walks the `InitializeAsync` method body looking for direct assignments to the flagged member
- Added `CS8618_Suppression` descriptor to `Descriptors.Suppressors.cs`
- Added `VerifyCompilerWarningSuppressor` test helpers to `CSharpVerifier.Suppressors.cs` (sets `CompilerDiagnostics.Warnings` so CS8618 is included in analysis)
- Added 6 test cases covering: field/property suppression, non-IAsyncLifetime classes, uninitialized fields, `this.`-qualified access, and selective suppression with multiple fields

## Design

The suppressor:
1. Checks if the containing type implements `IAsyncLifetime`
2. Finds the `InitializeAsync` implementation via `FindImplementationForInterfaceMember`
3. Walks assignment expressions in the method body
4. Suppresses only if the specific flagged member is directly assigned

## Known Limitations

- Only detects **direct assignments** in `InitializeAsync` body — assignments through helper methods called from `InitializeAsync` are not detected (conservative approach)
- When a class has an explicit constructor, CS8618 may be reported on the constructor rather than the field/property (Roslyn behavior per dotnet/roslyn#58073). The suppressor handles the field/property location case, which covers the typical IAsyncLifetime pattern

## Testing

- 6 new tests, all passing
- Full test suite: 3203 tests, 0 failures