### PR TITLE
Improve xUnit1045 to suppress diagnostic when all TheoryData values are provably serializable

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/X1045_TheoryDataTypeArgumentsShouldBeSerializableTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/X1045_TheoryDataTypeArgumentsShouldBeSerializableTests.cs
@@ -22,9 +22,9 @@ public class X1045_TheoryDataTypeArgumentsShouldBeSerializableTests
 
 			public class ObjectClass {
 				public sealed class Class : TheoryData<object> { }
-				public static readonly TheoryData<object> Field = new TheoryData<object>() { };
-				public static TheoryData<object> Method(int a, string b) => new TheoryData<object>() { };
-				public static TheoryData<object> Property => new TheoryData<object>() { };
+				public static readonly TheoryData<object> Field = new TheoryData<object>() { new object() };
+				public static TheoryData<object> Method(int a, string b) => new TheoryData<object>() { new object() };
+				public static TheoryData<object> Property => new TheoryData<object>() { new object() };
 
 				[Theory]
 				[MemberData(nameof(Field), DisableDiscoveryEnumeration = true)]
@@ -39,6 +39,28 @@ public class X1045_TheoryDataTypeArgumentsShouldBeSerializableTests
 				[{|xUnit1045:MemberData(nameof(Property))|}]
 				public void Triggers(object parameter) { }
 			}
