### PR TITLE
Fix xUnit1015 when MemberData is declared on derived type

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
@@ -2,7 +2,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 using Verify = CSharpVerifier<Xunit.Analyzers.MemberDataShouldReferenceValidMember>;
-using Microsoft.CodeAnalysis.Testing;
+
 public class MemberDataShouldReferenceValidMemberTests
 {
 	public class X1014_MemberDataShouldUseNameOfOperator
@@ -75,30 +75,30 @@ public class MemberDataShouldReferenceValidMemberTests
 		}
 
 		[Fact]
-			public async ValueTask DoesNotTrigger_WhenMemberExistsOnDerivedType_AndBaseTypeIsAbstract()
-			{
-			    var source = /* lang=c#-test */ """
-			        using System.Collections.Generic;
-			        using Xunit;
-			
-			        public abstract class BaseClassWithTestWithoutData
-			        {
-			            [Theory]
-			            [MemberData(nameof(SubClassWithTestData.TestData))]
-			            public void Test(int x) { }
-			        }
-			
-			        public class SubClassWithTestData : BaseClassWithTestWithoutData
-			        {
-			            public static IEnumerable<object?[]> TestData()
-			            {
-			                yield return new object?[] { 42 };
-			            }
-			        }
-			        """;
-			
-			    await Verify.VerifyAnalyzer(source, Array.Empty<DiagnosticResult>());
-}
+		public async ValueTask DoesNotTrigger_WhenMemberExistsOnDerivedType_AndBaseTypeIsAbstract()
+		{
+			var source = /* lang=c#-test */ """
+				using System.Collections.Generic;
+				using Xunit;
+
+				public abstract class BaseClassWithTestWithoutData
+				{
+					[Theory]
+					[MemberData(nameof(SubClassWithTestData.TestData))]
+					public void Test(int x) { }
+				}
+
+				public class SubClassWithTestData : BaseClassWithTestWithoutData
+				{
+					public static IEnumerable<object?[]> TestData()
+					{
+						yield return new object?[] { 42 };
+					}
+				}
+				""";
+
+			await Verify.VerifyAnalyzer(LanguageVersion.CSharp8, source);
+		}
 	}
 
 	public class X1016_MemberDataMustReferencePublicMember

--- a/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/MemberDataShouldReferenceValidMemberTests.cs
@@ -2,7 +2,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 using Verify = CSharpVerifier<Xunit.Analyzers.MemberDataShouldReferenceValidMember>;
-
+using Microsoft.CodeAnalysis.Testing;
 public class MemberDataShouldReferenceValidMemberTests
 {
 	public class X1014_MemberDataShouldUseNameOfOperator
@@ -73,6 +73,32 @@ public class MemberDataShouldReferenceValidMemberTests
 
 			await Verify.VerifyAnalyzer([source1, source2], expected);
 		}
+
+		[Fact]
+			public async ValueTask DoesNotTrigger_WhenMemberExistsOnDerivedType_AndBaseTypeIsAbstract()
+			{
+			    var source = /* lang=c#-test */ """
+			        using System.Collections.Generic;
+			        using Xunit;
+			
+			        public abstract class BaseClassWithTestWithoutData
+			        {
+			            [Theory]
+			            [MemberData(nameof(SubClassWithTestData.TestData))]
+			            public void Test(int x) { }
+			        }
+			
+			        public class SubClassWithTestData : BaseClassWithTestWithoutData
+			        {
+			            public static IEnumerable<object?[]> TestData()
+			            {
+			                yield return new object?[] { 42 };
+			            }
+			        }
+			        """;
+			
+			    await Verify.VerifyAnalyzer(source, Array.Empty<DiagnosticResult>());
+}
 	}
 
 	public class X1016_MemberDataMustReferencePublicMember

