### PR TITLE
xunit/xunit#3336: Fix xUnit2023 fixer trivia and indentation

### DIFF
--- a/src/xunit.analyzers.fixes/X2000/AssertSingleShouldBeUsedForSingleParameterFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertSingleShouldBeUsedForSingleParameterFixer.cs
@@ -43,7 +43,7 @@ public class AssertSingleShouldBeUsedForSingleParameterFixer : XunitCodeFixProvi
 	static IEnumerable<SyntaxNode> GetLambdaStatements(SimpleLambdaExpressionSyntax lambdaExpression)
 	{
 		if (lambdaExpression.ExpressionBody is InvocationExpressionSyntax lambdaBody)
-			yield return ExpressionStatement(lambdaBody).WithAdditionalAnnotations(Formatter.Annotation, Simplifier.Annotation);
+			yield return ExpressionStatement(lambdaBody.NormalizeWhitespace()).WithAdditionalAnnotations(Formatter.Annotation, Simplifier.Annotation);
 		else if (lambdaExpression.Block is not null && lambdaExpression.Block.Statements.Count != 0)
 			foreach (var statement in lambdaExpression.Block.Statements)
 				yield return statement.WithAdditionalAnnotations(Formatter.Annotation, Simplifier.Annotation);
@@ -69,7 +69,7 @@ public class AssertSingleShouldBeUsedForSingleParameterFixer : XunitCodeFixProvi
 		string parameterName,
 		InvocationExpressionSyntax replacementNode)
 	{
-		var equalsToReplacementNode = EqualsValueClause(replacementNode);
+		var equalsToReplacementNode = EqualsValueClause(replacementNode.WithoutTrivia());
 
 		var oneItemVariableDeclaration = VariableDeclaration(
 			ParseTypeName("var"),

--- a/src/xunit.analyzers.tests/Fixes/X2000/AssertSingleShouldBeUsedForSingleParameterFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/AssertSingleShouldBeUsedForSingleParameterFixerTests.cs
@@ -28,6 +28,66 @@ public class AssertSingleShouldBeUsedForSingleParameterFixerTests
 		await Verify.VerifyCodeFix(LanguageVersion.CSharp8, source, source, AssertSingleShouldBeUsedForSingleParameterFixer.Key_UseSingleMethod);
 	}
 
+	// https://github.com/xunit/xunit/issues/3336
+	[Fact]
+	public async ValueTask ReplacesCommentedAndMultiLineCollections()
+	{
+		var before = /* lang=c#-test */ """
+			using System.Collections.Generic;
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void WithLeadingComment() {
+					// Assert
+					[|Assert.Collection(default(IEnumerable<object>), item => Assert.NotNull(item))|];
+				}
+
+				[Fact]
+				public void WithMultiLineCollection() {
+					[|Assert.Collection(
+						default(IEnumerable<object>),
+						item => Assert.NotNull(item))|];
+				}
+
+				[Fact]
+				public void WithMultiLineInspector() {
+					[|Assert.Collection(default(IEnumerable<string>),
+						item => Assert.Equal(
+							"abc",
+							item))|];
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using System.Collections.Generic;
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void WithLeadingComment() {
+					// Assert
+					var item = Assert.Single(default(IEnumerable<object>));
+					Assert.NotNull(item);
+				}
+
+				[Fact]
+				public void WithMultiLineCollection() {
+					var item = Assert.Single(default(IEnumerable<object>));
+					Assert.NotNull(item);
+				}
+
+				[Fact]
+				public void WithMultiLineInspector() {
+					var item = Assert.Single(default(IEnumerable<string>));
+					Assert.Equal("abc", item);
+				}
+			}
+			""";
+
+		await Verify.VerifyCodeFix(LanguageVersion.CSharp8, before, after, AssertSingleShouldBeUsedForSingleParameterFixer.Key_UseSingleMethod);
+	}
+
 	[Fact]
 	public async ValueTask EnumerableAcceptanceTest()
 	{


### PR DESCRIPTION
Fixes xunit/xunit#3336.

The fixer reused the original invocation and lambda nodes without clearing their trivia, so a `// comment` on the `Assert.Collection` got copied onto the generated `var` line (with its indentation reset to column zero), and a multi-line inspector body kept its old indentation instead of lining up under the new statement.

Stripping the trivia off the reused invocation fixes the comment; normalizing the inspector body fixes the indentation. Added a regression test for a leading comment, a multi-line collection, and a multi-line inspector.