+
+			public class SafeObjectClass {
+				public static readonly TheoryData<object> Field = new TheoryData<object>() { { (object)1 }, { (object)"test" } };
+				public static TheoryData<object> Method(int a, string b) => new TheoryData<object>() { { (object)1 }, { (object)"test" } };
+				public static TheoryData<object> Property => new TheoryData<object>() { { (object)1 }, { (object)"test" } };
+
+				[Theory]
+				[MemberData(nameof(Field))]
+				[MemberData(nameof(Method), 1, "2")]
+				[MemberData(nameof(Property))]
+				public void DoesNotTriggerWhenInitializedWithSerializableValues(object parameter) { }
+			}
+
+			public class UnsafeObjectClass {
+				public static readonly TheoryData<object> Field = new TheoryData<object>() { { (object)1 }, { (object)new NonSerializableClass() } };
+
+				[Theory]
+				[{|xUnit1045:MemberData(nameof(Field))|}]
+				public void TriggersWhenMixedSerializableAndNonSerializable(object parameter) { }
+			}
+
+			public sealed class NonSerializableClass { }
 
 			public class IPossiblySerializableInterfaceClass {
 				public sealed class Class : TheoryData<IPossiblySerializableInterface> { }
@@ -248,9 +270,9 @@ public class X1045_TheoryDataTypeArgumentsShouldBeSerializableTests
 
 			public class ObjectClass {
 				public sealed class Class : TheoryData<object> { }
-				public static readonly TheoryData<object> Field = new TheoryData<object>() { };
-				public static TheoryData<object> Method(int a, string b) => new TheoryData<object>() { };
-				public static TheoryData<object> Property => new TheoryData<object>() { };
+				public static readonly TheoryData<object> Field = new TheoryData<object>() { new object() };
+				public static TheoryData<object> Method(int a, string b) => new TheoryData<object>() { new object() };
+				public static TheoryData<object> Property => new TheoryData<object>() { new object() };
 
 				[Theory(DisableDiscoveryEnumeration = true)]
 				[ClassData(typeof(Class))]
@@ -265,6 +287,26 @@ public class X1045_TheoryDataTypeArgumentsShouldBeSerializableTests
 				[{|xUnit1045:MemberData(nameof(Method), 1, "2")|}]
 				[{|xUnit1045:MemberData(nameof(Property))|}]
 				public void Triggers(object parameter) { }
+			}
+
+			public class SafeObjectClass {
+				public static readonly TheoryData<object> Field = new TheoryData<object>() { { (object)1 }, { (object)"test" } };
+				public static TheoryData<object> Method(int a, string b) => new TheoryData<object>() { { (object)1 }, { (object)"test" } };
+				public static TheoryData<object> Property => new TheoryData<object>() { { (object)1 }, { (object)"test" } };
+
+				[Theory]
+				[MemberData(nameof(Field))]
+				[MemberData(nameof(Method), 1, "2")]
+				[MemberData(nameof(Property))]
+				public void DoesNotTriggerWhenInitializedWithSerializableValues(object parameter) { }
+			}
+
+			public class UnsafeObjectClass {
+				public static readonly TheoryData<object> Field = new TheoryData<object>() { { (object)1 }, { (object)new NonSerializableSealedClass() } };
+
+				[Theory]
+				[{|xUnit1045:MemberData(nameof(Field))|}]
+				public void TriggersWhenMixedSerializableAndNonSerializable(object parameter) { }
 			}
 
 			public class IPossiblySerializableInterfaceClass {

--- a/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
+++ b/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
@@ -52,45 +52,48 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 				return;
 
 			var methodAttributes = method.GetAttributes();
-			foreach (var attributeList in methodSyntax.AttributeLists)
+			foreach (var dataAttributeSyntax in methodSyntax.AttributeLists.SelectMany(al => al.Attributes))
 			{
-				foreach (var dataAttributeSyntax in attributeList.Attributes)
+				var dataAttribute = methodAttributes.FirstOrDefault(a => a.ApplicationSyntaxReference?.GetSyntax(cancellationToken) == dataAttributeSyntax);
+				if (dataAttribute == null || !dataAttribute.IsInstanceOf(typeSymbols.DataAttribute))
+					continue;
+
+				cancellationToken.ThrowIfCancellationRequested();
+
+				var (types, dataSource) = finder.FindTypeArgumentsInfo(dataAttribute, testClass);
+
+				foreach (var type in types)
 				{
-					var dataAttribute = methodAttributes.FirstOrDefault(a => a.ApplicationSyntaxReference?.GetSyntax(cancellationToken) == dataAttributeSyntax);
-					if (dataAttribute == null || !dataAttribute.IsInstanceOf(typeSymbols.DataAttribute))
+					if (analyzer.TypeShouldBeIgnored(type))
 						continue;
-					cancellationToken.ThrowIfCancellationRequested();
 
-					var (types, dataSource) = finder.FindTypeArgumentsInfo(dataAttribute, testClass);
+					var serializability = analyzer.AnalyzeSerializability(type, xunitContext);
 
-					foreach (var type in types)
+					if (serializability != Serializability.AlwaysSerializable)
 					{
-						if (analyzer.TypeShouldBeIgnored(type))
+						if (serializability == Serializability.PossiblySerializable
+								&& CanStaticallyVerifyAllValuesAreSerializable(dataSource, semanticModel, analyzer, xunitContext, cancellationToken))
 							continue;
 
-						var serializability = analyzer.AnalyzeSerializability(type, xunitContext);
-
-						if (serializability != Serializability.AlwaysSerializable)
-						{
-							if (serializability == Serializability.PossiblySerializable
-							&& CanStaticallyVerifyAllValuesAreSerializable(dataSource, semanticModel, analyzer, xunitContext, cancellationToken))
-								continue;
-
-							context.ReportDiagnostic(
-								Diagnostic.Create(
-									serializability == Serializability.NeverSerializable
-										? Descriptors.X1044_AvoidUsingTheoryDataTypeArgumentsThatAreNotSerializable
-										: Descriptors.X1045_AvoidUsingTheoryDataTypeArgumentsThatMightNotBeSerializable,
-									dataAttributeSyntax.GetLocation(),
-									type.ToMinimalDisplayString(semanticModel, dataAttributeSyntax.SpanStart)
-								)
-							);
-						}
+						context.ReportDiagnostic(
+							Diagnostic.Create(
+								serializability == Serializability.NeverSerializable
+									? Descriptors.X1044_AvoidUsingTheoryDataTypeArgumentsThatAreNotSerializable
+									: Descriptors.X1045_AvoidUsingTheoryDataTypeArgumentsThatMightNotBeSerializable,
+								dataAttributeSyntax.GetLocation(),
+								type.ToMinimalDisplayString(semanticModel, dataAttributeSyntax.SpanStart)
+							)
+						);
 					}
 				}
 			}
 		}, SyntaxKind.MethodDeclaration);
 	}
+
+	static bool AttributeIsTheoryOrDataAttribute(
+		AttributeData attribute,
+		SerializableTypeSymbols typeSymbols) =>
+			attribute.IsInstanceOf(typeSymbols.TheoryAttribute, exactMatch: true) || attribute.IsInstanceOf(typeSymbols.DataAttribute);
 
 	static bool CanStaticallyVerifyAllValuesAreSerializable(
 		ISymbol? dataSource,
@@ -136,11 +139,9 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 			{
 				initializerExpression = method.ExpressionBody?.Expression;
 				if (initializerExpression == null && method.Body?.Statements.Count == 1 && method.Body.Statements[0] is ReturnStatementSyntax returnStmt)
-				{
 					initializerExpression = returnStmt.Expression;
-				}
 			}
-			else if (syntax is ClassDeclarationSyntax _)
+			else if (syntax is ClassDeclarationSyntax)
 			{
 				return false;
 			}
@@ -156,6 +157,15 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 
 		return foundAnyInitializer;
 	}
