### PR TITLE
Add xUnit1054: Timeout tests should reference TestContext.Current.CancellationToken

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/TestMethodWithTimeoutShouldUseCancellationTokenTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/TestMethodWithTimeoutShouldUseCancellationTokenTests.cs
@@ -1,0 +1,180 @@
+using System.Threading.Tasks;
+using Xunit;
+using Verify = CSharpVerifier<Xunit.Analyzers.TestMethodWithTimeoutShouldUseCancellationToken>;
+
+public class TestMethodWithTimeoutShouldUseCancellationTokenTests
+{
+	[Fact]
+	public async Task NoTimeout_DoesNotTrigger()
+	{
+		var source = /* lang=c#-test */ """
+			using System.Threading;
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					Thread.Sleep(1);
+				}
+			}
+			""";
+
+		await Verify.VerifyAnalyzerV3(source);
+	}
+
+	[Fact]
+	public async Task ZeroTimeout_DoesNotTrigger()
+	{
+		var source = /* lang=c#-test */ """
+			using System.Threading;
+			using Xunit;
+
+			public class TestClass {
+				[Fact(Timeout = 0)]
+				public void TestMethod() {
+					Thread.Sleep(1);
+				}
+			}
+			""";
+
+		await Verify.VerifyAnalyzerV3(source);
+	}
+
+	[Fact]
+	public async Task TimeoutWithDirectCancellationTokenReference_DoesNotTrigger()
+	{
+		var source = /* lang=c#-test */ """
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass {
+				[Fact(Timeout = 1000)]
+				public async Task TestMethod() {
+					await Task.Delay(1, TestContext.Current.CancellationToken);
+				}
+			}
+			""";
+
+		await Verify.VerifyAnalyzerV3(source);
+	}
+
+	[Fact]
+	public async Task TimeoutWithCancellationTokenViaLocal_DoesNotTrigger()
+	{
+		var source = /* lang=c#-test */ """
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass {
+				[Fact(Timeout = 1000)]
+				public async Task TestMethod() {
+					var token = TestContext.Current.CancellationToken;
+					await Task.Delay(1, token);
+				}
+			}
+			""";
+
+		await Verify.VerifyAnalyzerV3(source);
+	}
+
+	[Fact]
+	public async Task TimeoutWithCancellationTokenReferencedInLambda_DoesNotTrigger()
+	{
+		var source = /* lang=c#-test */ """
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass {
+				[Fact(Timeout = 1000)]
+				public async Task TestMethod() {
+					await Assert.ThrowsAsync<System.OperationCanceledException>(
+						async () => await Task.Delay(1000, TestContext.Current.CancellationToken));
+				}
+			}
+			""";
+
+		await Verify.VerifyAnalyzerV3(source);
+	}
+
+	[Fact]
+	public async Task TimeoutWithoutCancellationTokenReference_Triggers()
+	{
+		var source = /* lang=c#-test */ """
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass {
+				[Fact({|#0:Timeout = 1000|})]
+				public async Task TestMethod() {
+					await Task.Delay(1);
+				}
+			}
+			""";
+		var expected = Verify.Diagnostic().WithLocation(0).WithArguments("TestMethod");
+
+		await Verify.VerifyAnalyzerV3(source, expected);
+	}
+
+	[Fact]
+	public async Task TheoryWithTimeoutWithoutCancellationTokenReference_Triggers()
+	{
+		var source = /* lang=c#-test */ """
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass {
+				[Theory({|#0:Timeout = 1000|})]
+				[InlineData(1)]
+				public async Task TestMethod(int _) {
+					await Task.Delay(1);
+				}
+			}
+			""";
+		var expected = Verify.Diagnostic().WithLocation(0).WithArguments("TestMethod");
+
+		await Verify.VerifyAnalyzerV3(source, expected);
+	}
+
+	[Fact]
+	public async Task DerivedFactWithTimeoutWithoutCancellationTokenReference_Triggers()
+	{
+		var source = /* lang=c#-test */ """
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public sealed class MyFactAttribute : FactAttribute {
+				public MyFactAttribute(
+					[System.Runtime.CompilerServices.CallerFilePath] string sourceFilePath = "",
+					[System.Runtime.CompilerServices.CallerLineNumber] int sourceLineNumber = -1)
+					: base(sourceFilePath, sourceLineNumber) { }
+			}
+
+			public class TestClass {
+				[MyFact({|#0:Timeout = 1000|})]
+				public async Task TestMethod() {
+					await Task.Delay(1);
+				}
+			}
+			""";
+		var expected = Verify.Diagnostic().WithLocation(0).WithArguments("TestMethod");
+
+		await Verify.VerifyAnalyzerV3(source, expected);
+	}
+
+	[Fact]
+	public async Task NonTestMethodWithoutCancellationToken_DoesNotTrigger()
+	{
+		var source = /* lang=c#-test */ """
+			using System.Threading.Tasks;
+			using Xunit;
+
+			public class TestClass {
+				public async Task HelperMethod() {
+					await Task.Delay(1);
+				}
+			}
+			""";
+
+		await Verify.VerifyAnalyzerV3(source);
+	}
+}

