### PR TITLE
Add analyzer to flag non-serializable test case implementations (xUnit3006/xUnit3007)

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X3000/X3006_TestCaseMustBeSerializableTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X3000/X3006_TestCaseMustBeSerializableTests.cs
@@ -4,7 +4,9 @@ using Verify = CSharpVerifier<Xunit.Analyzers.TestCaseMustBeSerializable>;
 
 public class X3006_TestCaseMustBeSerializableTests
 {
-	static string CS0535(string interfaceName, int memberCount)
+	static string CS0535(
+		string interfaceName,
+		int memberCount)
 	{
 		var result = interfaceName;
 
@@ -15,81 +17,26 @@ public class X3006_TestCaseMustBeSerializableTests
 	}
 
 	[Fact]
-	public async ValueTask ClassNotImplementingITestCase_DoesNotTrigger()
+	public async ValueTask V3_only_NonAOT()
 	{
-		var source = /* lang=c#-test */ """
-			public class NotATestCase { }
-			""";
-
-		await Verify.VerifyAnalyzerV2(source);
-		await Verify.VerifyAnalyzerV3(source);
-	}
-
-	[Fact]
-	public async ValueTask V2_TestCaseAlwaysSerializable_DoesNotTrigger()
-	{
-		var source = /* lang=c#-test */ $$"""
-			using Xunit.Abstractions;
-
-			public abstract class MyAbstractTestCase : {{CS0535("ITestCase", 9)}} { }
-
-			public class MyTestCase : {{CS0535("ITestCase", 9)}} { }
-
-			public sealed class MySealedTestCase : {{CS0535("ITestCase", 9)}} { }
-			""";
-
-		await Verify.VerifyAnalyzerV2(source);
-	}
-
-	[Fact]
-	public async ValueTask V3_AbstractClassImplementingITestCase_DoesNotTrigger()
-	{
-		var source = /* lang=c#-test */ $$"""
+		var source = $$"""
 			using Xunit.Sdk;
 
-			public abstract class MyAbstractTestCase : {{CS0535("ITestCase", 19)}} { }
+			[assembly: RegisterXunitSerializer(typeof(MySerializer), typeof(ExternalSerializedTestCase))]
+
+			public class NonTestCase { }
+
+			public abstract class AbstractTestCase : {{CS0535("ITestCase", 19)}} { }
+
+			public sealed class SelfSerializedTestCase : {{CS0535("ITestCase", 19)}}, {{CS0535("IXunitSerializable", 2)}} { }
+
+			public sealed class ExternalSerializedTestCase : {{CS0535("ITestCase", 19)}} { }
+
+			public sealed class {|xUnit3006:UnserializedTestCase|} : {{CS0535("ITestCase", 19)}} { }
+
+			public class MySerializer : {{CS0535("IXunitSerializer", 3)}} { }
 			""";
 
 		await Verify.VerifyAnalyzerV3NonAot(source);
-	}
-
-	[Fact]
-	public async ValueTask V3_TestCaseWithIXunitSerializable_DoesNotTrigger()
-	{
-		var source = /* lang=c#-test */ $$"""
-			using Xunit.Sdk;
-
-			public sealed class MyTestCase : {{CS0535("ITestCase", 19)}}, {{CS0535("IXunitSerializable", 2)}} { }
-			""";
-
-		await Verify.VerifyAnalyzerV3NonAot(source);
-	}
-
-	[Fact]
-	public async ValueTask V3_TestCaseWithJsonTypeID_DoesNotTrigger()
-	{
-		var source = /* lang=c#-test */ $$"""
-			using Xunit.Sdk;
-
-			[JsonTypeID("my-test-case")]
-			public sealed class MyTestCase : {{CS0535("ITestCase", 19)}} { }
-			""";
-
-		await Verify.VerifyAnalyzerV3NonAot(source);
-	}
-
-	[Fact]
-	public async ValueTask V3_SealedTestCaseNotSerializable_Triggers()
-	{
-		var source = /* lang=c#-test */ $$"""
-			using Xunit.Sdk;
-
-			public sealed class {|#0:MyTestCase|} : {{CS0535("ITestCase", 19)}} { }
-			""";
-		var expected = Verify.Diagnostic("xUnit3006")
-			.WithLocation(0)
-			.WithArguments("MyTestCase", "Xunit.Sdk.ITestCase", "Xunit.Sdk.IXunitSerializable");
-
-		await Verify.VerifyAnalyzerV3NonAot(source, expected);
 	}
 }

--- a/src/xunit.analyzers.tests/Analyzers/X3000/X3006_TestCaseMustBeSerializableTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X3000/X3006_TestCaseMustBeSerializableTests.cs
@@ -1,0 +1,95 @@
+using System.Threading.Tasks;
+using Xunit;
+using Verify = CSharpVerifier<Xunit.Analyzers.TestCaseMustBeSerializable>;
+
+public class X3006_TestCaseMustBeSerializableTests
+{
+	static string CS0535(string interfaceName, int memberCount)
+	{
+		var result = interfaceName;
+
+		while (memberCount-- > 0)
+			result = $"{{|CS0535:{result}|}}";
+
+		return result;
+	}
+
+	[Fact]
+	public async ValueTask ClassNotImplementingITestCase_DoesNotTrigger()
+	{
+		var source = /* lang=c#-test */ """
+			public class NotATestCase { }
+			""";
+
+		await Verify.VerifyAnalyzerV2(source);
+		await Verify.VerifyAnalyzerV3(source);
+	}
+
+	[Fact]
+	public async ValueTask V2_TestCaseAlwaysSerializable_DoesNotTrigger()
+	{
+		var source = /* lang=c#-test */ $$"""
+			using Xunit.Abstractions;
+
+			public abstract class MyAbstractTestCase : {{CS0535("ITestCase", 9)}} { }
+
+			public class MyTestCase : {{CS0535("ITestCase", 9)}} { }
+
+			public sealed class MySealedTestCase : {{CS0535("ITestCase", 9)}} { }
+			""";
+
+		await Verify.VerifyAnalyzerV2(source);
+	}
+
+	[Fact]
+	public async ValueTask V3_AbstractClassImplementingITestCase_DoesNotTrigger()
+	{
+		var source = /* lang=c#-test */ $$"""
+			using Xunit.Sdk;
+
+			public abstract class MyAbstractTestCase : {{CS0535("ITestCase", 19)}} { }
+			""";
+
+		await Verify.VerifyAnalyzerV3NonAot(source);
+	}
+
+	[Fact]
+	public async ValueTask V3_TestCaseWithIXunitSerializable_DoesNotTrigger()
+	{
+		var source = /* lang=c#-test */ $$"""
+			using Xunit.Sdk;
+
+			public sealed class MyTestCase : {{CS0535("ITestCase", 19)}}, {{CS0535("IXunitSerializable", 2)}} { }
+			""";
+
+		await Verify.VerifyAnalyzerV3NonAot(source);
+	}
+
+	[Fact]
+	public async ValueTask V3_TestCaseWithJsonTypeID_DoesNotTrigger()
+	{
+		var source = /* lang=c#-test */ $$"""
+			using Xunit.Sdk;
+
+			[JsonTypeID("my-test-case")]
+			public sealed class MyTestCase : {{CS0535("ITestCase", 19)}} { }
+			""";
+
+		await Verify.VerifyAnalyzerV3NonAot(source);
+	}
+
+	[Fact]
+	public async ValueTask V3_SealedTestCaseNotSerializable_Triggers()
+	{
+		var source = /* lang=c#-test */ $$"""
+			using Xunit.Sdk;
+
+			public sealed class {|#0:MyTestCase|} : {{CS0535("ITestCase", 19)}} { }
+			""";
+		var expected = Verify.Diagnostic("xUnit3006")
+			.WithLocation(0)
+			.WithArguments("MyTestCase", "Xunit.Sdk.ITestCase", "Xunit.Sdk.IXunitSerializable");
+
+		await Verify.VerifyAnalyzerV3NonAot(source, expected);
+	}
+}

--- a/src/xunit.analyzers.tests/Analyzers/X3000/X3007_TestCaseMustBeSerializableTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X3000/X3007_TestCaseMustBeSerializableTests.cs
@@ -1,0 +1,56 @@
+using System.Threading.Tasks;
+using Xunit;
+using Verify = CSharpVerifier<Xunit.Analyzers.TestCaseMustBeSerializable>;
+
+public class X3007_TestCaseMustBeSerializableTests
+{
+	static string CS0535(string interfaceName, int memberCount)
+	{
+		var result = interfaceName;
+
+		while (memberCount-- > 0)
+			result = $"{{|CS0535:{result}|}}";
+
+		return result;
+	}
+
+	[Fact]
+	public async ValueTask V3_UnsealedTestCaseNotSerializable_Triggers()
+	{
+		var source = /* lang=c#-test */ $$"""
+			using Xunit.Sdk;
+
+			public class {|#0:MyTestCase|} : {{CS0535("ITestCase", 19)}} { }
+			""";
+		var expected = Verify.Diagnostic("xUnit3007")
+			.WithLocation(0)
+			.WithArguments("MyTestCase", "Xunit.Sdk.ITestCase", "Xunit.Sdk.IXunitSerializable");
+
+		await Verify.VerifyAnalyzerV3NonAot(source, expected);
+	}
+
+	[Fact]
+	public async ValueTask V3_UnsealedTestCaseWithIXunitSerializable_DoesNotTrigger()
+	{
+		var source = /* lang=c#-test */ $$"""
+			using Xunit.Sdk;
+
+			public class MyTestCase : {{CS0535("ITestCase", 19)}}, {{CS0535("IXunitSerializable", 2)}} { }
+			""";
+
+		await Verify.VerifyAnalyzerV3NonAot(source);
+	}
+
+	[Fact]
+	public async ValueTask V3_UnsealedTestCaseWithJsonTypeID_DoesNotTrigger()
+	{
+		var source = /* lang=c#-test */ $$"""
+			using Xunit.Sdk;
+
+			[JsonTypeID("my-test-case")]
+			public class MyTestCase : {{CS0535("ITestCase", 19)}} { }
+			""";
+
+		await Verify.VerifyAnalyzerV3NonAot(source);
+	}
+}

--- a/src/xunit.analyzers.tests/Analyzers/X3000/X3007_TestCaseMustBeSerializableTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X3000/X3007_TestCaseMustBeSerializableTests.cs
@@ -4,7 +4,9 @@ using Verify = CSharpVerifier<Xunit.Analyzers.TestCaseMustBeSerializable>;
 
 public class X3007_TestCaseMustBeSerializableTests
 {
-	static string CS0535(string interfaceName, int memberCount)
+	static string CS0535(
+		string interfaceName,
+		int memberCount)
 	{
 		var result = interfaceName;
 
@@ -15,40 +17,26 @@ public class X3007_TestCaseMustBeSerializableTests
 	}
 
 	[Fact]
-	public async ValueTask V3_UnsealedTestCaseNotSerializable_Triggers()
+	public async ValueTask V3_only_NonAOT()
 	{
-		var source = /* lang=c#-test */ $$"""
+		var source = $$"""
 			using Xunit.Sdk;
 
-			public class {|#0:MyTestCase|} : {{CS0535("ITestCase", 19)}} { }
-			""";
-		var expected = Verify.Diagnostic("xUnit3007")
-			.WithLocation(0)
-			.WithArguments("MyTestCase", "Xunit.Sdk.ITestCase", "Xunit.Sdk.IXunitSerializable");
+			[assembly: RegisterXunitSerializer(typeof(MySerializer), typeof(ExternalSerializedTestCase))]
 
-		await Verify.VerifyAnalyzerV3NonAot(source, expected);
-	}
+			public class NonTestCase { }
 
-	[Fact]
-	public async ValueTask V3_UnsealedTestCaseWithIXunitSerializable_DoesNotTrigger()
-	{
-		var source = /* lang=c#-test */ $$"""
-			using Xunit.Sdk;
+			public abstract class AbstractTestCase : {{CS0535("ITestCase", 19)}} { }
 
-			public class MyTestCase : {{CS0535("ITestCase", 19)}}, {{CS0535("IXunitSerializable", 2)}} { }
-			""";
+			public class SelfSerializedTestCase : {{CS0535("ITestCase", 19)}}, {{CS0535("IXunitSerializable", 2)}} { }
 
-		await Verify.VerifyAnalyzerV3NonAot(source);
-	}
+			public class ExternalSerializedTestCase : {{CS0535("ITestCase", 19)}} { }
 
-	[Fact]
-	public async ValueTask V3_UnsealedTestCaseWithJsonTypeID_DoesNotTrigger()
-	{
-		var source = /* lang=c#-test */ $$"""
-			using Xunit.Sdk;
+			public class DerivedTestCase : ExternalSerializedTestCase { }
 
-			[JsonTypeID("my-test-case")]
-			public class MyTestCase : {{CS0535("ITestCase", 19)}} { }
+			public class {|xUnit3007:UnserializedTestCase|} : {{CS0535("ITestCase", 19)}} { }
+
+			public class MySerializer : {{CS0535("IXunitSerializer", 3)}} { }
 			""";
 
 		await Verify.VerifyAnalyzerV3NonAot(source);

--- a/src/xunit.analyzers/Utility/Descriptors.xUnit3xxx.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.xUnit3xxx.cs
@@ -60,22 +60,22 @@ public static partial class Descriptors
 			"Type '{0}' must have a non-obsolete public constructor: public {0}({1})"
 		);
 
-	public static DiagnosticDescriptor X3006_TestCaseImplementationsMustBeSerializable { get; } =
+	public static DiagnosticDescriptor X3006_TestCaseImplementationMustBeSerializable { get; } =
 		Diagnostic(
 			"xUnit3006",
-			"Test case implementations must be serializable",
+			"Test case implementation must be serializable",
 			Extensibility,
-			Warning,
-			"Class '{0}' implements '{1}' but is not serializable. Test cases must be serializable to support test discovery and execution. Implement '{2}', decorate with '[JsonTypeID]', or register an external IXunitSerializer."
+			Error,
+			"Class '{0}' implements '{1}' but is not serializable. Test cases must be serializable to support test discovery and execution. Implement '{2}' or register an external IXunitSerializer."
 		);
 
-	public static DiagnosticDescriptor X3007_TestCaseImplementationsMightNotBeSerializable { get; } =
+	public static DiagnosticDescriptor X3007_TestCaseImplementationMightNotBeSerializable { get; } =
 		Diagnostic(
 			"xUnit3007",
-			"Test case implementations might not be serializable",
+			"Test case implementation might not be serializable",
 			Extensibility,
 			Warning,
-			"Class '{0}' implements '{1}' but might not be serializable. Test cases must be serializable to support test discovery and execution. Consider implementing '{2}', decorating with '[JsonTypeID]', or registering an external IXunitSerializer."
+			"Class '{0}' implements '{1}' but might not be serializable. Test cases must be serializable to support test discovery and execution. Consider implementing '{2}' or registering an external IXunitSerializer."
 		);
 
 	// Placeholder for rule X3008

--- a/src/xunit.analyzers/Utility/Descriptors.xUnit3xxx.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.xUnit3xxx.cs
@@ -60,9 +60,23 @@ public static partial class Descriptors
 			"Type '{0}' must have a non-obsolete public constructor: public {0}({1})"
 		);
 
-	// Placeholder for rule X3006
+	public static DiagnosticDescriptor X3006_TestCaseImplementationsMustBeSerializable { get; } =
+		Diagnostic(
+			"xUnit3006",
+			"Test case implementations must be serializable",
+			Extensibility,
+			Warning,
+			"Class '{0}' implements '{1}' but is not serializable. Test cases must be serializable to support test discovery and execution. Implement '{2}', decorate with '[JsonTypeID]', or register an external IXunitSerializer."
+		);
 
-	// Placeholder for rule X3007
+	public static DiagnosticDescriptor X3007_TestCaseImplementationsMightNotBeSerializable { get; } =
+		Diagnostic(
+			"xUnit3007",
+			"Test case implementations might not be serializable",
+			Extensibility,
+			Warning,
+			"Class '{0}' implements '{1}' but might not be serializable. Test cases must be serializable to support test discovery and execution. Consider implementing '{2}', decorating with '[JsonTypeID]', or registering an external IXunitSerializer."
+		);
 
 	// Placeholder for rule X3008
 

--- a/src/xunit.analyzers/Utility/SerializabilityAnalyzer.cs
+++ b/src/xunit.analyzers/Utility/SerializabilityAnalyzer.cs
@@ -16,7 +16,7 @@ public sealed class SerializabilityAnalyzer(SerializableTypeSymbols typeSymbols)
 	/// The logic in this method corresponds to the logic in SerializationHelper.IsSerializable
 	/// and SerializationHelper.Serialize.
 	/// </remarks>
-	public Serializability AnalayzeSerializability(
+	public Serializability AnalyzeSerializability(
 		ITypeSymbol type,
 		XunitContext xunitContext)
 	{
@@ -28,7 +28,7 @@ public sealed class SerializabilityAnalyzer(SerializableTypeSymbols typeSymbols)
 			return Serializability.NeverSerializable;
 
 		if (type.TypeKind == TypeKind.Array && type is IArrayTypeSymbol arrayType)
-			return AnalayzeSerializability(arrayType.ElementType, xunitContext);
+			return AnalyzeSerializability(arrayType.ElementType, xunitContext);
 
 		if (typeSymbols.Type.IsAssignableFrom(type))
 			return Serializability.AlwaysSerializable;

--- a/src/xunit.analyzers/X1000/TheoryDataRowArgumentsShouldBeSerializable.cs
+++ b/src/xunit.analyzers/X1000/TheoryDataRowArgumentsShouldBeSerializable.cs
@@ -56,7 +56,7 @@ public class TheoryDataRowArgumentsShouldBeSerializable : XunitDiagnosticAnalyze
 				if (analyzer.TypeShouldBeIgnored(argumentOperation.Type))
 					continue;
 
-				var serializability = analyzer.AnalayzeSerializability(argumentOperation.Type, xunitContext);
+				var serializability = analyzer.AnalyzeSerializability(argumentOperation.Type, xunitContext);
 
 				if (serializability != Serializability.AlwaysSerializable)
 				{

--- a/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
+++ b/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
@@ -68,7 +68,7 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 					if (analyzer.TypeShouldBeIgnored(type))
 						continue;
 
-					var serializability = analyzer.AnalayzeSerializability(type, xunitContext);
+					var serializability = analyzer.AnalyzeSerializability(type, xunitContext);
 
 					if (serializability != Serializability.AlwaysSerializable)
 						context.ReportDiagnostic(

--- a/src/xunit.analyzers/X3000/TestCaseMustBeSerializable.cs
+++ b/src/xunit.analyzers/X3000/TestCaseMustBeSerializable.cs
@@ -5,21 +5,20 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Xunit.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class TestCaseMustBeSerializable : XunitDiagnosticAnalyzer
+public class TestCaseMustBeSerializable() :
+	XunitV3DiagnosticAnalyzer(
+		Descriptors.X3006_TestCaseImplementationMustBeSerializable,
+		Descriptors.X3007_TestCaseImplementationMightNotBeSerializable)
 {
-	public TestCaseMustBeSerializable() :
-		base(
-			Descriptors.X3006_TestCaseImplementationsMustBeSerializable,
-			Descriptors.X3007_TestCaseImplementationsMightNotBeSerializable
-		)
-	{ }
-
 	public override void AnalyzeCompilation(
 		CompilationStartAnalysisContext context,
 		XunitContext xunitContext)
 	{
 		Guard.ArgumentNotNull(context);
 		Guard.ArgumentNotNull(xunitContext);
+
+		if (SerializableTypeSymbols.Create(context.Compilation, xunitContext) is not SerializableTypeSymbols typeSymbols)
+			return;
 
 		var iTestCaseType = xunitContext.Common.ITestCaseType;
 		if (iTestCaseType is null)
@@ -33,34 +32,20 @@ public class TestCaseMustBeSerializable : XunitDiagnosticAnalyzer
 				return;
 			if (namedType.IsAbstract)
 				return;
-
 			if (!iTestCaseType.IsAssignableFrom(namedType))
 				return;
-
-			// Types that implement IXunitSerializable
-			if (xunitContext.Common.IXunitSerializableType?.IsAssignableFrom(namedType) == true)
+			if (typeSymbols.IXunitSerializable.IsAssignableFrom(namedType) || typeSymbols.TypesWithCustomSerializers.Any(t => t.IsAssignableFrom(namedType)))
 				return;
-
-			// Types that decorate with [JsonTypeID]
-			if (xunitContext.V3Core?.JsonTypeIDAttributeType is INamedTypeSymbol jsonTypeIDAttributeType)
-				if (namedType.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, jsonTypeIDAttributeType)))
-					return;
-
-			var iXunitSerializableDisplay =
-				xunitContext.Common.IXunitSerializableType?.ToDisplayString()
-				?? "IXunitSerializable";
-
-			var isDefinitelyNotSerializable = namedType.IsSealed;
 
 			context.ReportDiagnostic(
 				Diagnostic.Create(
-					isDefinitelyNotSerializable
-						? Descriptors.X3006_TestCaseImplementationsMustBeSerializable
-						: Descriptors.X3007_TestCaseImplementationsMightNotBeSerializable,
+					namedType.IsSealed
+						? Descriptors.X3006_TestCaseImplementationMustBeSerializable
+						: Descriptors.X3007_TestCaseImplementationMightNotBeSerializable,
 					namedType.Locations.First(),
 					namedType.Name,
 					iTestCaseType.ToDisplayString(),
-					iXunitSerializableDisplay
+					xunitContext.Common.IXunitSerializableType?.ToDisplayString() ?? "IXunitSerializable"
 				)
 			);
 		}, SymbolKind.NamedType);

--- a/src/xunit.analyzers/X3000/TestCaseMustBeSerializable.cs
+++ b/src/xunit.analyzers/X3000/TestCaseMustBeSerializable.cs
@@ -1,0 +1,68 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Xunit.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class TestCaseMustBeSerializable : XunitDiagnosticAnalyzer
+{
+	public TestCaseMustBeSerializable() :
+		base(
+			Descriptors.X3006_TestCaseImplementationsMustBeSerializable,
+			Descriptors.X3007_TestCaseImplementationsMightNotBeSerializable
+		)
+	{ }
+
+	public override void AnalyzeCompilation(
+		CompilationStartAnalysisContext context,
+		XunitContext xunitContext)
+	{
+		Guard.ArgumentNotNull(context);
+		Guard.ArgumentNotNull(xunitContext);
+
+		var iTestCaseType = xunitContext.Common.ITestCaseType;
+		if (iTestCaseType is null)
+			return;
+
+		context.RegisterSymbolAction(context =>
+		{
+			if (context.Symbol is not INamedTypeSymbol namedType)
+				return;
+			if (namedType.TypeKind != TypeKind.Class)
+				return;
+			if (namedType.IsAbstract)
+				return;
+
+			if (!iTestCaseType.IsAssignableFrom(namedType))
+				return;
+
+			// Types that implement IXunitSerializable
+			if (xunitContext.Common.IXunitSerializableType?.IsAssignableFrom(namedType) == true)
+				return;
+
+			// Types that decorate with [JsonTypeID]
+			if (xunitContext.V3Core?.JsonTypeIDAttributeType is INamedTypeSymbol jsonTypeIDAttributeType)
+				if (namedType.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, jsonTypeIDAttributeType)))
+					return;
+
+			var iXunitSerializableDisplay =
+				xunitContext.Common.IXunitSerializableType?.ToDisplayString()
+				?? "IXunitSerializable";
+
+			var isDefinitelyNotSerializable = namedType.IsSealed;
+
+			context.ReportDiagnostic(
+				Diagnostic.Create(
+					isDefinitelyNotSerializable
+						? Descriptors.X3006_TestCaseImplementationsMustBeSerializable
+						: Descriptors.X3007_TestCaseImplementationsMightNotBeSerializable,
+					namedType.Locations.First(),
+					namedType.Name,
+					iTestCaseType.ToDisplayString(),
+					iXunitSerializableDisplay
+				)
+			);
+		}, SymbolKind.NamedType);
+	}
+}


### PR DESCRIPTION
# Add analyzer to flag non-serializable test case implementations (xUnit3006/xUnit3007)

Closes xunit/xunit#3535

## Summary

Adds a new diagnostic analyzer `TestCaseMustBeSerializable` that flags `ITestCase` implementations which are not serializable. Test cases must be serializable to support test discovery and execution.

Also fixes a pre-existing typo: `AnalayzeSerializability` → `AnalyzeSerializability`.

## New Diagnostics

| Rule | Severity | Title | When |
|------|----------|-------|------|
| **xUnit3006** | Warning | Test case implementations must be serializable | Sealed class implements `ITestCase` but does not implement `IXunitSerializable` or `[JsonTypeID]` |
| **xUnit3007** | Warning | Test case implementations might not be serializable | Unsealed class implements `ITestCase` but does not implement `IXunitSerializable` or `[JsonTypeID]` |

The distinction between X3006 and X3007 exists because unsealed classes might be handled by an external `IXunitSerializer` registration or a serializable subclass, which cannot be determined at compile time.

## Behavior

- **v2**: `ITestCase` inherits from `IXunitSerializable`, so all implementors are inherently serializable. The analyzer correctly does not trigger for v2 projects.
- **v3 (non-AOT)**: `ITestCase` does **not** inherit from `IXunitSerializable`. The analyzer triggers when a concrete class implements `ITestCase` without:
  - Implementing `IXunitSerializable`, or
  - Being decorated with `[JsonTypeID]`