+
+	static bool DiscoveryEnumerationIsDisabled(
+		IMethodSymbol method,
+		SerializableTypeSymbols typeSymbols) =>
+			method
+				.GetAttributes()
+				.Where(attribute => AttributeIsTheoryOrDataAttribute(attribute, typeSymbols))
+				.SelectMany(attribute => attribute.NamedArguments)
+				.Any(argument => argument.Key == "DisableDiscoveryEnumeration" && argument.Value.Value is true);
 
 	static bool IsExpressionAllSerializable(
 		ExpressionSyntax expression,
@@ -183,16 +193,11 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 			if (element is InitializerExpressionSyntax complexElement)
 			{
 				foreach (var innerElement in complexElement.Expressions)
-				{
 					if (!IsValueSerializable(innerElement, model, analyzer, xunitContext, cancellationToken))
 						return false;
-				}
 			}
-			else
-			{
-				if (!IsValueSerializable(element, model, analyzer, xunitContext, cancellationToken))
-					return false;
-			}
+			else if (!IsValueSerializable(element, model, analyzer, xunitContext, cancellationToken))
+				return false;
 		}
 
 		return true;
@@ -225,20 +230,6 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 
 		return true;
 	}
-
-	static bool AttributeIsTheoryOrDataAttribute(
-		AttributeData attribute,
-		SerializableTypeSymbols typeSymbols) =>
-			attribute.IsInstanceOf(typeSymbols.TheoryAttribute, exactMatch: true) || attribute.IsInstanceOf(typeSymbols.DataAttribute);
-
-	static bool DiscoveryEnumerationIsDisabled(
-		IMethodSymbol method,
-		SerializableTypeSymbols typeSymbols) =>
-			method
-				.GetAttributes()
-				.Where(attribute => AttributeIsTheoryOrDataAttribute(attribute, typeSymbols))
-				.SelectMany(attribute => attribute.NamedArguments)
-				.Any(argument => argument.Key == "DisableDiscoveryEnumeration" && argument.Value.Value is true);
 
 	sealed class TheoryDataTypeArgumentFinder(SerializableTypeSymbols typeSymbols)
 	{

--- a/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
+++ b/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -50,39 +51,178 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 			if (DiscoveryEnumerationIsDisabled(method, typeSymbols))
 				return;
 
-			var dataAttributes =
-				methodSyntax
-					.AttributeLists
-					.SelectMany(list => list.Attributes)
-					.Zip(method.GetAttributes(), (attributeSyntax, attribute) => (attributeSyntax, attribute))
-					.Where((tuple) => tuple.attribute.IsInstanceOf(typeSymbols.DataAttribute));
-
-			foreach ((var dataAttributeSyntax, var dataAttribute) in dataAttributes)
+			var methodAttributes = method.GetAttributes();
+			foreach (var attributeList in methodSyntax.AttributeLists)
 			{
-				cancellationToken.ThrowIfCancellationRequested();
-
-				var types = finder.FindTypeArguments(dataAttribute, testClass);
-
-				foreach (var type in types)
+				foreach (var dataAttributeSyntax in attributeList.Attributes)
 				{
-					if (analyzer.TypeShouldBeIgnored(type))
+					var dataAttribute = methodAttributes.FirstOrDefault(a => a.ApplicationSyntaxReference?.GetSyntax(cancellationToken) == dataAttributeSyntax);
+					if (dataAttribute == null || !dataAttribute.IsInstanceOf(typeSymbols.DataAttribute))
 						continue;
+					cancellationToken.ThrowIfCancellationRequested();
 
-					var serializability = analyzer.AnalyzeSerializability(type, xunitContext);
+					var (types, dataSource) = finder.FindTypeArgumentsInfo(dataAttribute, testClass);
 
-					if (serializability != Serializability.AlwaysSerializable)
-						context.ReportDiagnostic(
-							Diagnostic.Create(
-								serializability == Serializability.NeverSerializable
-									? Descriptors.X1044_AvoidUsingTheoryDataTypeArgumentsThatAreNotSerializable
-									: Descriptors.X1045_AvoidUsingTheoryDataTypeArgumentsThatMightNotBeSerializable,
-								dataAttributeSyntax.GetLocation(),
-								type.ToMinimalDisplayString(semanticModel, dataAttributeSyntax.SpanStart)
-							)
-						);
+					foreach (var type in types)
+					{
+						if (analyzer.TypeShouldBeIgnored(type))
+							continue;
+
+						var serializability = analyzer.AnalyzeSerializability(type, xunitContext);
+
+						if (serializability != Serializability.AlwaysSerializable)
+						{
+							if (CanStaticallyVerifyAllValuesAreSerializable(dataSource, semanticModel, analyzer, xunitContext, cancellationToken))
+								continue;
+
+							context.ReportDiagnostic(
+								Diagnostic.Create(
+									serializability == Serializability.NeverSerializable
+										? Descriptors.X1044_AvoidUsingTheoryDataTypeArgumentsThatAreNotSerializable
+										: Descriptors.X1045_AvoidUsingTheoryDataTypeArgumentsThatMightNotBeSerializable,
+									dataAttributeSyntax.GetLocation(),
+									type.ToMinimalDisplayString(semanticModel, dataAttributeSyntax.SpanStart)
+								)
+							);
+						}
+					}
 				}
 			}
 		}, SyntaxKind.MethodDeclaration);
