### PR TITLE
Fix StackOverflowException in analyzer tests by bypassing Roslyn SDK WeightedMatch Issue

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X3000/X3000_CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X3000/X3000_CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectTests.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using Xunit.Analyzers;
 using Verify_WithAbstractions = CSharpVerifier<X3000_CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectTests.AbstractionsAnalyzer>;
@@ -20,33 +21,33 @@ public class X3000_CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectTests
 			class NoInterfaces_DoesNotTrigger { }
 
 			// Discovery and execution messages
-			class [|IMessageSink_Triggers|] : {{MemberCount("IMessageSink", 1)}} { }
-			class [|IMessageSinkMessage_Triggers|] : {{MemberCount("IMessageSinkMessage", 0)}} { }
+			class [|IMessageSink_Triggers|] : IMessageSink { }
+			class [|IMessageSinkMessage_Triggers|] : IMessageSinkMessage { }
 
 			// Reflection
-			class [|IAssemblyInfo_Triggers|] : {{MemberCount("IAssemblyInfo", 5)}} { }
-			class [|IAttributeInfo_Triggers|] : {{MemberCount("IAttributeInfo", 3)}} { }
-			class [|IMethodInfo_Triggers|] : {{MemberCount("IMethodInfo", 11)}} { }
-			class [|IParameterInfo_Triggers|] : {{MemberCount("IParameterInfo", 2)}} { }
-			class [|ITypeInfo_Triggers|] : {{MemberCount("ITypeInfo", 13)}} { }
+			class [|IAssemblyInfo_Triggers|] : IAssemblyInfo { }
+			class [|IAttributeInfo_Triggers|] : IAttributeInfo { }
+			class [|IMethodInfo_Triggers|] : IMethodInfo { }
+			class [|IParameterInfo_Triggers|] : IParameterInfo { }
+			class [|ITypeInfo_Triggers|] : ITypeInfo { }
 
 			// Object model
-			class [|ITest_Triggers|] : {{MemberCount("ITest", 2)}} { }
-			class [|ITestAssembly_Triggers|] : {{MemberCount("ITestAssembly", 4)}} { }
-			class [|ITestCase_Triggers|] : {{MemberCount("ITestCase", 9)}} { }
-			class [|ITestClass_Triggers|] : {{MemberCount("ITestClass", 4)}} { }
-			class [|ITestCollection_Triggers|] : {{MemberCount("ITestCollection", 6)}} { }
-			class [|ITestMethod_Triggers|] : {{MemberCount("ITestMethod", 4)}} { }
+			class [|ITest_Triggers|] : ITest { }
+			class [|ITestAssembly_Triggers|] : ITestAssembly { }
+			class [|ITestCase_Triggers|] : ITestCase { }
+			class [|ITestClass_Triggers|] : ITestClass { }
+			class [|ITestCollection_Triggers|] : ITestCollection { }
+			class [|ITestMethod_Triggers|] : ITestMethod { }
 
 			// Test framework
-			class [|ISourceInformation_Triggers|] : {{MemberCount("ISourceInformation", 4)}} { }
-			class [|ISourceInformationProvider_Triggers|] : {{MemberCount("ISourceInformationProvider", 2)}} { }
-			class [|ITestFramework_Triggers|] : {{MemberCount("ITestFramework", 4)}} { }
-			class [|ITestFrameworkDiscoverer_Triggers|] : {{MemberCount("ITestFrameworkDiscoverer", 6)}} { }
-			class [|ITestFrameworkExecutor_Triggers|] : {{MemberCount("ITestFrameworkExecutor", 4)}} { }
+			class [|ISourceInformation_Triggers|] : ISourceInformation { }
+			class [|ISourceInformationProvider_Triggers|] : ISourceInformationProvider { }
+			class [|ITestFramework_Triggers|] : ITestFramework { }
+			class [|ITestFrameworkDiscoverer_Triggers|] : ITestFrameworkDiscoverer { }
+			class [|ITestFrameworkExecutor_Triggers|] : ITestFrameworkExecutor { }
 			""";
 
-		await Verify_WithAbstractions.VerifyAnalyzerV2(source);
+		await Verify_WithAbstractions.VerifyAnalyzerV2(CompilerDiagnostics.None, source);
 	}
 
 	[Fact]
@@ -65,125 +66,125 @@ public class X3000_CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectTests
 			class NoInterfaces_DoesNotTrigger { }
 
 			// Discovery and execution messages
-			class [|IMessageSink_Triggers|] : {{MemberCount("IMessageSink", 1)}} { }
-			class [|IMessageSinkMessage_Triggers|] : {{MemberCount("IMessageSinkMessage", 0)}} { }
+			class [|IMessageSink_Triggers|] : IMessageSink { }
+			class [|IMessageSinkMessage_Triggers|] : IMessageSinkMessage { }
 
 			// Reflection
-			class [|IAssemblyInfo_Triggers|] : {{MemberCount("IAssemblyInfo", 5)}} { }
-			class [|IAttributeInfo_Triggers|] : {{MemberCount("IAttributeInfo", 3)}} { }
-			class [|IMethodInfo_Triggers|] : {{MemberCount("IMethodInfo", 11)}} { }
-			class [|IParameterInfo_Triggers|] : {{MemberCount("IParameterInfo", 2)}} { }
-			class [|ITypeInfo_Triggers|] : {{MemberCount("ITypeInfo", 13)}} { }
+			class [|IAssemblyInfo_Triggers|] : IAssemblyInfo { }
+			class [|IAttributeInfo_Triggers|] : IAttributeInfo { }
+			class [|IMethodInfo_Triggers|] : IMethodInfo { }
+			class [|IParameterInfo_Triggers|] : IParameterInfo { }
+			class [|ITypeInfo_Triggers|] : ITypeInfo { }
 
 			// Object model
-			class [|ITest_Triggers|] : {{MemberCount("ITest", 2)}} { }
-			class [|ITestAssembly_Triggers|] : {{MemberCount("ITestAssembly", 4)}} { }
-			class [|ITestCase_Triggers|] : {{MemberCount("ITestCase", 9)}} { }
-			class [|ITestClass_Triggers|] : {{MemberCount("ITestClass", 4)}} { }
-			class [|ITestCollection_Triggers|] : {{MemberCount("ITestCollection", 6)}} { }
-			class [|ITestMethod_Triggers|] : {{MemberCount("ITestMethod", 4)}} { }
-			class [|IXunitTestCase_Triggers|] : {{MemberCount("IXunitTestCase", 13)}} { }
+			class [|ITest_Triggers|] : ITest { }
+			class [|ITestAssembly_Triggers|] : ITestAssembly { }
+			class [|ITestCase_Triggers|] : ITestCase { }
+			class [|ITestClass_Triggers|] : ITestClass { }
+			class [|ITestCollection_Triggers|] : ITestCollection { }
+			class [|ITestMethod_Triggers|] : ITestMethod { }
+			class [|IXunitTestCase_Triggers|] : IXunitTestCase { }
 
 			// Test framework
-			class [|ISourceInformation_Triggers|] : {{MemberCount("ISourceInformation", 4)}} { }
-			class [|ISourceInformationProvider_Triggers|] : {{MemberCount("ISourceInformationProvider", 2)}} { }
-			class [|ITestFramework_Triggers|] : {{MemberCount("ITestFramework", 4)}} { }
-			class [|ITestFrameworkDiscoverer_Triggers|] : {{MemberCount("ITestFrameworkDiscoverer", 6)}} { }
-			class [|ITestFrameworkExecutor_Triggers|] : {{MemberCount("ITestFrameworkExecutor", 4)}} { }
+			class [|ISourceInformation_Triggers|] : ISourceInformation { }
+			class [|ISourceInformationProvider_Triggers|] : ISourceInformationProvider { }
+			class [|ITestFramework_Triggers|] : ITestFramework { }
+			class [|ITestFrameworkDiscoverer_Triggers|] : ITestFrameworkDiscoverer { }
+			class [|ITestFrameworkExecutor_Triggers|] : ITestFrameworkExecutor { }
 
 			// ----- Incompatible base class -----
 
 			// Discovery and execution messages
-			class [|IMessageSink_Foo_Triggers|] : Foo, {{MemberCount("IMessageSink", 1)}} { }
-			class [|IMessageSinkMessage_Foo_Triggers|] : Foo, {{MemberCount("IMessageSinkMessage", 0)}} { }
+			class [|IMessageSink_Foo_Triggers|] : Foo, IMessageSink { }
+			class [|IMessageSinkMessage_Foo_Triggers|] : Foo, IMessageSinkMessage { }
 
 			// Reflection
-			class [|IAssemblyInfo_Foo_Triggers|] : Foo, {{MemberCount("IAssemblyInfo", 5)}} { }
-			class [|IAttributeInfo_Foo_Triggers|] : Foo, {{MemberCount("IAttributeInfo", 3)}} { }
-			class [|IMethodInfo_Foo_Triggers|] : Foo, {{MemberCount("IMethodInfo", 11)}} { }
-			class [|IParameterInfo_Foo_Triggers|] : Foo, {{MemberCount("IParameterInfo", 2)}} { }
-			class [|ITypeInfo_Foo_Triggers|] : Foo, {{MemberCount("ITypeInfo", 13)}} { }
+			class [|IAssemblyInfo_Foo_Triggers|] : Foo, IAssemblyInfo { }
+			class [|IAttributeInfo_Foo_Triggers|] : Foo, IAttributeInfo { }
+			class [|IMethodInfo_Foo_Triggers|] : Foo, IMethodInfo { }
+			class [|IParameterInfo_Foo_Triggers|] : Foo, IParameterInfo { }
+			class [|ITypeInfo_Foo_Triggers|] : Foo, ITypeInfo { }
 
 			// Object model
-			class [|ITest_Foo_Triggers|] : Foo, {{MemberCount("ITest", 2)}} { }
-			class [|ITestAssembly_Foo_Triggers|] : Foo, {{MemberCount("ITestAssembly", 4)}} { }
-			class [|ITestCase_Foo_Triggers|] : Foo, {{MemberCount("ITestCase", 9)}} { }
-			class [|ITestClass_Foo_Triggers|] : Foo, {{MemberCount("ITestClass", 4)}} { }
-			class [|ITestCollection_Foo_Triggers|] : Foo, {{MemberCount("ITestCollection", 6)}} { }
-			class [|ITestMethod_Foo_Triggers|] : Foo, {{MemberCount("ITestMethod", 4)}} { }
-			class [|IXunitTestCase_Foo_Triggers|] : Foo, {{MemberCount("IXunitTestCase", 13)}} { }
+			class [|ITest_Foo_Triggers|] : Foo, ITest { }
+			class [|ITestAssembly_Foo_Triggers|] : Foo, ITestAssembly { }
+			class [|ITestCase_Foo_Triggers|] : Foo, ITestCase { }
+			class [|ITestClass_Foo_Triggers|] : Foo, ITestClass { }
+			class [|ITestCollection_Foo_Triggers|] : Foo, ITestCollection { }
+			class [|ITestMethod_Foo_Triggers|] : Foo, ITestMethod { }
+			class [|IXunitTestCase_Foo_Triggers|] : Foo, IXunitTestCase { }
 
 			// Test framework
-			class [|ISourceInformation_Foo_Triggers|] : Foo, {{MemberCount("ISourceInformation", 4)}} { }
-			class [|ISourceInformationProvider_Foo_Triggers|] : Foo, {{MemberCount("ISourceInformationProvider", 2)}} { }
-			class [|ITestFramework_Foo_Triggers|] : Foo, {{MemberCount("ITestFramework", 4)}} { }
-			class [|ITestFrameworkDiscoverer_Foo_Triggers|] : Foo, {{MemberCount("ITestFrameworkDiscoverer", 6)}} { }
-			class [|ITestFrameworkExecutor_Foo_Triggers|] : Foo, {{MemberCount("ITestFrameworkExecutor", 4)}} { }
+			class [|ISourceInformation_Foo_Triggers|] : Foo, ISourceInformation { }
+			class [|ISourceInformationProvider_Foo_Triggers|] : Foo, ISourceInformationProvider { }
+			class [|ITestFramework_Foo_Triggers|] : Foo, ITestFramework { }
+			class [|ITestFrameworkDiscoverer_Foo_Triggers|] : Foo, ITestFrameworkDiscoverer { }
+			class [|ITestFrameworkExecutor_Foo_Triggers|] : Foo, ITestFrameworkExecutor { }
 
 			// ----- With LongLivedMarshalByRefObject -----
 
 			// Discovery and execution messages
-			class IMessageSink_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, {{MemberCount("IMessageSink", 1)}} { }
-			class IMessageSinkMessage_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, {{MemberCount("IMessageSinkMessage", 0)}} { }
+			class IMessageSink_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, IMessageSink { }
+			class IMessageSinkMessage_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, IMessageSinkMessage { }
 
 			// Reflection
-			class IAssemblyInfo_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, {{MemberCount("IAssemblyInfo", 5)}} { }
-			class IAttributeInfo_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, {{MemberCount("IAttributeInfo", 3)}} { }
-			class IMethodInfo_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, {{MemberCount("IMethodInfo", 11)}} { }
-			class IParameterInfo_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, {{MemberCount("IParameterInfo", 2)}} { }
-			class ITypeInfo_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, {{MemberCount("ITypeInfo", 13)}} { }
+			class IAssemblyInfo_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, IAssemblyInfo { }
+			class IAttributeInfo_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, IAttributeInfo { }
+			class IMethodInfo_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, IMethodInfo { }
+			class IParameterInfo_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, IParameterInfo { }
+			class ITypeInfo_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, ITypeInfo { }
 
 			// Object model
-			class ITest_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, {{MemberCount("ITest", 2)}} { }
-			class ITestAssembly_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, {{MemberCount("ITestAssembly", 4)}} { }
-			class ITestCase_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, {{MemberCount("ITestCase", 9)}} { }
-			class ITestClass_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, {{MemberCount("ITestClass", 4)}} { }
-			class ITestCollection_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, {{MemberCount("ITestCollection", 6)}} { }
-			class ITestMethod_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, {{MemberCount("ITestMethod", 4)}} { }
-			class IXunitTestCase_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, {{MemberCount("IXunitTestCase", 13)}} { }
+			class ITest_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, ITest { }
+			class ITestAssembly_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, ITestAssembly { }
+			class ITestCase_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, ITestCase { }
+			class ITestClass_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, ITestClass { }
+			class ITestCollection_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, ITestCollection { }
+			class ITestMethod_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, ITestMethod { }
+			class IXunitTestCase_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, IXunitTestCase { }
 
 			// Test framework
-			class ISourceInformation_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, {{MemberCount("ISourceInformation", 4)}} { }
-			class ISourceInformationProvider_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, {{MemberCount("ISourceInformationProvider", 2)}} { }
-			class ITestFramework_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, {{MemberCount("ITestFramework", 4)}} { }
-			class ITestFrameworkDiscoverer_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, {{MemberCount("ITestFrameworkDiscoverer", 6)}} { }
-			class ITestFrameworkExecutor_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, {{MemberCount("ITestFrameworkExecutor", 4)}} { }
+			class ISourceInformation_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, ISourceInformation { }
+			class ISourceInformationProvider_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, ISourceInformationProvider { }
+			class ITestFramework_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, ITestFramework { }
+			class ITestFrameworkDiscoverer_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, ITestFrameworkDiscoverer { }
+			class ITestFrameworkExecutor_LLMBRO_DoesNotTrigger : Xunit.LongLivedMarshalByRefObject, ITestFrameworkExecutor { }
 
 			// ----- With MyLLMBRO -----
 
 			// Discovery and execution messages
-			class IMessageSink_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("IMessageSink", 1)}} { }
-			class IMessageSinkMessage_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("IMessageSinkMessage", 0)}} { }
+			class IMessageSink_MyLLMBRO_DoesNotTrigger : MyLLMBRO, IMessageSink { }
+			class IMessageSinkMessage_MyLLMBRO_DoesNotTrigger : MyLLMBRO, IMessageSinkMessage { }
 
 			// Reflection
-			class IAssemblyInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("IAssemblyInfo", 5)}} { }
-			class IAttributeInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("IAttributeInfo", 3)}} { }
-			class IMethodInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("IMethodInfo", 11)}} { }
-			class IParameterInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("IParameterInfo", 2)}} { }
-			class ITypeInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITypeInfo", 13)}} { }
+			class IAssemblyInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, IAssemblyInfo { }
+			class IAttributeInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, IAttributeInfo { }
+			class IMethodInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, IMethodInfo { }
+			class IParameterInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, IParameterInfo { }
+			class ITypeInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITypeInfo { }
 
 			// Object model
-			class ITest_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITest", 2)}} { }
-			class ITestAssembly_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITestAssembly", 4)}} { }
-			class ITestCase_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITestCase", 9)}} { }
-			class ITestClass_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITestClass", 4)}} { }
-			class ITestCollection_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITestCollection", 6)}} { }
-			class ITestMethod_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITestMethod", 4)}} { }
-			class IXunitTestCase_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("IXunitTestCase", 13)}} { }
+			class ITest_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITest { }
+			class ITestAssembly_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITestAssembly { }
+			class ITestCase_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITestCase { }
+			class ITestClass_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITestClass { }
+			class ITestCollection_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITestCollection { }
+			class ITestMethod_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITestMethod { }
+			class IXunitTestCase_MyLLMBRO_DoesNotTrigger : MyLLMBRO, IXunitTestCase { }
 
 			// Test framework
-			class ISourceInformation_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ISourceInformation", 4)}} { }
-			class ISourceInformationProvider_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ISourceInformationProvider", 2)}} { }
-			class ITestFramework_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITestFramework", 4)}} { }
-			class ITestFrameworkDiscoverer_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITestFrameworkDiscoverer", 6)}} { }
-			class ITestFrameworkExecutor_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITestFrameworkExecutor", 4)}} { }
+			class ISourceInformation_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ISourceInformation { }
+			class ISourceInformationProvider_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ISourceInformationProvider { }
+			class ITestFramework_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITestFramework { }
+			class ITestFrameworkDiscoverer_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITestFrameworkDiscoverer { }
+			class ITestFrameworkExecutor_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITestFrameworkExecutor { }
 
 			// ----- Concrete base class that already derives from LLMBRO -----
 
 			class ConcreteTestCase_DoesNotTrigger : XunitTestCase { }
 			""";
 