--- a/src/xunit.analyzers/X1000/MemberDataShouldReferenceValidMember.cs
+++ b/src/xunit.analyzers/X1000/MemberDataShouldReferenceValidMember.cs
@@ -443,6 +443,80 @@ public class MemberDataShouldReferenceValidMember : XunitDiagnosticAnalyzer
 		return true;
 	}
 
+
+	static bool ShouldSuppressX1015BecauseAllDerivedConcreteTypesHaveMember(
+	SyntaxNodeAnalysisContext context,
+	ITypeSymbol declaredMemberTypeSymbol,
+	string memberName)
+{
+	if (declaredMemberTypeSymbol is not INamedTypeSymbol baseType)
+		return false;
+
+	// Only consider the special-case from the issue:
+	// - the declared type is an abstract class
+	if (baseType.TypeKind != TypeKind.Class || !baseType.IsAbstract)
+		return false;
+
+	var compilation = context.SemanticModel.Compilation;
+
+	static IEnumerable<INamedTypeSymbol> GetAllTypes(INamespaceSymbol @namespace)
+	{
+		foreach (var member in @namespace.GetMembers())
+		{
+			if (member is INamespaceSymbol childNs)
+			{
+				foreach (var t in GetAllTypes(childNs))
+					yield return t;
+			}
+			else if (member is INamedTypeSymbol namedType)
+			{
+				foreach (var t in GetAllTypes(namedType))
+					yield return t;
+			}
+		}
+	}
+
+	static IEnumerable<INamedTypeSymbol> GetAllTypes(INamedTypeSymbol type)
+	{
+		yield return type;
+
+		foreach (var nested in type.GetTypeMembers())
+			foreach (var t in GetAllTypes(nested))
+				yield return t;
+	}
+
+	static bool IsDerivedFrom(INamedTypeSymbol type, INamedTypeSymbol baseType)
+	{
+		for (var current = type.BaseType; current is not null; current = current.BaseType)
+			if (SymbolEqualityComparer.Default.Equals(current, baseType))
+				return true;
+
+		return false;
+	}
+
+	var derivedConcreteTypes = GetAllTypes(compilation.Assembly.GlobalNamespace)
+		.Where(t =>
+			t.TypeKind == TypeKind.Class &&
+			!t.IsAbstract &&
+			IsDerivedFrom(t, baseType))
+		.ToList();
+
+	// If we can't find any derived concrete types in this compilation,
+	// we can't prove it's safe - do not suppress.
+	if (derivedConcreteTypes.Count == 0)
+		return false;
+
+	// Suppress only if ALL derived concrete types contain the member.
+	foreach (var derived in derivedConcreteTypes)
+	{
+		if (derived.GetMembers(memberName).Length == 0)
+			return false;
+	}
+
+	return true;
+}
+	
+
 	static void ReportIllegalNonMethodArguments(
 		SyntaxNodeAnalysisContext context,
 		AttributeSyntax attribute,
@@ -620,7 +694,13 @@ public class MemberDataShouldReferenceValidMember : XunitDiagnosticAnalyzer
 		SyntaxNodeAnalysisContext context,
 		AttributeSyntax attribute,
 		string memberName,
-		ITypeSymbol declaredMemberTypeSymbol) =>
+		ITypeSymbol declaredMemberTypeSymbol)
+			{
+			// Special case: abstract base class references MemberData member that exists only on derived types.
+			// If ALL derived concrete types in this compilation contain the member, don't warn.
+			if (ShouldSuppressX1015BecauseAllDerivedConcreteTypesHaveMember(context, declaredMemberTypeSymbol, memberName))
+				return;
+		
 			context.ReportDiagnostic(
 				Diagnostic.Create(
 					Descriptors.X1015_MemberDataMustReferenceExistingMember,
@@ -629,6 +709,7 @@ public class MemberDataShouldReferenceValidMember : XunitDiagnosticAnalyzer
 					SymbolDisplay.ToDisplayString(declaredMemberTypeSymbol)
 				)
 			);
+		}
 
 	static void ReportNonPublicAccessibility(
 		SyntaxNodeAnalysisContext context,

--- a/src/xunit.analyzers/X1000/MemberDataShouldReferenceValidMember.cs
+++ b/src/xunit.analyzers/X1000/MemberDataShouldReferenceValidMember.cs
@@ -445,77 +445,67 @@ public class MemberDataShouldReferenceValidMember : XunitDiagnosticAnalyzer
 
 
 	static bool ShouldSuppressX1015BecauseAllDerivedConcreteTypesHaveMember(
-	SyntaxNodeAnalysisContext context,
-	ITypeSymbol declaredMemberTypeSymbol,
-	string memberName)
-{
-	if (declaredMemberTypeSymbol is not INamedTypeSymbol baseType)
-		return false;
-
-	// Only consider the special-case from the issue:
-	// - the declared type is an abstract class
-	if (baseType.TypeKind != TypeKind.Class || !baseType.IsAbstract)
-		return false;
-
-	var compilation = context.SemanticModel.Compilation;
-
-	static IEnumerable<INamedTypeSymbol> GetAllTypes(INamespaceSymbol @namespace)
+		SyntaxNodeAnalysisContext context,
+		ITypeSymbol declaredMemberTypeSymbol,
+		string memberName)
 	{
-		foreach (var member in @namespace.GetMembers())
-		{
-			if (member is INamespaceSymbol childNs)
-			{
-				foreach (var t in GetAllTypes(childNs))
-					yield return t;
-			}
-			else if (member is INamedTypeSymbol namedType)
-			{
-				foreach (var t in GetAllTypes(namedType))
-					yield return t;
-			}
-		}
-	}
-
-	static IEnumerable<INamedTypeSymbol> GetAllTypes(INamedTypeSymbol type)
-	{
-		yield return type;
-
-		foreach (var nested in type.GetTypeMembers())
-			foreach (var t in GetAllTypes(nested))
-				yield return t;
-	}
-
-	static bool IsDerivedFrom(INamedTypeSymbol type, INamedTypeSymbol baseType)
-	{
-		for (var current = type.BaseType; current is not null; current = current.BaseType)
-			if (SymbolEqualityComparer.Default.Equals(current, baseType))
-				return true;
-
-		return false;
-	}
-
-	var derivedConcreteTypes = GetAllTypes(compilation.Assembly.GlobalNamespace)
-		.Where(t =>
-			t.TypeKind == TypeKind.Class &&
-			!t.IsAbstract &&
-			IsDerivedFrom(t, baseType))
-		.ToList();
-
-	// If we can't find any derived concrete types in this compilation,
-	// we can't prove it's safe - do not suppress.
-	if (derivedConcreteTypes.Count == 0)
-		return false;
-
-	// Suppress only if ALL derived concrete types contain the member.
-	foreach (var derived in derivedConcreteTypes)
-	{
-		if (derived.GetMembers(memberName).Length == 0)
+		if (declaredMemberTypeSymbol is not INamedTypeSymbol baseType)
 			return false;
+
+		// Only consider the special-case from the issue:
+		// - the declared type is an abstract class
+		if (baseType.TypeKind != TypeKind.Class || !baseType.IsAbstract)
+			return false;
+
+		var compilation = context.SemanticModel.Compilation;
+
+		static IEnumerable<INamedTypeSymbol> GetAllTypesFromNamespace(INamespaceSymbol @namespace)
+		{
+			foreach (var member in @namespace.GetMembers())
+				if (member is INamespaceSymbol childNs)
+					foreach (var t in GetAllTypesFromNamespace(childNs))
+						yield return t;
+				else if (member is INamedTypeSymbol namedType)
+					foreach (var t in GetAllTypesFromType(namedType))
+						yield return t;
+		}
+
+		static IEnumerable<INamedTypeSymbol> GetAllTypesFromType(INamedTypeSymbol type)
+		{
+			yield return type;
+
+			foreach (var nested in type.GetTypeMembers())
+				foreach (var t in GetAllTypesFromType(nested))
+					yield return t;
+		}
+
+		static bool IsDerivedFrom(INamedTypeSymbol type, INamedTypeSymbol baseType)
+		{
+			for (var current = type.BaseType; current is not null; current = current.BaseType)
+				if (SymbolEqualityComparer.Default.Equals(current, baseType))
+					return true;
+
+			return false;
+		}
+
+		var derivedConcreteTypes =
+			GetAllTypesFromNamespace(compilation.Assembly.GlobalNamespace)
+				.Where(t => t.TypeKind == TypeKind.Class && !t.IsAbstract && IsDerivedFrom(t, baseType))
+				.ToList();
+
+		// If we can't find any derived concrete types in this compilation,
+		// we can't prove it's safe - do not suppress.
+		if (derivedConcreteTypes.Count == 0)
+			return false;
+
+		// Suppress only if ALL derived concrete types contain the member.
+		foreach (var derived in derivedConcreteTypes)
+			if (derived.GetMembers(memberName).Length == 0)
+				return false;
+
+		return true;
 	}
 
-	return true;
-}
-	
 
 	static void ReportIllegalNonMethodArguments(
 		SyntaxNodeAnalysisContext context,
@@ -695,21 +685,21 @@ public class MemberDataShouldReferenceValidMember : XunitDiagnosticAnalyzer
 		AttributeSyntax attribute,
 		string memberName,
 		ITypeSymbol declaredMemberTypeSymbol)