+	}
+
+	static bool CanStaticallyVerifyAllValuesAreSerializable(
+		ISymbol? dataSource,
+		SemanticModel semanticModel,
+		SerializabilityAnalyzer analyzer,
+		XunitContext xunitContext,
+		CancellationToken cancellationToken)
+	{
+		if (dataSource is null)
+			return false;
+
+		var syntaxReferences = dataSource.DeclaringSyntaxReferences;
+		if (syntaxReferences.Length == 0)
+			return false;
+
+		bool foundAnyInitializer = false;
+
+		foreach (var syntaxRef in syntaxReferences)
+		{
+			var syntax = syntaxRef.GetSyntax(cancellationToken);
+			if (syntax.SyntaxTree != semanticModel.SyntaxTree)
+				return false;
+
+			ExpressionSyntax? initializerExpression = null;
+
+			if (syntax is PropertyDeclarationSyntax property)
+			{
+				initializerExpression = property.Initializer?.Value ?? property.ExpressionBody?.Expression;
+				if (initializerExpression == null && property.AccessorList != null)
+				{
+					var getter = property.AccessorList.Accessors.FirstOrDefault(a => a.Keyword.IsKind(SyntaxKind.GetKeyword));
+					if (getter?.Body?.Statements.Count == 1 && getter.Body.Statements[0] is ReturnStatementSyntax returnStmt)
+						initializerExpression = returnStmt.Expression;
+					else if (getter?.ExpressionBody != null)
+						initializerExpression = getter.ExpressionBody.Expression;
+				}
+			}
+			else if (syntax is VariableDeclaratorSyntax variableDeclarator)
+			{
+				initializerExpression = variableDeclarator.Initializer?.Value;
+			}
+			else if (syntax is MethodDeclarationSyntax method)
+			{
+				initializerExpression = method.ExpressionBody?.Expression;
+				if (initializerExpression == null && method.Body?.Statements.Count == 1 && method.Body.Statements[0] is ReturnStatementSyntax returnStmt)
+				{
+					initializerExpression = returnStmt.Expression;
+				}
+			}
+			else if (syntax is ClassDeclarationSyntax _)
+			{
+				return false;
+			}
+
+			if (initializerExpression == null)
+				continue;
+
+			foundAnyInitializer = true;
+
+			if (!IsExpressionAllSerializable(initializerExpression, semanticModel, analyzer, xunitContext, cancellationToken))
+				return false;
+		}
+
+		return foundAnyInitializer;
+	}
+
+	static bool IsExpressionAllSerializable(
+		ExpressionSyntax expression,
+		SemanticModel model,
+		SerializabilityAnalyzer analyzer,
+		XunitContext xunitContext,
+		CancellationToken cancellationToken)
+	{
+		InitializerExpressionSyntax? initializer = null;
+		if (expression is ObjectCreationExpressionSyntax objCreation)
+			initializer = objCreation.Initializer;
+		else if (expression is ImplicitObjectCreationExpressionSyntax implicitObjCreation)
+			initializer = implicitObjCreation.Initializer;
+
+		if (initializer == null || !initializer.IsKind(SyntaxKind.CollectionInitializerExpression))
+			return false;
+
+		if (initializer.Expressions.Count == 0)
+			return false;
+
+		foreach (var element in initializer.Expressions)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+
+			if (element is InitializerExpressionSyntax complexElement)
+			{
+				foreach (var innerElement in complexElement.Expressions)
+				{
+					if (!IsValueSerializable(innerElement, model, analyzer, xunitContext, cancellationToken))
+						return false;
+				}
+			}
+			else
+			{
+				if (!IsValueSerializable(element, model, analyzer, xunitContext, cancellationToken))
+					return false;
+			}
+		}
+
+		return true;
+	}
+
+	static bool IsValueSerializable(
+		ExpressionSyntax expression,
+		SemanticModel model,
+		SerializabilityAnalyzer analyzer,
+		XunitContext xunitContext,
+		CancellationToken cancellationToken)
+	{
+		var expr = expression;
+		while (true)
+		{
+			if (expr is CastExpressionSyntax castExpr)
+				expr = castExpr.Expression;
+			else if (expr is ParenthesizedExpressionSyntax paren)
+				expr = paren.Expression;
+			else
+				break;
+		}
+
+		if (expr.IsKind(SyntaxKind.NullLiteralExpression))
+			return true;
+
+		var typeInfo = model.GetTypeInfo(expr, cancellationToken);
+		if (typeInfo.Type == null || analyzer.AnalyzeSerializability(typeInfo.Type, xunitContext) != Serializability.AlwaysSerializable)
+			return false;
+
+		return true;
 	}
 
 	static bool AttributeIsTheoryOrDataAttribute(
@@ -109,12 +249,32 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 		/// a generic TheoryData class, such as if it is a member with the type <see cref="IEnumerable{T}"/>
 		/// of <see cref="object"/>[], then no type arguments will be found.
 		/// </summary>
-		public IEnumerable<ITypeSymbol> FindTypeArguments(
+		public (IEnumerable<ITypeSymbol> TypeArguments, ISymbol? DataSource) FindTypeArgumentsInfo(
 			AttributeData dataAttribute,
-			INamedTypeSymbol testClass) =>
-				GetDataSourceType(dataAttribute, testClass) is INamedTypeSymbol type
-					? GetTheoryDataTypeArguments(type)
-					: [];
+			INamedTypeSymbol testClass)
+		{
+			var dataSource = FindDataSourceSymbol(dataAttribute, testClass);
+			var type = dataSource switch
+			{
+				INamedTypeSymbol namedType => namedType,
+				_ => GetMemberType(dataSource) as INamedTypeSymbol
+			};
+
+			return (type is not null ? GetTheoryDataTypeArguments(type) : [], dataSource);
+		}
+
+		ISymbol? FindDataSourceSymbol(
+			AttributeData dataAttribute,
+			INamedTypeSymbol testClass)
+		{
+			if (dataAttribute.IsInstanceOf(typeSymbols.ClassDataAttribute, exactMatch: true))
+				return dataAttribute.ConstructorArguments.FirstOrDefault().Value as INamedTypeSymbol;
+
+			if (dataAttribute.IsInstanceOf(typeSymbols.MemberDataAttribute, exactMatch: true))
+				return GetMemberSymbol(dataAttribute, testClass);
+
+			return null;
+		}
 
 		static IMethodSymbol? GetCompatibleMethod(
 			ITypeSymbol type,
@@ -140,19 +300,6 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 
 				return methods.FirstOrDefault(method => method.Parameters.Length == arguments.Length);
 			}
-
-			return null;
-		}
-
-		INamedTypeSymbol? GetDataSourceType(
-			AttributeData dataAttribute,
-			INamedTypeSymbol testClass)
-		{
-			if (dataAttribute.IsInstanceOf(typeSymbols.ClassDataAttribute, exactMatch: true))
-				return dataAttribute.ConstructorArguments.FirstOrDefault().Value as INamedTypeSymbol;
-
-			if (dataAttribute.IsInstanceOf(typeSymbols.MemberDataAttribute, exactMatch: true))
-				return GetMemberType(dataAttribute, testClass) as INamedTypeSymbol;
 
 			return null;
 		}
