### PR TITLE
Report xUnit1025 for InlineData duplicated via implicit numeric conversion

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/X1025_InlineDataShouldBeUniqueWithinTheoryTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/X1025_InlineDataShouldBeUniqueWithinTheoryTests.cs
@@ -176,6 +176,51 @@ public class X1025_InlineDataShouldBeUniqueWithinTheoryTests
 				[{|#20:InlineData(10)|}]
 				[{|#21:InlineData(20)|}]
 				public void DoubledTwice_TriggersTwice(int n) { }
+
+				// Duplicated data (implicit conversions)
+
+				private const int ConstInt = 1;
+				private const byte ConstByte = 1;
+			
+				[Theory]
+				[InlineData(ConstInt)]
+				[{|#30:InlineData(ConstByte)|}]
+				public void IntAndByteConstants_Triggers(int n) { }
+			
+				[Theory]
+				[InlineData(1)]
+				[{|#31:InlineData((byte)1)|}]
+				public void IntAndByteLiterals_Triggers(int n) { }
+			
+				[Theory]
+				[InlineData(1)]
+				[{|#32:InlineData(1.0)|}]
+				public void IntAndDouble_Triggers(double d) { }
+			
+				[Theory]
+				[InlineData((byte)1, 2L)]
+				[{|#33:InlineData(1, (short)2)|}]
+				public void MixedNumericTypes_Triggers(long x, long y) { }
+			
+				[Theory]
+				[InlineData(1, (byte)2)]
+				[{|#34:InlineData((byte)1, 2)|}]
+				public void ParamsArray_Triggers(params int[] a) { }
+			
+				[Theory]
+				[InlineData]
+				[{|#35:InlineData((byte)1)|}]
+				public void DefaultValue_Triggers(int n = 1) { }
+			
+				[Theory]
+				[InlineData(1)]
+				[{|#36:InlineData((byte)1)|}]
+				public void NullableParameter_Triggers(int? n) { }
+			
+				[Theory]
+				[InlineData('a')]
+				[{|#37:InlineData(97)|}]
+				public void CharAndInt_Triggers(int n) { }
 			}
 
 			#nullable enable
@@ -225,95 +270,19 @@ public class X1025_InlineDataShouldBeUniqueWithinTheoryTests
 			Verify.Diagnostic().WithLocation(19).WithArguments("Tripled_TriggersTwice", "TestClass"),
 			Verify.Diagnostic().WithLocation(20).WithArguments("DoubledTwice_TriggersTwice", "TestClass"),
 			Verify.Diagnostic().WithLocation(21).WithArguments("DoubledTwice_TriggersTwice", "TestClass"),
+			Verify.Diagnostic().WithLocation(30).WithArguments("IntAndByteConstants_Triggers", "TestClass"),
+			Verify.Diagnostic().WithLocation(31).WithArguments("IntAndByteLiterals_Triggers", "TestClass"),
+			Verify.Diagnostic().WithLocation(32).WithArguments("IntAndDouble_Triggers", "TestClass"),
+			Verify.Diagnostic().WithLocation(33).WithArguments("MixedNumericTypes_Triggers", "TestClass"),
+			Verify.Diagnostic().WithLocation(34).WithArguments("ParamsArray_Triggers", "TestClass"),
+			Verify.Diagnostic().WithLocation(35).WithArguments("DefaultValue_Triggers", "TestClass"),
+			Verify.Diagnostic().WithLocation(36).WithArguments("NullableParameter_Triggers", "TestClass"),
+			Verify.Diagnostic().WithLocation(37).WithArguments("CharAndInt_Triggers", "TestClass"),
 
 			Verify.Diagnostic().WithLocation(101).WithArguments("DoubleNullInlineData_Triggers", "NullableTestClass"),
 			Verify.Diagnostic().WithLocation(114).WithArguments("DefaultValueVsNull_Triggers", "NullableTestClass"),
 			Verify.Diagnostic().WithLocation(115).WithArguments("Null_RawValuesVsExplicitArray_Triggers", "NullableTestClass"),
 			Verify.Diagnostic().WithLocation(117).WithArguments("DefaultOfReferenceType_Triggers", "NullableTestClass"),
-		};
-
-		await Verify.VerifyAnalyzer(LanguageVersion.CSharp8, source, expected);
-	}
-
-	[Fact]
-	public async ValueTask ImplicitlyConvertedValues()
-	{
-		var source = /* lang=c#-test */ """
-			using Xunit;
-
-			public class TestClass {
-				private const int ConstInt = 1;
-				private const byte ConstByte = 1;
-
-				// Unique data
-
-				[Theory]
-				[InlineData(1)]
-				[InlineData((byte)2)]
-				public void DifferentValues_DoesNotTrigger(int n) { }
-
-				[Theory]
-				[InlineData(1)]
-				[InlineData((byte)1)]
-				public void ObjectParameter_DoesNotTrigger(object o) { }
-
-				[Theory]
-				[InlineData(0.1f)]
-				[InlineData(0.1)]
-				public void FloatAndDoubleWithPrecisionLoss_DoesNotTrigger(double d) { }
-
-				// Duplicated data
-
-				[Theory]
-				[InlineData(ConstInt)]
-				[{|#0:InlineData(ConstByte)|}]
-				public void IntAndByteConstants_Triggers(int n) { }
-
-				[Theory]
-				[InlineData(1)]
-				[{|#1:InlineData((byte)1)|}]
-				public void IntAndByteLiterals_Triggers(int n) { }
-
-				[Theory]
-				[InlineData(1)]
-				[{|#2:InlineData(1.0)|}]
-				public void IntAndDouble_Triggers(double d) { }
-
-				[Theory]
-				[InlineData((byte)1, 2L)]
-				[{|#3:InlineData(1, (short)2)|}]
-				public void MixedNumericTypes_Triggers(long x, long y) { }
-
-				[Theory]
-				[InlineData(1, (byte)2)]
-				[{|#4:InlineData((byte)1, 2)|}]
-				public void ParamsArray_Triggers(params int[] a) { }
-
-				[Theory]
-				[InlineData]
-				[{|#5:InlineData((byte)1)|}]
-				public void DefaultValue_Triggers(int n = 1) { }
-
-				[Theory]
-				[InlineData(1)]
-				[{|#6:InlineData((byte)1)|}]
-				public void NullableParameter_Triggers(int? n) { }
-
-				[Theory]
-				[InlineData('a')]
-				[{|#7:InlineData(97)|}]
-				public void CharAndInt_Triggers(int n) { }
-			}
-			""";
-		var expected = new[] {
-			Verify.Diagnostic().WithLocation(0).WithArguments("IntAndByteConstants_Triggers", "TestClass"),
-			Verify.Diagnostic().WithLocation(1).WithArguments("IntAndByteLiterals_Triggers", "TestClass"),
-			Verify.Diagnostic().WithLocation(2).WithArguments("IntAndDouble_Triggers", "TestClass"),
-			Verify.Diagnostic().WithLocation(3).WithArguments("MixedNumericTypes_Triggers", "TestClass"),
-			Verify.Diagnostic().WithLocation(4).WithArguments("ParamsArray_Triggers", "TestClass"),
-			Verify.Diagnostic().WithLocation(5).WithArguments("DefaultValue_Triggers", "TestClass"),
-			Verify.Diagnostic().WithLocation(6).WithArguments("NullableParameter_Triggers", "TestClass"),
-			Verify.Diagnostic().WithLocation(7).WithArguments("CharAndInt_Triggers", "TestClass"),
 		};
 
 		await Verify.VerifyAnalyzer(LanguageVersion.CSharp8, source, expected);

--- a/src/xunit.analyzers.tests/Analyzers/X1000/X1025_InlineDataShouldBeUniqueWithinTheoryTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/X1025_InlineDataShouldBeUniqueWithinTheoryTests.cs
@@ -236,6 +236,90 @@ public class X1025_InlineDataShouldBeUniqueWithinTheoryTests
 	}
 
 	[Fact]
+	public async ValueTask ImplicitlyConvertedValues()
+	{
+		var source = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				private const int ConstInt = 1;
+				private const byte ConstByte = 1;
+
+				// Unique data
+
+				[Theory]
+				[InlineData(1)]
+				[InlineData((byte)2)]
+				public void DifferentValues_DoesNotTrigger(int n) { }
+
+				[Theory]
+				[InlineData(1)]
+				[InlineData((byte)1)]
+				public void ObjectParameter_DoesNotTrigger(object o) { }
+
+				[Theory]
+				[InlineData(0.1f)]
+				[InlineData(0.1)]
+				public void FloatAndDoubleWithPrecisionLoss_DoesNotTrigger(double d) { }
+
+				// Duplicated data
+
+				[Theory]
+				[InlineData(ConstInt)]
+				[{|#0:InlineData(ConstByte)|}]
+				public void IntAndByteConstants_Triggers(int n) { }
+
+				[Theory]
+				[InlineData(1)]
+				[{|#1:InlineData((byte)1)|}]
+				public void IntAndByteLiterals_Triggers(int n) { }
+
+				[Theory]
+				[InlineData(1)]
+				[{|#2:InlineData(1.0)|}]
+				public void IntAndDouble_Triggers(double d) { }
+
+				[Theory]
+				[InlineData((byte)1, 2L)]
+				[{|#3:InlineData(1, (short)2)|}]
+				public void MixedNumericTypes_Triggers(long x, long y) { }
+
+				[Theory]
+				[InlineData(1, (byte)2)]
+				[{|#4:InlineData((byte)1, 2)|}]
+				public void ParamsArray_Triggers(params int[] a) { }
+
+				[Theory]
+				[InlineData]
+				[{|#5:InlineData((byte)1)|}]
+				public void DefaultValue_Triggers(int n = 1) { }
+
+				[Theory]
+				[InlineData(1)]
+				[{|#6:InlineData((byte)1)|}]
+				public void NullableParameter_Triggers(int? n) { }
+
+				[Theory]
+				[InlineData('a')]
+				[{|#7:InlineData(97)|}]
+				public void CharAndInt_Triggers(int n) { }
+			}
+			""";
+		var expected = new[] {
+			Verify.Diagnostic().WithLocation(0).WithArguments("IntAndByteConstants_Triggers", "TestClass"),
+			Verify.Diagnostic().WithLocation(1).WithArguments("IntAndByteLiterals_Triggers", "TestClass"),
+			Verify.Diagnostic().WithLocation(2).WithArguments("IntAndDouble_Triggers", "TestClass"),
+			Verify.Diagnostic().WithLocation(3).WithArguments("MixedNumericTypes_Triggers", "TestClass"),
+			Verify.Diagnostic().WithLocation(4).WithArguments("ParamsArray_Triggers", "TestClass"),
+			Verify.Diagnostic().WithLocation(5).WithArguments("DefaultValue_Triggers", "TestClass"),
+			Verify.Diagnostic().WithLocation(6).WithArguments("NullableParameter_Triggers", "TestClass"),
+			Verify.Diagnostic().WithLocation(7).WithArguments("CharAndInt_Triggers", "TestClass"),
+		};
+
+		await Verify.VerifyAnalyzer(LanguageVersion.CSharp8, source, expected);
+	}
+
+	[Fact]
 	public async ValueTask V3_only()
 	{
 		var source = /* lang=c#-test */ """

--- a/src/xunit.analyzers/X1000/InlineDataShouldBeUniqueWithinTheory.cs
+++ b/src/xunit.analyzers/X1000/InlineDataShouldBeUniqueWithinTheory.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -125,15 +127,18 @@ public class InlineDataShouldBeUniqueWithinTheory : XunitDiagnosticAnalyzer
 				IsSingleNullByInlineDataOrByDefaultParamValue(xArguments)
 				&& IsSingleNullByInlineDataOrByDefaultParamValue(yArguments);
 
-			return areBothNullEntirely || AreArgumentsEqual(xArguments, yArguments);
+			return areBothNullEntirely || AreArgumentsEqual(xArguments, yArguments, topLevel: true);
 		}
 
 		// Since arguments can be object[] at any level we need to compare 2 sequences of trees for equality.
 		// The algorithm traverses each tree in a sequence and compares with the corresponding tree in the other sequence.
 		// Any difference at any stage results in inequality proved and <c>false</c> returned.
-		static bool AreArgumentsEqual(
+		// Top-level primitive values are normalized to the target parameter type first, so that values which
+		// only differ by an implicit conversion (e.g. int 1 vs. byte 1 for an int parameter) compare as equal.
+		bool AreArgumentsEqual(
 			ImmutableArray<object> xArguments,
-			ImmutableArray<object> yArguments)
+			ImmutableArray<object> yArguments,
+			bool topLevel)
 		{
 			if (xArguments.Length != yArguments.Length)
 				return false;
@@ -142,6 +147,7 @@ public class InlineDataShouldBeUniqueWithinTheory : XunitDiagnosticAnalyzer
 			{
 				var x = xArguments[i];
 				var y = yArguments[i];
+				var targetType = topLevel ? GetTargetParameterType(i) : null;
 
 				switch (x)
 				{
@@ -149,12 +155,17 @@ public class InlineDataShouldBeUniqueWithinTheory : XunitDiagnosticAnalyzer
 						switch (y)
 						{
 							case TypedConstant yArgPrimitive when yArgPrimitive.Kind != TypedConstantKind.Array:
-								if (!xArgPrimitive.Equals(yArgPrimitive))
+								if (xArgPrimitive.Kind == TypedConstantKind.Primitive && yArgPrimitive.Kind == TypedConstantKind.Primitive)
+								{
+									if (!object.Equals(GetNormalizedValue(xArgPrimitive.Value, targetType), GetNormalizedValue(yArgPrimitive.Value, targetType)))
+										return false;
+								}
+								else if (!xArgPrimitive.Equals(yArgPrimitive))
 									return false;
 								break;
 
 							case IParameterSymbol yMethodParamDefault:
-								if (!object.Equals(xArgPrimitive.Value, yMethodParamDefault.ExplicitDefaultValue))
+								if (!object.Equals(GetNormalizedValue(xArgPrimitive.Value, yMethodParamDefault.Type), yMethodParamDefault.ExplicitDefaultValue))
 									return false;
 								break;
 
@@ -167,7 +178,7 @@ public class InlineDataShouldBeUniqueWithinTheory : XunitDiagnosticAnalyzer
 						switch (y)
 						{
 							case TypedConstant yArgPrimitive when yArgPrimitive.Kind != TypedConstantKind.Array:
-								if (!object.Equals(xMethodParamDefault.ExplicitDefaultValue, yArgPrimitive.Value))
+								if (!object.Equals(xMethodParamDefault.ExplicitDefaultValue, GetNormalizedValue(yArgPrimitive.Value, xMethodParamDefault.Type)))
 									return false;
 								break;
 
@@ -185,7 +196,7 @@ public class InlineDataShouldBeUniqueWithinTheory : XunitDiagnosticAnalyzer
 						switch (y)
 						{
 							case TypedConstant yArgArray when yArgArray.Kind == TypedConstantKind.Array && !yArgArray.IsNull:
-								if (!AreArgumentsEqual(xArgArray.Values.Cast<object>().ToImmutableArray(), yArgArray.Values.Cast<object>().ToImmutableArray()))
+								if (!AreArgumentsEqual(xArgArray.Values.Cast<object>().ToImmutableArray(), yArgArray.Values.Cast<object>().ToImmutableArray(), topLevel: false))
 									return false;
 								break;
 							default:
@@ -200,6 +211,69 @@ public class InlineDataShouldBeUniqueWithinTheory : XunitDiagnosticAnalyzer
 
 			return true;
 		}
+
+		ITypeSymbol? GetTargetParameterType(int ordinal)
+		{
+			var parameters = attributeRelatedMethod.Parameters;
+			if (parameters.Length == 0)
+				return null;
+
+			var parameter = ordinal < parameters.Length ? parameters[ordinal] : parameters[parameters.Length - 1];
+			if (parameter.IsParams && parameter.Type is IArrayTypeSymbol arrayType && parameter.Ordinal <= ordinal)
+				return arrayType.ElementType;
+
+			return ordinal < parameters.Length ? parameter.Type : null;
+		}
+
+		// Normalizes a primitive value to the type of the parameter it will be assigned to, mirroring the
+		// conversion the test framework performs at runtime. The round trip guards against lossy conversions
+		// (e.g. float 0.1f to a double parameter), which must not be treated as equal values.
+		static object? GetNormalizedValue(
+			object? value,
+			ITypeSymbol? targetType)
+		{
+			if (value is null || targetType is null)
+				return value;
+
+			if (targetType is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T, TypeArguments.Length: 1 } nullableType)
+				targetType = nullableType.TypeArguments[0];
+
+			if (!numericTypes.TryGetValue(targetType.SpecialType, out var targetClrType))
+				return value;
+			if (!numericTypes.ContainsValue(value.GetType()))
+				return value;
+
+			try
+			{
+				var converted = Convert.ChangeType(value, targetClrType, CultureInfo.InvariantCulture);
+				var roundTripped = Convert.ChangeType(converted, value.GetType(), CultureInfo.InvariantCulture);
+				return value.Equals(roundTripped) ? converted : value;
+			}
+			catch (InvalidCastException)
+			{
+				return value;
+			}
+			catch (OverflowException)
+			{
+				return value;
+			}
+		}
+
+		static readonly Dictionary<SpecialType, Type> numericTypes = new()
+		{
+			{ SpecialType.System_Byte, typeof(byte) },
+			{ SpecialType.System_SByte, typeof(sbyte) },
+			{ SpecialType.System_Int16, typeof(short) },
+			{ SpecialType.System_UInt16, typeof(ushort) },
+			{ SpecialType.System_Int32, typeof(int) },
+			{ SpecialType.System_UInt32, typeof(uint) },
+			{ SpecialType.System_Int64, typeof(long) },
+			{ SpecialType.System_UInt64, typeof(ulong) },
+			{ SpecialType.System_Single, typeof(float) },
+			{ SpecialType.System_Double, typeof(double) },
+			{ SpecialType.System_Decimal, typeof(decimal) },
+			{ SpecialType.System_Char, typeof(char) },
+		};
 
 		// A special search for a degenerated case of either:
 		// 1. InlineData(null) or
@@ -224,7 +298,33 @@ public class InlineDataShouldBeUniqueWithinTheory : XunitDiagnosticAnalyzer
 		public int GetHashCode(AttributeData attributeData)
 		{
 			var arguments = GetEffectiveTestArguments(attributeData);
-			var flattened = GetFlattenedArgumentPrimitives(arguments);
+			var flattened = new List<object?>();
+
+			for (var i = 0; i < arguments.Length; i++)
+			{
+				switch (arguments[i])
+				{
+					case TypedConstant argPrimitive when argPrimitive.Kind == TypedConstantKind.Primitive:
+						flattened.Add(GetNormalizedValue(argPrimitive.Value, GetTargetParameterType(i)));
+						break;
+
+					case TypedConstant argPrimitive when argPrimitive.Kind != TypedConstantKind.Array:
+						flattened.Add(argPrimitive.Value);
+						break;
+
+					case IParameterSymbol methodParameterWithDefault:
+						flattened.Add(methodParameterWithDefault.ExplicitDefaultValue);
+						break;
+
+					case TypedConstant argArray when argArray.Kind == TypedConstantKind.Array && !argArray.IsNull:
+						flattened.AddRange(GetFlattenedArgumentPrimitives(argArray.Values.Cast<object>()));
+						break;
+
+					case TypedConstant nullObjectArray when nullObjectArray.Kind == TypedConstantKind.Array && nullObjectArray.IsNull:
+						flattened.Add(null);
+						break;
+				}
+			}
 
 			var hash = 17;
 


### PR DESCRIPTION
Fixes xunit/xunit#2957

xUnit1025 compared InlineData rows using the raw typed constants, so two rows that produce the same value for a parameter through an implicit numeric conversion (for example `1` and `(byte)1` for an `int` parameter) were not reported as duplicates.

This change normalizes top-level primitive values to the target parameter type before comparing:

- Resolves the target type per argument index, including `params` array element types, nullable underlying types, and default parameter values.
- Converts only when the conversion is lossless, verified by a round-trip check, so `0.1f` passed to a `double` parameter stays distinct from `0.1`.
- Applies the same normalization in `GetHashCode` so the hash set actually calls `Equals` for these pairs.
- Nested object arrays and non-numeric values keep their previous comparison semantics.