-		await Verify_WithExecution.VerifyAnalyzerV2(source);
+		await Verify_WithExecution.VerifyAnalyzerV2(CompilerDiagnostics.None, source);
 	}
 
 	[Fact]
@@ -202,129 +203,117 @@ public class X3000_CrossAppDomainClassesMustBeLongLivedMarshalByRefObjectTests
 			class NoInterfaces_DoesNotTrigger { }
 
 			// Discovery and execution messages
-			class [|IMessageSink_Triggers|] : {{MemberCount("IMessageSink", 1)}} { }
-			class [|IMessageSinkMessage_Triggers|] : {{MemberCount("IMessageSinkMessage", 0)}} { }
+			class [|IMessageSink_Triggers|] : IMessageSink { }
+			class [|IMessageSinkMessage_Triggers|] : IMessageSinkMessage { }
 
 			// Reflection
-			class [|IAssemblyInfo_Triggers|] : {{MemberCount("IAssemblyInfo", 5)}} { }
-			class [|IAttributeInfo_Triggers|] : {{MemberCount("IAttributeInfo", 3)}} { }
-			class [|IMethodInfo_Triggers|] : {{MemberCount("IMethodInfo", 11)}} { }
-			class [|IParameterInfo_Triggers|] : {{MemberCount("IParameterInfo", 2)}} { }
-			class [|ITypeInfo_Triggers|] : {{MemberCount("ITypeInfo", 13)}} { }
+			class [|IAssemblyInfo_Triggers|] : IAssemblyInfo { }
+			class [|IAttributeInfo_Triggers|] : IAttributeInfo { }
+			class [|IMethodInfo_Triggers|] : IMethodInfo { }
+			class [|IParameterInfo_Triggers|] : IParameterInfo { }
+			class [|ITypeInfo_Triggers|] : ITypeInfo { }
 
 			// Object model
-			class [|ITest_Triggers|] : {{MemberCount("ITest", 2)}} { }
-			class [|ITestAssembly_Triggers|] : {{MemberCount("ITestAssembly", 4)}} { }
-			class [|ITestCase_Triggers|] : {{MemberCount("ITestCase", 9)}} { }
-			class [|ITestClass_Triggers|] : {{MemberCount("ITestClass", 4)}} { }
-			class [|ITestCollection_Triggers|] : {{MemberCount("ITestCollection", 6)}} { }
-			class [|ITestMethod_Triggers|] : {{MemberCount("ITestMethod", 4)}} { }
+			class [|ITest_Triggers|] : ITest { }
+			class [|ITestAssembly_Triggers|] : ITestAssembly { }
+			class [|ITestCase_Triggers|] : ITestCase { }
+			class [|ITestClass_Triggers|] : ITestClass { }
+			class [|ITestCollection_Triggers|] : ITestCollection { }
+			class [|ITestMethod_Triggers|] : ITestMethod { }
 
 			// Test framework