@@ -183,7 +330,7 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 		/// <remarks>
 		/// The logic in this method corresponds to the logic in MemberDataAttributeBase.GetData.
 		/// </remarks>
-		static ITypeSymbol? GetMemberType(
+		static ISymbol? GetMemberSymbol(
 			AttributeData memberDataAttribute,
 			INamedTypeSymbol testClass)
 		{
@@ -193,12 +340,9 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 			{
 				var containingType = GetMemberContainingType(memberDataAttribute) ?? testClass;
 
-				var member =
-					GetProperty(containingType, memberName)
+				return GetProperty(containingType, memberName)
 						?? GetField(containingType, memberName)
 						?? GetMethod(containingType, memberName, memberDataAttribute) as ISymbol;
-
-				return GetMemberType(member);
 			}
 
 			return null;

--- a/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
+++ b/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
@@ -72,7 +72,8 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 
 						if (serializability != Serializability.AlwaysSerializable)
 						{
-							if (CanStaticallyVerifyAllValuesAreSerializable(dataSource, semanticModel, analyzer, xunitContext, cancellationToken))
+							if (serializability == Serializability.PossiblySerializable
+							&& CanStaticallyVerifyAllValuesAreSerializable(dataSource, semanticModel, analyzer, xunitContext, cancellationToken))
 								continue;
 
 							context.ReportDiagnostic(


### PR DESCRIPTION
Fixes #2981

### Problem

`xUnit1045` fires for `TheoryData<object>` (and other `PossiblySerializable` type arguments) even when the collection is initialized exclusively with serializable values like primitives, strings, or constants:

```csharp
public static TheoryData<object> Data => new()
{
    { 1 },
    { "hello" },
};

[Theory]
[MemberData(nameof(Data))] // xUnit1045 fires here — false positive
public void Test1(object value) { }
```

### Solution

When the analyzer encounters a `PossiblySerializable` type argument (like `object`), it now performs **value-level inspection** on the data source before reporting `xUnit1045`. It navigates from the `[MemberData]` attribute to the backing member's declaration via `ISymbol.DeclaringSyntaxReferences`, extracts the collection initializer, and checks the compile-time type of every value using the semantic model.

If **all** values are `AlwaysSerializable` (e.g., `int`, `string`, `bool`, `DateTime`, etc.), the diagnostic is suppressed. Otherwise, it fires as before.

> **Note:** This only applies to `xUnit1045` (`PossiblySerializable`). `xUnit1044` (`NeverSerializable`) is never suppressed by value-level inspection, since the type argument itself is definitively non-serializable regardless of values.

### What's supported

- **Fields**: `public static readonly TheoryData<object> Data = new() { { (object)1 } };`
- **Properties**: expression-bodied, initializer-based, and single-return getter bodies
- **Methods**: expression-bodied and single-return methods
- **Cast unwrapping**: `(object)1` is unwrapped to inspect the underlying `int`
- **Constants**: `const int X = 1; new TheoryData<object> { (object)X }` — semantic model resolves the type
- **Null literals**: treated as serializable (xUnit handles null)

### What correctly falls back to warning

- **Empty initializers** `{ }` — can't prove safety, collection may be mutated elsewhere
- **`ClassData`** — can't inspect class internals
- **Data source in a different file** — avoids `RS1030` (`Compilation.GetSemanticModel()` is forbidden in analyzers); also covers partial classes where the member is in a separate file
- **Complex method bodies** — anything beyond a single return/expression body
- **Non-serializable values** — `new SomeClass()` correctly keeps the diagnostic

### Known limitation

The analysis is based on the collection initializer at declaration time. If a `TheoryData<object>` field is initialized with serializable values but later mutated via `Add()` with non-serializable data, the diagnostic will not fire. This is an inherent trade-off of compile-time analysis — the same limitation exists for other initializer-based inspections, and is analogous to the existing `DisableDiscoveryEnumeration` opt-out which also trusts the developer's intent.

### Changes

- `TheoryDataTypeArgumentsShouldBeSerializable.cs` — Added `CanStaticallyVerifyAllValuesAreSerializable`, `IsExpressionAllSerializable`, and `IsValueSerializable` methods. Refactored `TheoryDataTypeArgumentFinder` to expose the data source `ISymbol` alongside the type arguments.
- `X1045_TheoryDataTypeArgumentsShouldBeSerializableTests.cs` — Added `SafeObjectClass` (suppression) and `UnsafeObjectClass` (still fires) test scenarios inline with existing test structure.