--- a/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
@@ -492,7 +492,14 @@ public static partial class Descriptors
 			"The member {0} referenced by MemberData is not initialized before use. Add an inline initializer or initialize the value in the static constructor."
 		);
 
-	// Placeholder for rule X1054
+	public static DiagnosticDescriptor X1054_TestMethodWithTimeoutShouldUseCancellationToken { get; } =
+		Diagnostic(
+			"xUnit1054",
+			"Test methods with a Timeout should reference TestContext.Current.CancellationToken",
+			Usage,
+			Warning,
+			"Test method '{0}' has a Timeout but does not reference TestContext.Current.CancellationToken. Tests with a Timeout should reference TestContext.Current.CancellationToken so they can terminate promptly when the timeout is exceeded."
+		);
 
 	// Placeholder for rule X1055
 

--- a/src/xunit.analyzers/X1000/TestMethodWithTimeoutShouldUseCancellationToken.cs
+++ b/src/xunit.analyzers/X1000/TestMethodWithTimeoutShouldUseCancellationToken.cs
@@ -1,0 +1,108 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Xunit.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class TestMethodWithTimeoutShouldUseCancellationToken() :
+	XunitV3DiagnosticAnalyzer(Descriptors.X1054_TestMethodWithTimeoutShouldUseCancellationToken)
+{
+	public override void AnalyzeCompilation(
+		CompilationStartAnalysisContext context,
+		XunitContext xunitContext)
+	{
+		Guard.ArgumentNotNull(context);
+		Guard.ArgumentNotNull(xunitContext);
+
+		var factAttributeType = xunitContext.Core.FactAttributeType;
+		if (factAttributeType is null)
+			return;
+
+		var testContextType = TypeSymbolFactory.TestContext_V3(context.Compilation);
+		if (testContextType is null)
+			return;
+
+		var cancellationTokenProperty = testContextType
+			.GetMembers("CancellationToken")
+			.OfType<IPropertySymbol>()
+			.FirstOrDefault();
+		if (cancellationTokenProperty is null)
+			return;
+
+		context.RegisterOperationBlockAction(ctx =>
+		{
+			if (ctx.OwningSymbol is not IMethodSymbol method)
+				return;
+
+			if (ctx.OperationBlocks.Length == 0)
+				return;
+
+			var timeoutAttribute = TryGetTimeoutAttribute(method, factAttributeType);
+			if (timeoutAttribute is null)
+				return;
+
+			foreach (var block in ctx.OperationBlocks)
+				foreach (var descendant in block.DescendantsAndSelf())
+					if (descendant is IPropertyReferenceOperation propertyReference
+							&& SymbolEqualityComparer.Default.Equals(propertyReference.Property, cancellationTokenProperty))
+						return;
+
+			var location = GetTimeoutLocation(timeoutAttribute) ?? method.Locations.FirstOrDefault();
+			if (location is null)
+				return;
+
+			ctx.ReportDiagnostic(
+				Diagnostic.Create(
+					Descriptors.X1054_TestMethodWithTimeoutShouldUseCancellationToken,
+					location,
+					method.Name
+				)
+			);
+		});
+	}
+
+	static AttributeData? TryGetTimeoutAttribute(
+		IMethodSymbol method,
+		INamedTypeSymbol factAttributeType)
+	{
+		foreach (var attribute in method.GetAttributes())
+		{
+			if (attribute.AttributeClass is null)
+				continue;
+
+			var isFactLike = false;
+			for (var current = attribute.AttributeClass; current is not null; current = current.BaseType)
+				if (SymbolEqualityComparer.Default.Equals(current, factAttributeType))
+				{
+					isFactLike = true;
+					break;
+				}
+
+			if (!isFactLike)
+				continue;
+
+			foreach (var named in attribute.NamedArguments)
+				if (named.Key == "Timeout" && named.Value.Value is int timeout && timeout > 0)
+					return attribute;
+		}
+
+		return null;
+	}
+
+	static Location? GetTimeoutLocation(AttributeData attribute)
+	{
+		if (attribute.ApplicationSyntaxReference?.GetSyntax() is not AttributeSyntax attributeSyntax)
+			return null;
+
+		if (attributeSyntax.ArgumentList is { } argumentList)
+			foreach (var argument in argumentList.Arguments)
+				if (argument.NameEquals?.Name.Identifier.ValueText == "Timeout")
+					return argument.GetLocation();
+
+		return attributeSyntax.GetLocation();
+	}
+}


