### PR TITLE
Exclude params parameters from X1041 diagnostic in test constructors

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/EnsureFixturesHaveASourceTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/EnsureFixturesHaveASourceTests.cs
@@ -75,6 +75,22 @@ public class EnsureFixturesHaveASourceTests
 
 			await Verify.VerifyAnalyzer(source);
 		}
+
+		[Fact]
+		public async Task ParamsParameter_DoesNotTrigger()
+		{
+			var source = /* lang=c#-test */ """
+				using Xunit;
+
+				public class TestClass {
+					public TestClass(params object[] _) { }
+						
+					[Fact] public void TestMethod() { }
+				}
+				""";
+
+			await Verify.VerifyAnalyzer(source);
+		}
 	}
 
 	public class ClassFixtures

--- a/src/xunit.analyzers/X1000/EnsureFixturesHaveASource.cs
+++ b/src/xunit.analyzers/X1000/EnsureFixturesHaveASource.cs
@@ -130,6 +130,7 @@ public class EnsureFixturesHaveASource : XunitDiagnosticAnalyzer
 				);
 
 			foreach (var parameter in ctors[0].Parameters.Where(p => !p.IsOptional
+					&& !p.IsParams
 					&& !validConstructorArgumentTypes.Contains(p.Type)
 					&& (xunitContext.HasV2References || p.Type is not INamedTypeSymbol nts || !nts.IsGenericType || !validConstructorArgumentTypes.Contains(nts.ConstructedFrom))))
 				context.ReportDiagnostic(


### PR DESCRIPTION
Fixes xunit/xunit#3499