-			class [|ISourceInformation_Triggers|] : {{MemberCount("ISourceInformation", 4)}} { }
-			class [|ISourceInformationProvider_Triggers|] : {{MemberCount("ISourceInformationProvider", 2)}} { }
-			class [|ITestFramework_Triggers|] : {{MemberCount("ITestFramework", 4)}} { }
-			class [|ITestFrameworkDiscoverer_Triggers|] : {{MemberCount("ITestFrameworkDiscoverer", 6)}} { }
-			class [|ITestFrameworkExecutor_Triggers|] : {{MemberCount("ITestFrameworkExecutor", 4)}} { }
+			class [|ISourceInformation_Triggers|] : ISourceInformation { }
+			class [|ISourceInformationProvider_Triggers|] : ISourceInformationProvider { }
+			class [|ITestFramework_Triggers|] : ITestFramework { }
+			class [|ITestFrameworkDiscoverer_Triggers|] : ITestFrameworkDiscoverer { }
+			class [|ITestFrameworkExecutor_Triggers|] : ITestFrameworkExecutor { }
 
 			// ----- Incompatible base class -----
 
 			// Discovery and execution messages
-			class [|IMessageSink_Foo_Triggers|] : Foo, {{MemberCount("IMessageSink", 1)}} { }
-			class [|IMessageSinkMessage_Foo_Triggers|] : Foo, {{MemberCount("IMessageSinkMessage", 0)}} { }
+			class [|IMessageSink_Foo_Triggers|] : Foo, IMessageSink { }
+			class [|IMessageSinkMessage_Foo_Triggers|] : Foo, IMessageSinkMessage { }
 
 			// Reflection
-			class [|IAssemblyInfo_Foo_Triggers|] : Foo, {{MemberCount("IAssemblyInfo", 5)}} { }
-			class [|IAttributeInfo_Foo_Triggers|] : Foo, {{MemberCount("IAttributeInfo", 3)}} { }
-			class [|IMethodInfo_Foo_Triggers|] : Foo, {{MemberCount("IMethodInfo", 11)}} { }
-			class [|IParameterInfo_Foo_Triggers|] : Foo, {{MemberCount("IParameterInfo", 2)}} { }
-			class [|ITypeInfo_Foo_Triggers|] : Foo, {{MemberCount("ITypeInfo", 13)}} { }
+			class [|IAssemblyInfo_Foo_Triggers|] : Foo, IAssemblyInfo { }
+			class [|IAttributeInfo_Foo_Triggers|] : Foo, IAttributeInfo { }
+			class [|IMethodInfo_Foo_Triggers|] : Foo, IMethodInfo { }
+			class [|IParameterInfo_Foo_Triggers|] : Foo, IParameterInfo { }
+			class [|ITypeInfo_Foo_Triggers|] : Foo, ITypeInfo { }
 
 			// Object model
-			class [|ITest_Foo_Triggers|] : Foo, {{MemberCount("ITest", 2)}} { }
-			class [|ITestAssembly_Foo_Triggers|] : Foo, {{MemberCount("ITestAssembly", 4)}} { }
-			class [|ITestCase_Foo_Triggers|] : Foo, {{MemberCount("ITestCase", 9)}} { }
-			class [|ITestClass_Foo_Triggers|] : Foo, {{MemberCount("ITestClass", 4)}} { }
-			class [|ITestCollection_Foo_Triggers|] : Foo, {{MemberCount("ITestCollection", 6)}} { }
-			class [|ITestMethod_Foo_Triggers|] : Foo, {{MemberCount("ITestMethod", 4)}} { }
+			class [|ITest_Foo_Triggers|] : Foo, ITest { }
+			class [|ITestAssembly_Foo_Triggers|] : Foo, ITestAssembly { }
+			class [|ITestCase_Foo_Triggers|] : Foo, ITestCase { }
+			class [|ITestClass_Foo_Triggers|] : Foo, ITestClass { }
+			class [|ITestCollection_Foo_Triggers|] : Foo, ITestCollection { }
+			class [|ITestMethod_Foo_Triggers|] : Foo, ITestMethod { }
 
 			// Test framework
-			class [|ISourceInformation_Foo_Triggers|] : Foo, {{MemberCount("ISourceInformation", 4)}} { }
-			class [|ISourceInformationProvider_Foo_Triggers|] : Foo, {{MemberCount("ISourceInformationProvider", 2)}} { }
-			class [|ITestFramework_Foo_Triggers|] : Foo, {{MemberCount("ITestFramework", 4)}} { }
-			class [|ITestFrameworkDiscoverer_Foo_Triggers|] : Foo, {{MemberCount("ITestFrameworkDiscoverer", 6)}} { }
-			class [|ITestFrameworkExecutor_Foo_Triggers|] : Foo, {{MemberCount("ITestFrameworkExecutor", 4)}} { }
+			class [|ISourceInformation_Foo_Triggers|] : Foo, ISourceInformation { }
+			class [|ISourceInformationProvider_Foo_Triggers|] : Foo, ISourceInformationProvider { }
+			class [|ITestFramework_Foo_Triggers|] : Foo, ITestFramework { }
+			class [|ITestFrameworkDiscoverer_Foo_Triggers|] : Foo, ITestFrameworkDiscoverer { }
+			class [|ITestFrameworkExecutor_Foo_Triggers|] : Foo, ITestFrameworkExecutor { }
 
 			// ----- With LongLivedMarshalByRefObject -----
 
 			// Discovery and execution messages
-			class IMessageSink_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, {{MemberCount("IMessageSink", 1)}} { }
-			class IMessageSinkMessage_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, {{MemberCount("IMessageSinkMessage", 0)}} { }
+			class IMessageSink_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, IMessageSink { }
+			class IMessageSinkMessage_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, IMessageSinkMessage { }
 
 			// Reflection
-			class IAssemblyInfo_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, {{MemberCount("IAssemblyInfo", 5)}} { }
-			class IAttributeInfo_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, {{MemberCount("IAttributeInfo", 3)}} { }
-			class IMethodInfo_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, {{MemberCount("IMethodInfo", 11)}} { }
-			class IParameterInfo_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, {{MemberCount("IParameterInfo", 2)}} { }
-			class ITypeInfo_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, {{MemberCount("ITypeInfo", 13)}} { }
+			class IAssemblyInfo_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, IAssemblyInfo { }
+			class IAttributeInfo_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, IAttributeInfo { }
+			class IMethodInfo_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, IMethodInfo { }
+			class IParameterInfo_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, IParameterInfo { }
+			class ITypeInfo_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, ITypeInfo { }
 
 			// Object model
-			class ITest_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, {{MemberCount("ITest", 2)}} { }
-			class ITestAssembly_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, {{MemberCount("ITestAssembly", 4)}} { }
-			class ITestCase_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, {{MemberCount("ITestCase", 9)}} { }
-			class ITestClass_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, {{MemberCount("ITestClass", 4)}} { }
-			class ITestCollection_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, {{MemberCount("ITestCollection", 6)}} { }
-			class ITestMethod_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, {{MemberCount("ITestMethod", 4)}} { }
+			class ITest_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, ITest { }
+			class ITestAssembly_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, ITestAssembly { }
+			class ITestCase_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, ITestCase { }
+			class ITestClass_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, ITestClass { }
+			class ITestCollection_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, ITestCollection { }
+			class ITestMethod_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, ITestMethod { }
 
 			// Test framework
-			class ISourceInformation_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, {{MemberCount("ISourceInformation", 4)}} { }
-			class ISourceInformationProvider_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, {{MemberCount("ISourceInformationProvider", 2)}} { }
-			class ITestFramework_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, {{MemberCount("ITestFramework", 4)}} { }
-			class ITestFrameworkDiscoverer_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, {{MemberCount("ITestFrameworkDiscoverer", 6)}} { }
-			class ITestFrameworkExecutor_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, {{MemberCount("ITestFrameworkExecutor", 4)}} { }
+			class ISourceInformation_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, ISourceInformation { }
+			class ISourceInformationProvider_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, ISourceInformationProvider { }
+			class ITestFramework_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, ITestFramework { }
+			class ITestFrameworkDiscoverer_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, ITestFrameworkDiscoverer { }
+			class ITestFrameworkExecutor_LLMBRO_DoesNotTrigger : LongLivedMarshalByRefObject, ITestFrameworkExecutor { }
 
 			// ----- With MyLLMBRO -----
 
 			// Discovery and execution messages
-			class IMessageSink_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("IMessageSink", 1)}} { }
-			class IMessageSinkMessage_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("IMessageSinkMessage", 0)}} { }
+			class IMessageSink_MyLLMBRO_DoesNotTrigger : MyLLMBRO, IMessageSink { }
+			class IMessageSinkMessage_MyLLMBRO_DoesNotTrigger : MyLLMBRO, IMessageSinkMessage { }
 
 			// Reflection
-			class IAssemblyInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("IAssemblyInfo", 5)}} { }
-			class IAttributeInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("IAttributeInfo", 3)}} { }
-			class IMethodInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("IMethodInfo", 11)}} { }
-			class IParameterInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("IParameterInfo", 2)}} { }
-			class ITypeInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITypeInfo", 13)}} { }
+			class IAssemblyInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, IAssemblyInfo { }
+			class IAttributeInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, IAttributeInfo { }
+			class IMethodInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, IMethodInfo { }
+			class IParameterInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, IParameterInfo { }
+			class ITypeInfo_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITypeInfo { }
 
 			// Object model
-			class ITest_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITest", 2)}} { }
-			class ITestAssembly_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITestAssembly", 4)}} { }
-			class ITestCase_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITestCase", 9)}} { }
-			class ITestClass_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITestClass", 4)}} { }
-			class ITestCollection_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITestCollection", 6)}} { }
-			class ITestMethod_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITestMethod", 4)}} { }
+			class ITest_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITest { }
+			class ITestAssembly_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITestAssembly { }
+			class ITestCase_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITestCase { }
+			class ITestClass_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITestClass { }
+			class ITestCollection_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITestCollection { }
+			class ITestMethod_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITestMethod { }
 
 			// Test framework