### PR DESCRIPTION
Fixes xunit/xunit#2977.

Adds a new v3-only analyzer `xUnit1054` that flags any test method annotated with a `Fact`-derived attribute and a non-zero `Timeout` whose body contains no reference to `TestContext.Current.CancellationToken`. Per the issue, tests with a timeout should be paying attention to the cancellation token so they can terminate promptly when the timeout is exceeded — this surfaces the omission at build time.

## What the analyzer does
- Runs only when v3 references are present (`XunitV3DiagnosticAnalyzer`).
- For each method symbol with an attribute whose attribute class derives from `FactAttribute` and whose `Timeout` named argument is a positive integer, walks the method's operation blocks (including lambdas and local functions) looking for any `IPropertyReferenceOperation` that resolves to `Xunit.TestContext.CancellationToken`.
- If none is found, reports at the `Timeout = ...` attribute argument (falling back to the attribute / method location).
- Per the issue, "reference anywhere in the body" is sufficient — we don't inspect which APIs receive the token, only that the test body is aware of it. This matches the complementary `xUnit1051` which handles the per-invocation case.

## Why at the attribute-argument location
The violation is about the test's contract (it promised to respect `Timeout`), so the squiggle should point at `Timeout = 1000` rather than the method body. Method location is used as a fallback for custom attribute application shapes.

## What's out of scope
- Custom `Fact`-derived attributes that set `Timeout` in the constructor rather than as a named argument at the call site. The analyzer only inspects the syntactic `NamedArguments` on the attribute application, mirroring how `Timeout` is normally authored. Happy to extend if the maintainers prefer.
- Class-level capture of `TestContext.Current.CancellationToken` into a field. The issue describes the check as "somewhere in the body of the test", so per-method scope seemed correct; again, happy to broaden.

## Tests
`TestMethodWithTimeoutShouldUseCancellationTokenTests` covers:
- No `Timeout` → no diagnostic.
- `Timeout = 0` → no diagnostic.
- `Timeout = 1000` with direct / via-local / in-lambda references to `TestContext.Current.CancellationToken` → no diagnostic.
- `[Fact(Timeout = 1000)]` with no reference → diagnostic.
- `[Theory(Timeout = 1000)]` with no reference → diagnostic.
- `[MyFact(Timeout = 1000)]` (derived attribute) with no reference → diagnostic.
- Non-test method without any reference → no diagnostic.

## Checklist
- [x] I've read the guidelines for contributing.
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team. *(Opening this PR as the planned approach — happy to discuss on the issue first if preferred; the issue itself has a clear spec and no open questions, so it seemed lighter-weight to propose in code.)*
- [ ] The code builds and tests pass locally. *(Could not verify locally — my machine only has .NET SDK 8 installed and the repo requires 10. Relying on CI.)*
- [x] Commit message follows the repo format.
- [x] Tests for the change have been added.
- [x] Code follows the same patterns and style as existing code in this repo.