### PR TITLE
Fix InlineData parameter index after invalid literal

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/InlineDataMustMatchTheoryParametersTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/InlineDataMustMatchTheoryParametersTests.cs
@@ -332,6 +332,30 @@ public class InlineDataMustMatchTheoryParametersTests
 
 			await Verify.VerifyAnalyzer(source);
 		}
+
+		// https://github.com/xunit/xunit/issues/3569
+		[Fact]
+		public async Task InvalidLiteralDoesNotDesynchronizeSubsequentParameters()
+		{
+			var source = /* lang=c#-test */ """
+				using Xunit;
+
+				public enum MyEnum {
+					Value1,
+					Value2,
+					Value3
+				}
+
+				public sealed class ReproClass {
+					[Theory]
+					[InlineData({|CS0182:1.1m|}, MyEnum.Value1)]
+					public void ReproMethod(decimal param1, MyEnum param2)
+					{ }
+				}
+				""";
+
+			await Verify.VerifyAnalyzer(source);
+		}
 	}
 
 	public class X1009_TooFewValues

--- a/src/xunit.analyzers/X1000/InlineDataMustMatchTheoryParameters.cs
+++ b/src/xunit.analyzers/X1000/InlineDataMustMatchTheoryParameters.cs
@@ -102,7 +102,12 @@ public class InlineDataMustMatchTheoryParameters : XunitDiagnosticAnalyzer
 					// If the value isn't legal (malformed or illegal type), then just skip validation and let
 					// the compiler report the problem.
 					if (value.Kind == TypedConstantKind.Error)
+					{
+						if (!parameter.IsParams)
+							paramIdx++;
+
 						continue;
+					}
 
 					// If the parameter type is object, everything is compatible, though we still need to check for nullability
 					if (SymbolEqualityComparer.Default.Equals(parameter.Type, compilation.ObjectType)
@@ -171,7 +176,12 @@ public class InlineDataMustMatchTheoryParameters : XunitDiagnosticAnalyzer
 					else
 					{
 						if (value.Type is null)
+						{
+							if (!parameter.IsParams)
+								paramIdx++;
+
 							continue;
+						}
 
 						var isCompatible = ConversionChecker.IsConvertible(compilation, value.Type, parameter.Type, xunitContext, value.Kind == TypedConstantKind.Primitive ? value.Value : null);
 						if (!isCompatible && paramsElementType is not null)


### PR DESCRIPTION
## Summary
- Advances the theory parameter index after an invalid InlineData literal so subsequent values stay aligned with their parameters
- Adds a regression test for the decimal literal + enum parameter scenario from xunit/xunit#3569

Fixes xunit/xunit#3569

## Tests
- `dotnet test src/xunit.analyzers.tests/xunit.analyzers.tests.csproj --filter FullyQualifiedName~InvalidLiteralDoesNotDesynchronizeSubsequentParameters --no-restore`
- `dotnet test src/xunit.analyzers.tests/xunit.analyzers.tests.csproj --filter FullyQualifiedName~X1010_IncompatibleValueType --no-restore`