-			class ISourceInformation_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ISourceInformation", 4)}} { }
-			class ISourceInformationProvider_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ISourceInformationProvider", 2)}} { }
-			class ITestFramework_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITestFramework", 4)}} { }
-			class ITestFrameworkDiscoverer_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITestFrameworkDiscoverer", 6)}} { }
-			class ITestFrameworkExecutor_MyLLMBRO_DoesNotTrigger : MyLLMBRO, {{MemberCount("ITestFrameworkExecutor", 4)}} { }
+			class ISourceInformation_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ISourceInformation { }
+			class ISourceInformationProvider_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ISourceInformationProvider { }
+			class ITestFramework_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITestFramework { }
+			class ITestFrameworkDiscoverer_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITestFrameworkDiscoverer { }
+			class ITestFrameworkExecutor_MyLLMBRO_DoesNotTrigger : MyLLMBRO, ITestFrameworkExecutor { }
 			""";
 
-		await Verify_WithRunnerUtility.VerifyAnalyzerV2RunnerUtility(source);
-	}
-
-	public static string MemberCount(
-		string memberName,
-		int memberCount)
-	{
-		var result = memberName;
-
-		while (memberCount-- > 0)
-			result = $"{{|CS0535:{result}|}}";
-
-		return result;
+		await Verify_WithRunnerUtility.VerifyAnalyzerV2RunnerUtility(CompilerDiagnostics.None, source);
 	}
 
 	internal class AbstractionsAnalyzer : CrossAppDomainClassesMustBeLongLivedMarshalByRefObject

--- a/src/xunit.analyzers.tests/Analyzers/X3000/X3002_DoNotTestForConcreteTypeOfJsonSerializableTypesTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X3000/X3002_DoNotTestForConcreteTypeOfJsonSerializableTypesTests.cs
@@ -1,8 +1,7 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
 using Verify = CSharpVerifier<Xunit.Analyzers.DoNotTestForConcreteTypeOfJsonSerializableTypes>;
-
-namespace Xunit.Analyzers;
 
 public class X3002_DoNotTestForConcreteTypeOfJsonSerializableTypesTests
 {

--- a/src/xunit.analyzers.tests/Analyzers/X3000/X3006_TestCaseMustBeSerializableTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X3000/X3006_TestCaseMustBeSerializableTests.cs
@@ -1,42 +1,35 @@
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using Verify = CSharpVerifier<Xunit.Analyzers.TestCaseMustBeSerializable>;
 
 public class X3006_TestCaseMustBeSerializableTests
 {
-	static string CS0535(
-		string interfaceName,
-		int memberCount)
-	{
-		var result = interfaceName;
-
-		while (memberCount-- > 0)
-			result = $"{{|CS0535:{result}|}}";
-
-		return result;
-	}
-
 	[Fact]
 	public async ValueTask V3_only_NonAOT()
 	{
-		var source = $$"""
+		var source = """
 			using Xunit.Sdk;
 
 			[assembly: RegisterXunitSerializer(typeof(MySerializer), typeof(ExternalSerializedTestCase))]
 
 			public class NonTestCase { }
 
-			public abstract class AbstractTestCase : {{CS0535("ITestCase", 19)}} { }
+			public abstract class AbstractTestCase : ITestCase { }
 
-			public sealed class SelfSerializedTestCase : {{CS0535("ITestCase", 19)}}, {{CS0535("IXunitSerializable", 2)}} { }
+			public sealed class SelfSerializedTestCase : ITestCase, IXunitSerializable { }
 
-			public sealed class ExternalSerializedTestCase : {{CS0535("ITestCase", 19)}} { }
+			public sealed class ExternalSerializedTestCase : ITestCase { }
 
-			public sealed class {|xUnit3006:UnserializedTestCase|} : {{CS0535("ITestCase", 19)}} { }
+			public sealed class {|#0:UnserializedTestCase|} : ITestCase { }
 
-			public class MySerializer : {{CS0535("IXunitSerializer", 3)}} { }
+			public class MySerializer : IXunitSerializer { }
 			""";
 
-		await Verify.VerifyAnalyzerV3NonAot(source);
+		var expected = Verify.Diagnostic("xUnit3006")
+			.WithLocation(0)
+			.WithArguments("UnserializedTestCase", "Xunit.Sdk.ITestCase", "Xunit.Sdk.IXunitSerializable");
+
+		await Verify.VerifyAnalyzerV3NonAot(CompilerDiagnostics.None, source, expected);
 	}
 }

