### PR TITLE
Improves handling of generic type constraints and CRTP (xunit/xunit#2986)

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/InlineDataMustMatchTheoryParametersTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/InlineDataMustMatchTheoryParametersTests.cs
@@ -988,6 +988,32 @@ public class InlineDataMustMatchTheoryParametersTests
 				await Verify.VerifyAnalyzer(source);
 			}
 
+#if ROSLYN_LATEST && NET8_0_OR_GREATER
+			[Fact]
+			public async Task TypeConstraint_WithCRTP() // CRTP: Curiously Recurring Template Pattern or T: Interface<T>
+			{
+				var source = /* lang=c#-test */ """
+				using Xunit;
+				using System.Numerics;
+
+				public class TestClass {
+					[Theory]
+					[InlineData(0U)]
+					[InlineData(2U)]
+					[InlineData(5294967295U)] // ulong value
+					[InlineData({|xUnit1010:-1U|})]
+					[InlineData({|xUnit1010:2|})]
+					[InlineData({|xUnit1010:0|})]
+					[InlineData({|xUnit1010:"A"|})]
+					public void UnsignedNumberIsAtLeastZero<T>(T number)
+						where T : IUnsignedNumber<T> => Assert.False(T.IsNegative(number));
+				}
+				""";
+
+				await Verify.VerifyAnalyzer(LanguageVersion.CSharp11, source);
+			}
+#endif
+
 			[Theory]
 #if NETFRAMEWORK
 			[InlineData("'a'")]


### PR DESCRIPTION
Partially fixes [this issue](https://github.com/xunit/xunit/issues/2986) by improving handling of generic type constraints, including CRTP. This only applies to InlineData, since MemberData is not presently checked for constraints. Includes a new unit test built around the initial issue.