-			{
-			// Special case: abstract base class references MemberData member that exists only on derived types.
-			// If ALL derived concrete types in this compilation contain the member, don't warn.
-			if (ShouldSuppressX1015BecauseAllDerivedConcreteTypesHaveMember(context, declaredMemberTypeSymbol, memberName))
-				return;
-		
-			context.ReportDiagnostic(
-				Diagnostic.Create(
-					Descriptors.X1015_MemberDataMustReferenceExistingMember,
-					attribute.GetLocation(),
-					memberName,
-					SymbolDisplay.ToDisplayString(declaredMemberTypeSymbol)
-				)
-			);
-		}
+	{
+		// Special case: abstract base class references MemberData member that exists only on derived types.
+		// If ALL derived concrete types in this compilation contain the member, don't warn.
+		if (ShouldSuppressX1015BecauseAllDerivedConcreteTypesHaveMember(context, declaredMemberTypeSymbol, memberName))
+			return;
+
+		context.ReportDiagnostic(
+			Diagnostic.Create(
+				Descriptors.X1015_MemberDataMustReferenceExistingMember,
+				attribute.GetLocation(),
+				memberName,
+				SymbolDisplay.ToDisplayString(declaredMemberTypeSymbol)
+			)
+		);
+	}
 
 	static void ReportNonPublicAccessibility(
 		SyntaxNodeAnalysisContext context,

--- a/src/xunit.analyzers/X1000/MemberDataShouldReferenceValidMember.cs
+++ b/src/xunit.analyzers/X1000/MemberDataShouldReferenceValidMember.cs
@@ -443,7 +443,6 @@ public class MemberDataShouldReferenceValidMember : XunitDiagnosticAnalyzer
 		return true;
 	}
 
-
 	static bool ShouldSuppressX1015BecauseAllDerivedConcreteTypesHaveMember(
 		SyntaxNodeAnalysisContext context,
 		ITypeSymbol declaredMemberTypeSymbol,
@@ -505,7 +504,6 @@ public class MemberDataShouldReferenceValidMember : XunitDiagnosticAnalyzer
 
 		return true;
 	}
-
 
 	static void ReportIllegalNonMethodArguments(
 		SyntaxNodeAnalysisContext context,


### PR DESCRIPTION
Fixes xunit/xunit#3501

- Suppress xUnit1015 when the test is declared on an abstract base class and the referenced MemberData member exists on all derived concrete classes in the compilation.
- Added regression test covering the abstract-base + derived MemberData scenario.