--- a/src/xunit.analyzers.tests/Analyzers/X3000/X3007_TestCaseMustBeSerializableTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X3000/X3007_TestCaseMustBeSerializableTests.cs
@@ -1,44 +1,37 @@
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using Verify = CSharpVerifier<Xunit.Analyzers.TestCaseMustBeSerializable>;
 
 public class X3007_TestCaseMustBeSerializableTests
 {
-	static string CS0535(
-		string interfaceName,
-		int memberCount)
-	{
-		var result = interfaceName;
-
-		while (memberCount-- > 0)
-			result = $"{{|CS0535:{result}|}}";
-
-		return result;
-	}
-
 	[Fact]
 	public async ValueTask V3_only_NonAOT()
 	{
-		var source = $$"""
+		var source = """
 			using Xunit.Sdk;
 
 			[assembly: RegisterXunitSerializer(typeof(MySerializer), typeof(ExternalSerializedTestCase))]
 
 			public class NonTestCase { }
 
-			public abstract class AbstractTestCase : {{CS0535("ITestCase", 19)}} { }
+			public abstract class AbstractTestCase : ITestCase { }
 
-			public class SelfSerializedTestCase : {{CS0535("ITestCase", 19)}}, {{CS0535("IXunitSerializable", 2)}} { }
+			public class SelfSerializedTestCase : ITestCase, IXunitSerializable { }
 
-			public class ExternalSerializedTestCase : {{CS0535("ITestCase", 19)}} { }
+			public class ExternalSerializedTestCase : ITestCase { }
 
 			public class DerivedTestCase : ExternalSerializedTestCase { }
 
-			public class {|xUnit3007:UnserializedTestCase|} : {{CS0535("ITestCase", 19)}} { }
+			public class {|#0:UnserializedTestCase|} : ITestCase { }
 
-			public class MySerializer : {{CS0535("IXunitSerializer", 3)}} { }
+			public class MySerializer : IXunitSerializer { }
 			""";
 
-		await Verify.VerifyAnalyzerV3NonAot(source);
+		var expected = Verify.Diagnostic("xUnit3007")
+			.WithLocation(0)
+			.WithArguments("UnserializedTestCase", "Xunit.Sdk.ITestCase", "Xunit.Sdk.IXunitSerializable");
+
+		await Verify.VerifyAnalyzerV3NonAot(CompilerDiagnostics.None, source, expected);
 	}
 }

--- a/src/xunit.analyzers.tests/Utility/CSharpVerifier.Analyzers.RunnerUtility.cs
+++ b/src/xunit.analyzers.tests/Utility/CSharpVerifier.Analyzers.RunnerUtility.cs
@@ -19,8 +19,27 @@ public partial class CSharpVerifier<TAnalyzer>
 		string source,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV2RunnerUtility(LanguageVersion.CSharp6, [source], diagnostics);
-		await VerifyAnalyzerV3RunnerUtility(LanguageVersion.CSharp6, [source], diagnostics);
+		await VerifyAnalyzerV2RunnerUtility(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, [source], diagnostics);
+		await VerifyAnalyzerV3RunnerUtility(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, [source], diagnostics);
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2 and v3 Runner Utility, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	/// <remarks>
+	/// AOT tests will be run against C# version 13 (the minimum required for .NET 9).
+	/// </remarks>
+	public static async Task VerifyAnalyzerRunnerUtility(
+		CompilerDiagnostics compilerDiagnostics,
+		string source,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV2RunnerUtility(compilerDiagnostics, LanguageVersion.CSharp6, [source], diagnostics);
+		await VerifyAnalyzerV3RunnerUtility(compilerDiagnostics, LanguageVersion.CSharp6, [source], diagnostics);
 	}
 
 	/// <summary>
@@ -35,8 +54,26 @@ public partial class CSharpVerifier<TAnalyzer>
 		string source,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV2RunnerUtility(languageVersion, [source], diagnostics);
-		await VerifyAnalyzerV3RunnerUtility(languageVersion, [source], diagnostics);
+		await VerifyAnalyzerV2RunnerUtility(CompilerDiagnostics.Errors, languageVersion, [source], diagnostics);
+		await VerifyAnalyzerV3RunnerUtility(CompilerDiagnostics.Errors, languageVersion, [source], diagnostics);
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2 and v3 Runner Utility, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static async Task VerifyAnalyzerRunnerUtility(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string source,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV2RunnerUtility(compilerDiagnostics, languageVersion, [source], diagnostics);
+		await VerifyAnalyzerV3RunnerUtility(compilerDiagnostics, languageVersion, [source], diagnostics);
 	}
 
 	/// <summary>
@@ -52,8 +89,27 @@ public partial class CSharpVerifier<TAnalyzer>
 		string[] sources,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV2RunnerUtility(LanguageVersion.CSharp6, sources, diagnostics);
-		await VerifyAnalyzerV3RunnerUtility(LanguageVersion.CSharp6, sources, diagnostics);
+		await VerifyAnalyzerV2RunnerUtility(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, sources, diagnostics);
+		await VerifyAnalyzerV3RunnerUtility(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, sources, diagnostics);
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2 and v3 Runner Utility, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	/// <remarks>
+	/// AOT tests will be run against C# version 13 (the minimum required for .NET 9).
+	/// </remarks>
+	public static async Task VerifyAnalyzerRunnerUtility(
+		CompilerDiagnostics compilerDiagnostics,
+		string[] sources,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV2RunnerUtility(compilerDiagnostics, LanguageVersion.CSharp6, sources, diagnostics);
+		await VerifyAnalyzerV3RunnerUtility(compilerDiagnostics, LanguageVersion.CSharp6, sources, diagnostics);
 	}
 
 	/// <summary>
@@ -68,8 +124,26 @@ public partial class CSharpVerifier<TAnalyzer>
 		string[] sources,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV2RunnerUtility(languageVersion, sources, diagnostics);
-		await VerifyAnalyzerV3RunnerUtility(languageVersion, sources, diagnostics);
+		await VerifyAnalyzerV2RunnerUtility(CompilerDiagnostics.Errors, languageVersion, sources, diagnostics);
+		await VerifyAnalyzerV3RunnerUtility(CompilerDiagnostics.Errors, languageVersion, sources, diagnostics);
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2 and v3 Runner Utility, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static async Task VerifyAnalyzerRunnerUtility(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string[] sources,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV2RunnerUtility(compilerDiagnostics, languageVersion, sources, diagnostics);
+		await VerifyAnalyzerV3RunnerUtility(compilerDiagnostics, languageVersion, sources, diagnostics);
 	}
 
 	/// <summary>
@@ -82,8 +156,24 @@ public partial class CSharpVerifier<TAnalyzer>
 		string source,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV2RunnerUtility(LanguageVersion.CSharp6, [source], diagnostics);
-		await VerifyAnalyzerV3RunnerUtilityNonAot(LanguageVersion.CSharp6, [source], diagnostics);
+		await VerifyAnalyzerV2RunnerUtility(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, [source], diagnostics);
+		await VerifyAnalyzerV3RunnerUtilityNonAot(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, [source], diagnostics);
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2 and v3 Runner Utility, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static async Task VerifyAnalyzerRunnerUtilityNonAot(
+		CompilerDiagnostics compilerDiagnostics,
+		string source,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV2RunnerUtility(compilerDiagnostics, LanguageVersion.CSharp6, [source], diagnostics);
+		await VerifyAnalyzerV3RunnerUtilityNonAot(compilerDiagnostics, LanguageVersion.CSharp6, [source], diagnostics);
 	}
 
 	/// <summary>
@@ -98,8 +188,26 @@ public partial class CSharpVerifier<TAnalyzer>
 		string source,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV2RunnerUtility(languageVersion, [source], diagnostics);
-		await VerifyAnalyzerV3RunnerUtilityNonAot(languageVersion, [source], diagnostics);
+		await VerifyAnalyzerV2RunnerUtility(CompilerDiagnostics.Errors, languageVersion, [source], diagnostics);
+		await VerifyAnalyzerV3RunnerUtilityNonAot(CompilerDiagnostics.Errors, languageVersion, [source], diagnostics);
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2 and v3 Runner Utility, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static async Task VerifyAnalyzerRunnerUtilityNonAot(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string source,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV2RunnerUtility(compilerDiagnostics, languageVersion, [source], diagnostics);
+		await VerifyAnalyzerV3RunnerUtilityNonAot(compilerDiagnostics, languageVersion, [source], diagnostics);
 	}
 
 	/// <summary>
@@ -112,8 +220,24 @@ public partial class CSharpVerifier<TAnalyzer>
 		string[] sources,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV2RunnerUtility(LanguageVersion.CSharp6, sources, diagnostics);
-		await VerifyAnalyzerV3RunnerUtilityNonAot(LanguageVersion.CSharp6, sources, diagnostics);
+		await VerifyAnalyzerV2RunnerUtility(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, sources, diagnostics);
+		await VerifyAnalyzerV3RunnerUtilityNonAot(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, sources, diagnostics);
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2 and v3 Runner Utility, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static async Task VerifyAnalyzerRunnerUtilityNonAot(
+		CompilerDiagnostics compilerDiagnostics,
+		string[] sources,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV2RunnerUtility(compilerDiagnostics, LanguageVersion.CSharp6, sources, diagnostics);
+		await VerifyAnalyzerV3RunnerUtilityNonAot(compilerDiagnostics, LanguageVersion.CSharp6, sources, diagnostics);
 	}
 
 	/// <summary>
@@ -128,8 +252,26 @@ public partial class CSharpVerifier<TAnalyzer>
 		string[] sources,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV2RunnerUtility(languageVersion, sources, diagnostics);
-		await VerifyAnalyzerV3RunnerUtilityNonAot(languageVersion, sources, diagnostics);
+		await VerifyAnalyzerV2RunnerUtility(CompilerDiagnostics.Errors, languageVersion, sources, diagnostics);
+		await VerifyAnalyzerV3RunnerUtilityNonAot(CompilerDiagnostics.Errors, languageVersion, sources, diagnostics);
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2 and v3 Runner Utility, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static async Task VerifyAnalyzerRunnerUtilityNonAot(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string[] sources,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV2RunnerUtility(compilerDiagnostics, languageVersion, sources, diagnostics);
+		await VerifyAnalyzerV3RunnerUtilityNonAot(compilerDiagnostics, languageVersion, sources, diagnostics);
 	}
 
 	// ----- v2 -----
@@ -143,7 +285,20 @@ public partial class CSharpVerifier<TAnalyzer>
 	public static Task VerifyAnalyzerV2RunnerUtility(
 		string source,
 		params DiagnosticResult[] diagnostics) =>
-			VerifyAnalyzerV2RunnerUtility(LanguageVersion.CSharp6, [source], diagnostics);
+			VerifyAnalyzerV2RunnerUtility(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, [source], diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2 Runner Utility, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV2RunnerUtility(
+		CompilerDiagnostics compilerDiagnostics,
+		string source,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV2RunnerUtility(compilerDiagnostics, LanguageVersion.CSharp6, [source], diagnostics);
 
 	/// <summary>
 	/// Runs code for analysis, against xUnit.net v2, using the provided version of C#.
@@ -156,7 +311,22 @@ public partial class CSharpVerifier<TAnalyzer>
 		LanguageVersion languageVersion,
 		string source,
 		params DiagnosticResult[] diagnostics) =>
-			VerifyAnalyzerV2RunnerUtility(languageVersion, [source], diagnostics);
+			VerifyAnalyzerV2RunnerUtility(CompilerDiagnostics.Errors, languageVersion, [source], diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV2RunnerUtility(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string source,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV2RunnerUtility(compilerDiagnostics, languageVersion, [source], diagnostics);
 
 	/// <summary>
 	/// Runs code for analysis, against xUnit.net v2 Runner Utility, using C# 6.
@@ -167,7 +337,20 @@ public partial class CSharpVerifier<TAnalyzer>
 	public static Task VerifyAnalyzerV2RunnerUtility(
 		string[] sources,
 		params DiagnosticResult[] diagnostics) =>
-			VerifyAnalyzerV2RunnerUtility(LanguageVersion.CSharp6, sources, diagnostics);
+			VerifyAnalyzerV2RunnerUtility(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, sources, diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2 Runner Utility, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV2RunnerUtility(
+		CompilerDiagnostics compilerDiagnostics,
+		string[] sources,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV2RunnerUtility(compilerDiagnostics, LanguageVersion.CSharp6, sources, diagnostics);
 
 	/// <summary>
 	/// Runs code for analysis, against xUnit.net v2, using the provided version of C#.
@@ -179,6 +362,21 @@ public partial class CSharpVerifier<TAnalyzer>
 	public static Task VerifyAnalyzerV2RunnerUtility(
 		LanguageVersion languageVersion,
 		string[] sources,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV2RunnerUtility(CompilerDiagnostics.Errors, languageVersion, sources, diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV2RunnerUtility(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string[] sources,
 		params DiagnosticResult[] diagnostics)
 	{
 		var test = new TestV2RunnerUtility(languageVersion);
@@ -186,6 +384,7 @@ public partial class CSharpVerifier<TAnalyzer>
 		foreach (var source in sources)
 			test.TestState.Sources.Add(source);
 
+		test.CompilerDiagnostics = compilerDiagnostics;
 		test.TestState.ExpectedDiagnostics.AddRange(diagnostics);
 		return test.RunAsync();
 	}
@@ -205,9 +404,30 @@ public partial class CSharpVerifier<TAnalyzer>
 		string source,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV3RunnerUtilityNonAot(LanguageVersion.CSharp6, [source], diagnostics);
+		await VerifyAnalyzerV3RunnerUtilityNonAot(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, [source], diagnostics);
 #if NETCOREAPP
-		await VerifyAnalyzerV3RunnerUtilityAot(LanguageVersion.CSharp13, [source], diagnostics);
+		await VerifyAnalyzerV3RunnerUtilityAot(CompilerDiagnostics.Errors, LanguageVersion.CSharp13, [source], diagnostics);
+#endif
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3 Runner Utility, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	/// <remarks>
+	/// AOT tests will be run against C# version 13 (the minimum required for .NET 9).
+	/// </remarks>
+	public static async Task VerifyAnalyzerV3RunnerUtility(
+		CompilerDiagnostics compilerDiagnostics,
+		string source,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV3RunnerUtilityNonAot(compilerDiagnostics, LanguageVersion.CSharp6, [source], diagnostics);
+#if NETCOREAPP
+		await VerifyAnalyzerV3RunnerUtilityAot(compilerDiagnostics, LanguageVersion.CSharp13, [source], diagnostics);
 #endif
 	}
 
@@ -227,9 +447,33 @@ public partial class CSharpVerifier<TAnalyzer>
 		string source,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV3RunnerUtilityNonAot(languageVersion, [source], diagnostics);
+		await VerifyAnalyzerV3RunnerUtilityNonAot(CompilerDiagnostics.Errors, languageVersion, [source], diagnostics);
 #if NETCOREAPP
-		await VerifyAnalyzerV3RunnerUtilityAot(languageVersion, [source], diagnostics);
+		await VerifyAnalyzerV3RunnerUtilityAot(CompilerDiagnostics.Errors, languageVersion, [source], diagnostics);
+#endif
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3 Runner Utility, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	/// <remarks>
+	/// If <paramref name="languageVersion"/> is less than 13, then AOT tests will be run
+	/// against version 13 (the minimum required for .NET 9).
+	/// </remarks>
+	public static async Task VerifyAnalyzerV3RunnerUtility(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string source,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV3RunnerUtilityNonAot(compilerDiagnostics, languageVersion, [source], diagnostics);
+#if NETCOREAPP
+		await VerifyAnalyzerV3RunnerUtilityAot(compilerDiagnostics, languageVersion, [source], diagnostics);
 #endif
 	}
 
@@ -246,9 +490,30 @@ public partial class CSharpVerifier<TAnalyzer>
 		string[] sources,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV3RunnerUtilityNonAot(LanguageVersion.CSharp6, sources, diagnostics);
+		await VerifyAnalyzerV3RunnerUtilityNonAot(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, sources, diagnostics);
 #if NETCOREAPP
-		await VerifyAnalyzerV3RunnerUtilityAot(LanguageVersion.CSharp13, sources, diagnostics);
+		await VerifyAnalyzerV3RunnerUtilityAot(CompilerDiagnostics.Errors, LanguageVersion.CSharp13, sources, diagnostics);
+#endif
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3 Runner Utility, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	/// <remarks>
+	/// AOT tests will be run against C# version 13 (the minimum required for .NET 9).
+	/// </remarks>
+	public static async Task VerifyAnalyzerV3RunnerUtility(
+		CompilerDiagnostics compilerDiagnostics,
+		string[] sources,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV3RunnerUtilityNonAot(compilerDiagnostics, LanguageVersion.CSharp6, sources, diagnostics);
+#if NETCOREAPP
+		await VerifyAnalyzerV3RunnerUtilityAot(compilerDiagnostics, LanguageVersion.CSharp13, sources, diagnostics);
 #endif
 	}
 
@@ -268,9 +533,33 @@ public partial class CSharpVerifier<TAnalyzer>
 		string[] sources,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV3RunnerUtilityNonAot(languageVersion, sources, diagnostics);
+		await VerifyAnalyzerV3RunnerUtilityNonAot(CompilerDiagnostics.Errors, languageVersion, sources, diagnostics);
 #if NETCOREAPP
-		await VerifyAnalyzerV3RunnerUtilityAot(languageVersion, sources, diagnostics);
+		await VerifyAnalyzerV3RunnerUtilityAot(CompilerDiagnostics.Errors, languageVersion, sources, diagnostics);
+#endif
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3 Runner Utility, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	/// <remarks>
+	/// If <paramref name="languageVersion"/> is less than 13, then AOT tests will be run
+	/// against version 13 (the minimum required for .NET 9).
+	/// </remarks>
+	public static async Task VerifyAnalyzerV3RunnerUtility(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string[] sources,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV3RunnerUtilityNonAot(compilerDiagnostics, languageVersion, sources, diagnostics);
+#if NETCOREAPP
+		await VerifyAnalyzerV3RunnerUtilityAot(compilerDiagnostics, languageVersion, sources, diagnostics);
 #endif
 	}
 
@@ -285,7 +574,20 @@ public partial class CSharpVerifier<TAnalyzer>
 	public static Task VerifyAnalyzerV3RunnerUtilityAot(
 		string source,
 		params DiagnosticResult[] diagnostics) =>
-			VerifyAnalyzerV3RunnerUtilityAot(LanguageVersion.CSharp13, [source], diagnostics);
+			VerifyAnalyzerV3RunnerUtilityAot(CompilerDiagnostics.Errors, LanguageVersion.CSharp13, [source], diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3 Runner Utility, using C# 13.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV3RunnerUtilityAot(
+		CompilerDiagnostics compilerDiagnostics,
+		string source,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV3RunnerUtilityAot(compilerDiagnostics, LanguageVersion.CSharp13, [source], diagnostics);
 
 	/// <summary>
 	/// Runs code for analysis, against xUnit.net v3 Runner Utility, using the provided version of C#.
@@ -298,7 +600,22 @@ public partial class CSharpVerifier<TAnalyzer>
 		LanguageVersion languageVersion,
 		string source,
 		params DiagnosticResult[] diagnostics) =>
-			VerifyAnalyzerV3RunnerUtilityAot(languageVersion, [source], diagnostics);
+			VerifyAnalyzerV3RunnerUtilityAot(CompilerDiagnostics.Errors, languageVersion, [source], diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3 Runner Utility, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV3RunnerUtilityAot(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string source,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV3RunnerUtilityAot(compilerDiagnostics, languageVersion, [source], diagnostics);
 
 	/// <summary>
 	/// Runs code for analysis, against xUnit.net v3 Runner Utility, using C# 13.
@@ -309,7 +626,20 @@ public partial class CSharpVerifier<TAnalyzer>
 	public static Task VerifyAnalyzerV3RunnerUtilityAot(
 		string[] sources,
 		params DiagnosticResult[] diagnostics) =>
-			VerifyAnalyzerV3RunnerUtilityAot(LanguageVersion.CSharp13, sources, diagnostics);
+			VerifyAnalyzerV3RunnerUtilityAot(CompilerDiagnostics.Errors, LanguageVersion.CSharp13, sources, diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3 Runner Utility, using C# 13.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV3RunnerUtilityAot(
+		CompilerDiagnostics compilerDiagnostics,
+		string[] sources,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV3RunnerUtilityAot(compilerDiagnostics, LanguageVersion.CSharp13, sources, diagnostics);
 
 	/// <summary>
 	/// Runs code for analysis, against xUnit.net v3 Runner Utility, using the provided version of C#.
@@ -318,7 +648,22 @@ public partial class CSharpVerifier<TAnalyzer>
 	/// <param name="sources">The code to verify</param>
 	/// <param name="diagnostics">The expected diagnostics (pass none for code that
 	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV3RunnerUtilityAot(
+		LanguageVersion languageVersion,
+		string[] sources,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV3RunnerUtilityAot(CompilerDiagnostics.Errors, languageVersion, sources, diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3 Runner Utility, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
 	public static async Task VerifyAnalyzerV3RunnerUtilityAot(
+		CompilerDiagnostics compilerDiagnostics,
 		LanguageVersion languageVersion,
 		string[] sources,
 		params DiagnosticResult[] diagnostics)
@@ -332,6 +677,7 @@ public partial class CSharpVerifier<TAnalyzer>
 		foreach (var source in sources)
 			testAot.TestState.Sources.Add(source);
 
+		testAot.CompilerDiagnostics = compilerDiagnostics;
 		testAot.TestState.ExpectedDiagnostics.AddRange(diagnostics);
 		testAot.DisabledDiagnostics.Add("CS1701");  // assert is net9, core is net8, ignore version drift
 		await testAot.RunAsync();
@@ -348,7 +694,20 @@ public partial class CSharpVerifier<TAnalyzer>
 	public static Task VerifyAnalyzerV3RunnerUtilityNonAot(
 		string source,
 		params DiagnosticResult[] diagnostics) =>
-			VerifyAnalyzerV3RunnerUtilityNonAot(LanguageVersion.CSharp6, [source], diagnostics);
+			VerifyAnalyzerV3RunnerUtilityNonAot(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, [source], diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3 Runner Utility, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV3RunnerUtilityNonAot(
+		CompilerDiagnostics compilerDiagnostics,
+		string source,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV3RunnerUtilityNonAot(compilerDiagnostics, LanguageVersion.CSharp6, [source], diagnostics);
 
 	/// <summary>
 	/// Runs code for analysis, against xUnit.net v3 Runner Utility, using the provided version of C#.
@@ -361,7 +720,22 @@ public partial class CSharpVerifier<TAnalyzer>
 		LanguageVersion languageVersion,
 		string source,
 		params DiagnosticResult[] diagnostics) =>
-			VerifyAnalyzerV3RunnerUtilityNonAot(languageVersion, [source], diagnostics);
+			VerifyAnalyzerV3RunnerUtilityNonAot(CompilerDiagnostics.Errors, languageVersion, [source], diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3 Runner Utility, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV3RunnerUtilityNonAot(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string source,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV3RunnerUtilityNonAot(compilerDiagnostics, languageVersion, [source], diagnostics);
 
 	/// <summary>
 	/// Runs code for analysis, against xUnit.net v3 Runner Utility, using C# 6.
@@ -372,7 +746,20 @@ public partial class CSharpVerifier<TAnalyzer>
 	public static Task VerifyAnalyzerV3RunnerUtilityNonAot(
 		string[] sources,
 		params DiagnosticResult[] diagnostics) =>
-			VerifyAnalyzerV3RunnerUtilityNonAot(LanguageVersion.CSharp6, sources, diagnostics);
+			VerifyAnalyzerV3RunnerUtilityNonAot(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, sources, diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3 Runner Utility, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV3RunnerUtilityNonAot(
+		CompilerDiagnostics compilerDiagnostics,
+		string[] sources,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV3RunnerUtilityNonAot(compilerDiagnostics, LanguageVersion.CSharp6, sources, diagnostics);
 
 	/// <summary>
 	/// Runs code for analysis, against xUnit.net v3 Runner Utility, using the provided version of C#.
@@ -381,7 +768,22 @@ public partial class CSharpVerifier<TAnalyzer>
 	/// <param name="sources">The code to verify</param>
 	/// <param name="diagnostics">The expected diagnostics (pass none for code that
 	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV3RunnerUtilityNonAot(
+		LanguageVersion languageVersion,
+		string[] sources,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV3RunnerUtilityNonAot(CompilerDiagnostics.Errors, languageVersion, sources, diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3 Runner Utility, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
 	public static async Task VerifyAnalyzerV3RunnerUtilityNonAot(
+		CompilerDiagnostics compilerDiagnostics,
 		LanguageVersion languageVersion,
 		string[] sources,
 		params DiagnosticResult[] diagnostics)
@@ -391,6 +793,7 @@ public partial class CSharpVerifier<TAnalyzer>
 		foreach (var source in sources)
 			test.TestState.Sources.Add(source);
 
+		test.CompilerDiagnostics = compilerDiagnostics;
 		test.TestState.ExpectedDiagnostics.AddRange(diagnostics);
 		await test.RunAsync();
 	}

--- a/src/xunit.analyzers.tests/Utility/CSharpVerifier.Analyzers.cs
+++ b/src/xunit.analyzers.tests/Utility/CSharpVerifier.Analyzers.cs
@@ -402,4 +402,44 @@ public partial class CSharpVerifier<TAnalyzer>
 		test.TestState.ExpectedDiagnostics.AddRange(diagnostics);
 		return test.RunAsync();
 	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3, using C# 6, with compiler
+	/// diagnostics verification disabled.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV3NonAot(
+		CompilerDiagnostics compilerDiagnostics,
+		string source,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV3NonAot(LanguageVersion.CSharp6, compilerDiagnostics, [source], diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3, using the provided version of C#, with
+	/// the specified level of compiler diagnostics verification.
+	/// </summary>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV3NonAot(
+		LanguageVersion languageVersion,
+		CompilerDiagnostics compilerDiagnostics,
+		string[] sources,
+		params DiagnosticResult[] diagnostics)
+	{
+		var test = new TestV3(languageVersion);
+
+		foreach (var source in sources)
+			test.TestState.Sources.Add(source);
+
+		test.CompilerDiagnostics = compilerDiagnostics;
+
+		test.TestState.ExpectedDiagnostics.AddRange(diagnostics);
+		return test.RunAsync();
+	}
 }

--- a/src/xunit.analyzers.tests/Utility/CSharpVerifier.Analyzers.cs
+++ b/src/xunit.analyzers.tests/Utility/CSharpVerifier.Analyzers.cs
@@ -19,8 +19,27 @@ public partial class CSharpVerifier<TAnalyzer>
 		string source,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV2(LanguageVersion.CSharp6, [source], diagnostics);
-		await VerifyAnalyzerV3(LanguageVersion.CSharp6, [source], diagnostics);
+		await VerifyAnalyzerV2(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, [source], diagnostics);
+		await VerifyAnalyzerV3(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, [source], diagnostics);
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2 and v3, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	/// <remarks>
+	/// AOT tests will be run against C# version 13 (the minimum required for .NET 9).
+	/// </remarks>
+	public static async Task VerifyAnalyzer(
+		CompilerDiagnostics compilerDiagnostics,
+		string source,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV2(compilerDiagnostics, LanguageVersion.CSharp6, [source], diagnostics);
+		await VerifyAnalyzerV3(compilerDiagnostics, LanguageVersion.CSharp6, [source], diagnostics);
 	}
 
 	/// <summary>
@@ -39,8 +58,30 @@ public partial class CSharpVerifier<TAnalyzer>
 		string source,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV2(languageVersion, [source], diagnostics);
-		await VerifyAnalyzerV3(languageVersion, [source], diagnostics);
+		await VerifyAnalyzerV2(CompilerDiagnostics.Errors, languageVersion, [source], diagnostics);
+		await VerifyAnalyzerV3(CompilerDiagnostics.Errors, languageVersion, [source], diagnostics);
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2 and v3, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	/// <remarks>
+	/// If <paramref name="languageVersion"/> is less than 13, then AOT tests will be run
+	/// against version 13 (the minimum required for .NET 9).
+	/// </remarks>
+	public static async Task VerifyAnalyzer(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string source,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV2(compilerDiagnostics, languageVersion, [source], diagnostics);
+		await VerifyAnalyzerV3(compilerDiagnostics, languageVersion, [source], diagnostics);
 	}
 
 	/// <summary>
@@ -56,8 +97,27 @@ public partial class CSharpVerifier<TAnalyzer>
 		string[] sources,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV2(LanguageVersion.CSharp6, sources, diagnostics);
-		await VerifyAnalyzerV3(LanguageVersion.CSharp6, sources, diagnostics);
+		await VerifyAnalyzerV2(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, sources, diagnostics);
+		await VerifyAnalyzerV3(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, sources, diagnostics);
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2 and v3, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	/// <remarks>
+	/// AOT tests will be run against C# version 13 (the minimum required for .NET 9).
+	/// </remarks>
+	public static async Task VerifyAnalyzer(
+		CompilerDiagnostics compilerDiagnostics,
+		string[] sources,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV2(compilerDiagnostics, LanguageVersion.CSharp6, sources, diagnostics);
+		await VerifyAnalyzerV3(compilerDiagnostics, LanguageVersion.CSharp6, sources, diagnostics);
 	}
 
 	/// <summary>
@@ -76,8 +136,30 @@ public partial class CSharpVerifier<TAnalyzer>
 		string[] sources,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV2(languageVersion, sources, diagnostics);
-		await VerifyAnalyzerV3(languageVersion, sources, diagnostics);
+		await VerifyAnalyzerV2(CompilerDiagnostics.Errors, languageVersion, sources, diagnostics);
+		await VerifyAnalyzerV3(CompilerDiagnostics.Errors, languageVersion, sources, diagnostics);
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2 and v3, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	/// <remarks>
+	/// If <paramref name="languageVersion"/> is less than 13, then AOT tests will be run
+	/// against version 13 (the minimum required for .NET 9).
+	/// </remarks>
+	public static async Task VerifyAnalyzer(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string[] sources,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV2(compilerDiagnostics, languageVersion, sources, diagnostics);
+		await VerifyAnalyzerV3(compilerDiagnostics, languageVersion, sources, diagnostics);
 	}
 
 	/// <summary>
@@ -87,6 +169,22 @@ public partial class CSharpVerifier<TAnalyzer>
 	/// <param name="diagnostics">The expected diagnostics (pass none for code that
 	/// should not trigger)</param>
 	public static async Task VerifyAnalyzerNonAot(
+		string source,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV2(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, [source], diagnostics);
+		await VerifyAnalyzerV3NonAot(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, [source], diagnostics);
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2 and v3, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static async Task VerifyAnalyzerNonAot(
+		CompilerDiagnostics compilerDiagnostics,
 		string source,
 		params DiagnosticResult[] diagnostics)
 	{
@@ -106,8 +204,26 @@ public partial class CSharpVerifier<TAnalyzer>
 		string source,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV2(languageVersion, [source], diagnostics);
-		await VerifyAnalyzerV3NonAot(languageVersion, [source], diagnostics);
+		await VerifyAnalyzerV2(CompilerDiagnostics.Errors, languageVersion, [source], diagnostics);
+		await VerifyAnalyzerV3NonAot(CompilerDiagnostics.Errors, languageVersion, [source], diagnostics);
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2 and v3, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static async Task VerifyAnalyzerNonAot(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string source,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV2(compilerDiagnostics, languageVersion, [source], diagnostics);
+		await VerifyAnalyzerV3NonAot(compilerDiagnostics, languageVersion, [source], diagnostics);
 	}
 
 	/// <summary>
@@ -120,8 +236,24 @@ public partial class CSharpVerifier<TAnalyzer>
 		string[] sources,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV2(LanguageVersion.CSharp6, sources, diagnostics);
-		await VerifyAnalyzerV3NonAot(LanguageVersion.CSharp6, sources, diagnostics);
+		await VerifyAnalyzerV2(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, sources, diagnostics);
+		await VerifyAnalyzerV3NonAot(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, sources, diagnostics);
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2 and v3, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static async Task VerifyAnalyzerNonAot(
+		CompilerDiagnostics compilerDiagnostics,
+		string[] sources,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV2(compilerDiagnostics, LanguageVersion.CSharp6, sources, diagnostics);
+		await VerifyAnalyzerV3NonAot(compilerDiagnostics, LanguageVersion.CSharp6, sources, diagnostics);
 	}
 
 	/// <summary>
@@ -136,8 +268,26 @@ public partial class CSharpVerifier<TAnalyzer>
 		string[] sources,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV2(languageVersion, sources, diagnostics);
-		await VerifyAnalyzerV3NonAot(languageVersion, sources, diagnostics);
+		await VerifyAnalyzerV2(CompilerDiagnostics.Errors, languageVersion, sources, diagnostics);
+		await VerifyAnalyzerV3NonAot(CompilerDiagnostics.Errors, languageVersion, sources, diagnostics);
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2 and v3, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static async Task VerifyAnalyzerNonAot(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string[] sources,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV2(compilerDiagnostics, languageVersion, sources, diagnostics);
+		await VerifyAnalyzerV3NonAot(compilerDiagnostics, languageVersion, sources, diagnostics);
 	}
 
 	// ----- v2 -----
@@ -151,7 +301,20 @@ public partial class CSharpVerifier<TAnalyzer>
 	public static Task VerifyAnalyzerV2(
 		string source,
 		params DiagnosticResult[] diagnostics) =>
-			VerifyAnalyzerV2(LanguageVersion.CSharp6, [source], diagnostics);
+			VerifyAnalyzerV2(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, [source], diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV2(
+		CompilerDiagnostics compilerDiagnostics,
+		string source,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV2(compilerDiagnostics, LanguageVersion.CSharp6, [source], diagnostics);
 
 	/// <summary>
 	/// Runs code for analysis, against xUnit.net v2, using the provided version of C#.
@@ -164,7 +327,22 @@ public partial class CSharpVerifier<TAnalyzer>
 		LanguageVersion languageVersion,
 		string source,
 		params DiagnosticResult[] diagnostics) =>
-			VerifyAnalyzerV2(languageVersion, [source], diagnostics);
+			VerifyAnalyzerV2(CompilerDiagnostics.Errors, languageVersion, [source], diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV2(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string source,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV2(compilerDiagnostics, languageVersion, [source], diagnostics);
 
 	/// <summary>
 	/// Runs code for analysis, against xUnit.net v2, using C# 6.
@@ -175,7 +353,20 @@ public partial class CSharpVerifier<TAnalyzer>
 	public static Task VerifyAnalyzerV2(
 		string[] sources,
 		params DiagnosticResult[] diagnostics) =>
-			VerifyAnalyzerV2(LanguageVersion.CSharp6, sources, diagnostics);
+			VerifyAnalyzerV2(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, sources, diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV2(
+		CompilerDiagnostics compilerDiagnostics,
+		string[] sources,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV2(compilerDiagnostics, LanguageVersion.CSharp6, sources, diagnostics);
 
 	/// <summary>
 	/// Runs code for analysis, against xUnit.net v2, using the provided version of C#.
@@ -187,6 +378,21 @@ public partial class CSharpVerifier<TAnalyzer>
 	public static Task VerifyAnalyzerV2(
 		LanguageVersion languageVersion,
 		string[] sources,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV2(CompilerDiagnostics.Errors, languageVersion, sources, diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v2, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV2(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string[] sources,
 		params DiagnosticResult[] diagnostics)
 	{
 		var test = new TestV2(languageVersion);
@@ -194,6 +400,7 @@ public partial class CSharpVerifier<TAnalyzer>
 		foreach (var source in sources)
 			test.TestState.Sources.Add(source);
 
+		test.CompilerDiagnostics = compilerDiagnostics;
 		test.TestState.ExpectedDiagnostics.AddRange(diagnostics);
 		return test.RunAsync();
 	}
@@ -213,9 +420,30 @@ public partial class CSharpVerifier<TAnalyzer>
 		string source,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV3NonAot(LanguageVersion.CSharp6, source, diagnostics);
+		await VerifyAnalyzerV3NonAot(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, source, diagnostics);
 #if NETCOREAPP
-		await VerifyAnalyzerV3Aot(LanguageVersion.CSharp13, source, diagnostics);
+		await VerifyAnalyzerV3Aot(CompilerDiagnostics.Errors, LanguageVersion.CSharp13, source, diagnostics);
+#endif
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	/// <remarks>
+	/// AOT tests will be run against C# version 13 (the minimum required for .NET 9).
+	/// </remarks>
+	public static async Task VerifyAnalyzerV3(
+		CompilerDiagnostics compilerDiagnostics,
+		string source,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV3NonAot(compilerDiagnostics, LanguageVersion.CSharp6, source, diagnostics);
+#if NETCOREAPP
+		await VerifyAnalyzerV3Aot(compilerDiagnostics, LanguageVersion.CSharp13, source, diagnostics);
 #endif
 	}
 
@@ -235,9 +463,33 @@ public partial class CSharpVerifier<TAnalyzer>
 		string source,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV3NonAot(languageVersion, source, diagnostics);
+		await VerifyAnalyzerV3NonAot(CompilerDiagnostics.Errors, languageVersion, source, diagnostics);
 #if NETCOREAPP
-		await VerifyAnalyzerV3Aot(languageVersion, source, diagnostics);
+		await VerifyAnalyzerV3Aot(CompilerDiagnostics.Errors, languageVersion, source, diagnostics);
+#endif
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	/// <remarks>
+	/// If <paramref name="languageVersion"/> is less than 13, then AOT tests will be run
+	/// against version 13 (the minimum required for .NET 9).
+	/// </remarks>
+	public static async Task VerifyAnalyzerV3(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string source,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV3NonAot(compilerDiagnostics, languageVersion, source, diagnostics);
+#if NETCOREAPP
+		await VerifyAnalyzerV3Aot(compilerDiagnostics, languageVersion, source, diagnostics);
 #endif
 	}
 
@@ -254,9 +506,30 @@ public partial class CSharpVerifier<TAnalyzer>
 		string[] sources,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV3NonAot(LanguageVersion.CSharp6, sources, diagnostics);
+		await VerifyAnalyzerV3NonAot(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, sources, diagnostics);
 #if NETCOREAPP
-		await VerifyAnalyzerV3Aot(LanguageVersion.CSharp13, sources, diagnostics);
+		await VerifyAnalyzerV3Aot(CompilerDiagnostics.Errors, LanguageVersion.CSharp13, sources, diagnostics);
+#endif
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	/// <remarks>
+	/// AOT tests will be run against C# version 13 (the minimum required for .NET 9).
+	/// </remarks>
+	public static async Task VerifyAnalyzerV3(
+		CompilerDiagnostics compilerDiagnostics,
+		string[] sources,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV3NonAot(compilerDiagnostics, LanguageVersion.CSharp6, sources, diagnostics);
+#if NETCOREAPP
+		await VerifyAnalyzerV3Aot(compilerDiagnostics, LanguageVersion.CSharp13, sources, diagnostics);
 #endif
 	}
 
@@ -276,9 +549,33 @@ public partial class CSharpVerifier<TAnalyzer>
 		string[] sources,
 		params DiagnosticResult[] diagnostics)
 	{
-		await VerifyAnalyzerV3NonAot(languageVersion, sources, diagnostics);
+		await VerifyAnalyzerV3NonAot(CompilerDiagnostics.Errors, languageVersion, sources, diagnostics);
 #if NETCOREAPP
-		await VerifyAnalyzerV3Aot(languageVersion, sources, diagnostics);
+		await VerifyAnalyzerV3Aot(CompilerDiagnostics.Errors, languageVersion, sources, diagnostics);
+#endif
+	}
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	/// <remarks>
+	/// If <paramref name="languageVersion"/> is less than 13, then AOT tests will be run
+	/// against version 13 (the minimum required for .NET 9).
+	/// </remarks>
+	public static async Task VerifyAnalyzerV3(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string[] sources,
+		params DiagnosticResult[] diagnostics)
+	{
+		await VerifyAnalyzerV3NonAot(compilerDiagnostics, languageVersion, sources, diagnostics);
+#if NETCOREAPP
+		await VerifyAnalyzerV3Aot(compilerDiagnostics, languageVersion, sources, diagnostics);
 #endif
 	}
 
@@ -293,7 +590,20 @@ public partial class CSharpVerifier<TAnalyzer>
 	public static Task VerifyAnalyzerV3Aot(
 		string source,
 		params DiagnosticResult[] diagnostics) =>
-			VerifyAnalyzerV3Aot(LanguageVersion.CSharp13, [source], diagnostics);
+			VerifyAnalyzerV3Aot(CompilerDiagnostics.Errors, LanguageVersion.CSharp13, [source], diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3 (Native AOT), using C# 13.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV3Aot(
+		CompilerDiagnostics compilerDiagnostics,
+		string source,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV3Aot(compilerDiagnostics, LanguageVersion.CSharp13, [source], diagnostics);
 
 	/// <summary>
 	/// Runs code for analysis, against xUnit.net v3 (Native AOT), using the provided version of C#.
@@ -306,7 +616,22 @@ public partial class CSharpVerifier<TAnalyzer>
 		LanguageVersion languageVersion,
 		string source,
 		params DiagnosticResult[] diagnostics) =>
-			VerifyAnalyzerV3Aot(languageVersion, [source], diagnostics);
+			VerifyAnalyzerV3Aot(CompilerDiagnostics.Errors, languageVersion, [source], diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3 (Native AOT), using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV3Aot(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string source,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV3Aot(compilerDiagnostics, languageVersion, [source], diagnostics);
 
 	/// <summary>
 	/// Runs code for analysis, against xUnit.net v3 (Native AOT), using C# 13.
@@ -317,7 +642,20 @@ public partial class CSharpVerifier<TAnalyzer>
 	public static Task VerifyAnalyzerV3Aot(
 		string[] sources,
 		params DiagnosticResult[] diagnostics) =>
-			VerifyAnalyzerV3Aot(LanguageVersion.CSharp13, sources, diagnostics);
+			VerifyAnalyzerV3Aot(CompilerDiagnostics.Errors, LanguageVersion.CSharp13, sources, diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3 (Native AOT), using C# 13.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV3Aot(
+		CompilerDiagnostics compilerDiagnostics,
+		string[] sources,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV3Aot(compilerDiagnostics, LanguageVersion.CSharp13, sources, diagnostics);
 
 	/// <summary>
 	/// Runs code for analysis, against xUnit.net v3, using the provided version of C#.
@@ -327,6 +665,21 @@ public partial class CSharpVerifier<TAnalyzer>
 	/// <param name="diagnostics">The expected diagnostics (pass none for code that
 	/// should not trigger)</param>
 	public static Task VerifyAnalyzerV3Aot(
+		LanguageVersion languageVersion,
+		string[] sources,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV3Aot(CompilerDiagnostics.Errors, languageVersion, sources, diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV3Aot(
+		CompilerDiagnostics compilerDiagnostics,
 		LanguageVersion languageVersion,
 		string[] sources,
 		params DiagnosticResult[] diagnostics)
@@ -340,6 +693,7 @@ public partial class CSharpVerifier<TAnalyzer>
 		foreach (var source in sources)
 			testAot.TestState.Sources.Add(source);
 
+		testAot.CompilerDiagnostics = compilerDiagnostics;
 		testAot.TestState.ExpectedDiagnostics.AddRange(diagnostics);
 		testAot.DisabledDiagnostics.Add("CS1701");  // assert is net9, core is net8, ignore version drift
 		return testAot.RunAsync();
@@ -356,7 +710,20 @@ public partial class CSharpVerifier<TAnalyzer>
 	public static Task VerifyAnalyzerV3NonAot(
 		string source,
 		params DiagnosticResult[] diagnostics) =>
-			VerifyAnalyzerV3NonAot(LanguageVersion.CSharp6, [source], diagnostics);
+			VerifyAnalyzerV3NonAot(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, [source], diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV3NonAot(
+		CompilerDiagnostics compilerDiagnostics,
+		string source,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV3NonAot(compilerDiagnostics, LanguageVersion.CSharp6, [source], diagnostics);
 
 	/// <summary>
 	/// Runs code for analysis, against xUnit.net v3, using the provided version of C#.
@@ -369,7 +736,22 @@ public partial class CSharpVerifier<TAnalyzer>
 		LanguageVersion languageVersion,
 		string source,
 		params DiagnosticResult[] diagnostics) =>
-			VerifyAnalyzerV3NonAot(languageVersion, [source], diagnostics);
+			VerifyAnalyzerV3NonAot(CompilerDiagnostics.Errors, languageVersion, [source], diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3, using the provided version of C#.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
+	/// <param name="source">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV3NonAot(
+		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
+		string source,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV3NonAot(compilerDiagnostics, languageVersion, [source], diagnostics);
 
 	/// <summary>
 	/// Runs code for analysis, against xUnit.net v3, using C# 6.
@@ -380,7 +762,20 @@ public partial class CSharpVerifier<TAnalyzer>
 	public static Task VerifyAnalyzerV3NonAot(
 		string[] sources,
 		params DiagnosticResult[] diagnostics) =>
-			VerifyAnalyzerV3NonAot(LanguageVersion.CSharp6, sources, diagnostics);
+			VerifyAnalyzerV3NonAot(CompilerDiagnostics.Errors, LanguageVersion.CSharp6, sources, diagnostics);
+
+	/// <summary>
+	/// Runs code for analysis, against xUnit.net v3, using C# 6.
+	/// </summary>
+	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="sources">The code to verify</param>
+	/// <param name="diagnostics">The expected diagnostics (pass none for code that
+	/// should not trigger)</param>
+	public static Task VerifyAnalyzerV3NonAot(
+		CompilerDiagnostics compilerDiagnostics,
+		string[] sources,
+		params DiagnosticResult[] diagnostics) =>
+			VerifyAnalyzerV3NonAot(compilerDiagnostics, LanguageVersion.CSharp6, sources, diagnostics);
 
 	/// <summary>
 	/// Runs code for analysis, against xUnit.net v3, using the provided version of C#.
@@ -392,43 +787,20 @@ public partial class CSharpVerifier<TAnalyzer>
 	public static Task VerifyAnalyzerV3NonAot(
 		LanguageVersion languageVersion,
 		string[] sources,
-		params DiagnosticResult[] diagnostics)
-	{
-		var test = new TestV3(languageVersion);
-
-		foreach (var source in sources)
-			test.TestState.Sources.Add(source);
-
-		test.TestState.ExpectedDiagnostics.AddRange(diagnostics);
-		return test.RunAsync();
-	}
-
-	/// <summary>
-	/// Runs code for analysis, against xUnit.net v3, using C# 6, with compiler
-	/// diagnostics verification disabled.
-	/// </summary>
-	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
-	/// <param name="source">The code to verify</param>
-	/// <param name="diagnostics">The expected diagnostics (pass none for code that
-	/// should not trigger)</param>
-	public static Task VerifyAnalyzerV3NonAot(
-		CompilerDiagnostics compilerDiagnostics,
-		string source,
 		params DiagnosticResult[] diagnostics) =>
-			VerifyAnalyzerV3NonAot(LanguageVersion.CSharp6, compilerDiagnostics, [source], diagnostics);
+			VerifyAnalyzerV3NonAot(CompilerDiagnostics.Errors, languageVersion, sources, diagnostics);
 
 	/// <summary>
-	/// Runs code for analysis, against xUnit.net v3, using the provided version of C#, with
-	/// the specified level of compiler diagnostics verification.
+	/// Runs code for analysis, against xUnit.net v3, using the provided version of C#.
 	/// </summary>
-	/// <param name="languageVersion">The language version to compile with</param>
 	/// <param name="compilerDiagnostics">The level of compiler diagnostics to verify</param>
+	/// <param name="languageVersion">The language version to compile with</param>
 	/// <param name="sources">The code to verify</param>
 	/// <param name="diagnostics">The expected diagnostics (pass none for code that
 	/// should not trigger)</param>
 	public static Task VerifyAnalyzerV3NonAot(
-		LanguageVersion languageVersion,
 		CompilerDiagnostics compilerDiagnostics,
+		LanguageVersion languageVersion,
 		string[] sources,
 		params DiagnosticResult[] diagnostics)
 	{
@@ -438,7 +810,6 @@ public partial class CSharpVerifier<TAnalyzer>
 			test.TestState.Sources.Add(source);
 
 		test.CompilerDiagnostics = compilerDiagnostics;
-
 		test.TestState.ExpectedDiagnostics.AddRange(diagnostics);
 		return test.RunAsync();
 	}


### PR DESCRIPTION
### Background

This PR addresses a StackOverflowException observed when running analyzer tests
(X3006 and X3007), particularly on macOS CI, discovered while working on
https://github.com/xunit/xunit.analyzers/pull/207.

The issue appears to be triggered by the diagnostic matching logic in
Microsoft.CodeAnalysis.Testing (see dotnet/roslyn-sdk#1253), where a large number
of similar compiler diagnostics can lead to very deep recursion in the matching
algorithm.

The previous tests used the {{CS0535("ITestCase", 19)}} pattern, which produces
many identical compiler diagnostics for missing interface implementations. These
diagnostics are not relevant to the analyzer behavior being tested, but they
significantly increase matching complexity.

---

### Fix

This change simplifies the tests and avoids generating large numbers of compiler
diagnostics:

- Removed the CS0535-based diagnostic generation from X3006 and X3007 tests
- Updated test sources to use direct interface implementations (e.g., `: ITestCase`)
- Configured the verifier to use `CompilerDiagnostics.None` for these cases,
  since compiler errors (CS0535) are expected but not relevant to analyzer behavior
- Added overloads to `VerifyAnalyzerV3NonAot` to support configuring compiler diagnostics

This keeps the tests focused on validating analyzer behavior (xUnit3006/xUnit3007)
while avoiding excessive diagnostic matching.

---

### Notes

- The core analyzer logic is unchanged—this is purely a structural update to the tests.
- The tests continue to validate analyzer diagnostics and arguments as before.
- CS0535 compiler errors are expected in these scenarios due to incomplete interface implementations, but they are not relevant to the analyzer behavior being tested. Ignoring them keeps the tests focused and avoids excessive diagnostic matching.

---

### Related

- https://github.com/xunit/xunit/issues/3535