### PR TITLE
Stop reporting xUnit1010 for InlineData strings that convert to the parameter type at runtime

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/X1010_InlineDataMustMatchTheoryParametersTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/X1010_InlineDataMustMatchTheoryParametersTests.cs
@@ -591,6 +591,101 @@ public class X1010_InlineDataMustMatchTheoryParametersTests
 				void ToGuid(Guid g) { }
 			}
 
+			// https://github.com/xunit/xunit/issues/2354
+			class NumericStringConversions {
+				[Theory]
+				[InlineData("42")]
+				[InlineData("-42")]
+				[InlineData({|xUnit1010:""|})]
+				[InlineData({|xUnit1010:"42.1"|})]
+				[InlineData({|xUnit1010:"2147483648"|})]
+				void ToInt32(int n) { }
+			
+				[Theory]
+				[InlineData("0.05")]
+				[InlineData("-0.05")]
+				[InlineData({|xUnit1010:"Hello world"|})]
+				void ToDecimal(decimal d) { }
+			
+				[Theory]
+				[InlineData("42")]
+				[InlineData({|xUnit1010:"300"|})]
+				void ToByte(byte b) { }
+			
+				[Theory]
+				[InlineData("42")]
+				void ToSByte(sbyte n) { }
+			
+				[Theory]
+				[InlineData("42")]
+				void ToInt16(short n) { }
+			
+				[Theory]
+				[InlineData("42")]
+				void ToUInt16(ushort n) { }
+			
+				[Theory]
+				[InlineData("42")]
+				[InlineData({|xUnit1010:"-1"|})]
+				void ToUInt32(uint n) { }
+			
+				[Theory]
+				[InlineData("42")]
+				void ToInt64(long n) { }
+			
+				[Theory]
+				[InlineData("42")]
+				void ToUInt64(ulong n) { }
+			
+				[Theory]
+				[InlineData("0.05")]
+				void ToSingle(float f) { }
+			
+				[Theory]
+				[InlineData("0.05")]
+				[InlineData("42")]
+				void ToDouble(double d) { }
+			
+				[Theory]
+				[InlineData("true")]
+				[InlineData("True")]
+				[InlineData({|xUnit1010:"yes"|})]
+				void ToBoolean(bool b) { }
+			
+				[Theory]
+				[InlineData("a")]
+				[InlineData({|xUnit1010:"ab"|})]
+				void ToChar(char c) { }
+			
+				[Theory]
+				[InlineData("42", "43")]
+				void ToMultipleInt32(int a, int b) { }
+			
+				[Theory]
+				[InlineData({|xUnit1010:"42"|})]
+				void ToNullableInt32(int? n) { }
+			
+				[Theory]
+				[InlineData({|xUnit1010:"InvariantCulture"|})]
+				void ToEnum(StringComparison s) { }
+			
+				[Theory]
+				[InlineData({|xUnit1010:"42"|}, {|xUnit1010:"43"|})]
+				void ToParamsArray(params int[] n) { }
+			
+				[Theory]
+				[InlineData({|xUnit1010:"42"|})]
+				void ToInt32WithDefaultValue(int n, int m = 0) { }
+			
+				[Theory]
+				[InlineData({|xUnit1010:"42"|})]
+				void ToInt32WithEmptyParamsArray(int n, params int[] rest) { }
+			
+				[Theory]
+				[InlineData("42", 43)]
+				void ToInt32WithFilledParamsArray(int n, params int[] rest) { }
+			}
+
 			#nullable enable
 
 			class NullableTestClass {
@@ -639,113 +734,6 @@ public class X1010_InlineDataMustMatchTheoryParametersTests
 			""";
 
 		await Verify.VerifyAnalyzer(LanguageVersion.CSharp8, source);
-	}
-
-	[Fact]
-	public async ValueTask V2_and_V3_ParsableStrings()
-	{
-		var source = /* lang=c#-test */ """
-			using System;
-			using Xunit;
-
-			class TestClass {
-				// https://github.com/xunit/xunit/issues/2354
-
-				[Theory]
-				[InlineData("42")]
-				[InlineData("-42")]
-				[InlineData({|xUnit1010:""|})]
-				[InlineData({|xUnit1010:"42.1"|})]
-				[InlineData({|xUnit1010:"2147483648"|})]
-				void ToInt32(int n) { }
-
-				[Theory]
-				[InlineData("0.05")]
-				[InlineData("-0.05")]
-				[InlineData({|xUnit1010:"Hello world"|})]
-				void ToDecimal(decimal d) { }
-
-				[Theory]
-				[InlineData("42")]
-				[InlineData({|xUnit1010:"300"|})]
-				void ToByte(byte b) { }
-
-				[Theory]
-				[InlineData("42")]
-				void ToSByte(sbyte n) { }
-
-				[Theory]
-				[InlineData("42")]
-				void ToInt16(short n) { }
-
-				[Theory]
-				[InlineData("42")]
-				void ToUInt16(ushort n) { }
-
-				[Theory]
-				[InlineData("42")]
-				[InlineData({|xUnit1010:"-1"|})]
-				void ToUInt32(uint n) { }
-
-				[Theory]
-				[InlineData("42")]
-				void ToInt64(long n) { }
-
-				[Theory]
-				[InlineData("42")]
-				void ToUInt64(ulong n) { }
-
-				[Theory]
-				[InlineData("0.05")]
-				void ToSingle(float f) { }
-
-				[Theory]
-				[InlineData("0.05")]
-				[InlineData("42")]
-				void ToDouble(double d) { }
-
-				[Theory]
-				[InlineData("true")]
-				[InlineData("True")]
-				[InlineData({|xUnit1010:"yes"|})]
-				void ToBoolean(bool b) { }
-
-				[Theory]
-				[InlineData("a")]
-				[InlineData({|xUnit1010:"ab"|})]
-				void ToChar(char c) { }
-
-				[Theory]
-				[InlineData("42", "43")]
-				void ToMultipleInt32(int a, int b) { }
-
-				[Theory]
-				[InlineData({|xUnit1010:"42"|})]
-				void ToNullableInt32(int? n) { }
-
-				[Theory]
-				[InlineData({|xUnit1010:"InvariantCulture"|})]
-				void ToEnum(StringComparison s) { }
-
-				[Theory]
-				[InlineData({|xUnit1010:"42"|}, {|xUnit1010:"43"|})]
-				void ToParamsArray(params int[] n) { }
-
-				[Theory]
-				[InlineData({|xUnit1010:"42"|})]
-				void ToInt32WithDefaultValue(int n, int m = 0) { }
-
-				[Theory]
-				[InlineData({|xUnit1010:"42"|})]
-				void ToInt32WithEmptyParamsArray(int n, params int[] rest) { }
-
-				[Theory]
-				[InlineData("42", 43)]
-				void ToInt32WithFilledParamsArray(int n, params int[] rest) { }
-			}
-			""";
-
-		await Verify.VerifyAnalyzer(source);
 	}
 
 	[Fact]

--- a/src/xunit.analyzers.tests/Analyzers/X1000/X1010_InlineDataMustMatchTheoryParametersTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/X1010_InlineDataMustMatchTheoryParametersTests.cs
@@ -642,6 +642,113 @@ public class X1010_InlineDataMustMatchTheoryParametersTests
 	}
 
 	[Fact]
+	public async ValueTask V2_and_V3_ParsableStrings()
+	{
+		var source = /* lang=c#-test */ """
+			using System;
+			using Xunit;
+
+			class TestClass {
+				// https://github.com/xunit/xunit/issues/2354
+
+				[Theory]
+				[InlineData("42")]
+				[InlineData("-42")]
+				[InlineData({|xUnit1010:""|})]
+				[InlineData({|xUnit1010:"42.1"|})]
+				[InlineData({|xUnit1010:"2147483648"|})]
+				void ToInt32(int n) { }
+
+				[Theory]
+				[InlineData("0.05")]
+				[InlineData("-0.05")]
+				[InlineData({|xUnit1010:"Hello world"|})]
+				void ToDecimal(decimal d) { }
+
+				[Theory]
+				[InlineData("42")]
+				[InlineData({|xUnit1010:"300"|})]
+				void ToByte(byte b) { }
+
+				[Theory]
+				[InlineData("42")]
+				void ToSByte(sbyte n) { }
+
+				[Theory]
+				[InlineData("42")]
+				void ToInt16(short n) { }
+
+				[Theory]
+				[InlineData("42")]
+				void ToUInt16(ushort n) { }
+
+				[Theory]
+				[InlineData("42")]
+				[InlineData({|xUnit1010:"-1"|})]
+				void ToUInt32(uint n) { }
+
+				[Theory]
+				[InlineData("42")]
+				void ToInt64(long n) { }
+
+				[Theory]
+				[InlineData("42")]
+				void ToUInt64(ulong n) { }
+
+				[Theory]
+				[InlineData("0.05")]
+				void ToSingle(float f) { }
+
+				[Theory]
+				[InlineData("0.05")]
+				[InlineData("42")]
+				void ToDouble(double d) { }
+
+				[Theory]
+				[InlineData("true")]
+				[InlineData("True")]
+				[InlineData({|xUnit1010:"yes"|})]
+				void ToBoolean(bool b) { }
+
+				[Theory]
+				[InlineData("a")]
+				[InlineData({|xUnit1010:"ab"|})]
+				void ToChar(char c) { }
+
+				[Theory]
+				[InlineData("42", "43")]
+				void ToMultipleInt32(int a, int b) { }
+
+				[Theory]
+				[InlineData({|xUnit1010:"42"|})]
+				void ToNullableInt32(int? n) { }
+
+				[Theory]
+				[InlineData({|xUnit1010:"InvariantCulture"|})]
+				void ToEnum(StringComparison s) { }
+
+				[Theory]
+				[InlineData({|xUnit1010:"42"|}, {|xUnit1010:"43"|})]
+				void ToParamsArray(params int[] n) { }
+
+				[Theory]
+				[InlineData({|xUnit1010:"42"|})]
+				void ToInt32WithDefaultValue(int n, int m = 0) { }
+
+				[Theory]
+				[InlineData({|xUnit1010:"42"|})]
+				void ToInt32WithEmptyParamsArray(int n, params int[] rest) { }
+
+				[Theory]
+				[InlineData("42", 43)]
+				void ToInt32WithFilledParamsArray(int n, params int[] rest) { }
+			}
+			""";
+
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Fact]
 	public async ValueTask V2_only_Pre240()
 	{
 		var source = /* lang=c#-test */ """

--- a/src/xunit.analyzers/Utility/ConversionChecker.cs
+++ b/src/xunit.analyzers/Utility/ConversionChecker.cs
@@ -23,12 +23,30 @@ static class ConversionChecker
 		SpecialType.System_UInt64,
 	];
 
+	static readonly Dictionary<SpecialType, Type> StringConversionTargets = new()
+	{
+		{ SpecialType.System_Boolean, typeof(bool) },
+		{ SpecialType.System_Char, typeof(char) },
+		{ SpecialType.System_SByte, typeof(sbyte) },
+		{ SpecialType.System_Byte, typeof(byte) },
+		{ SpecialType.System_Int16, typeof(short) },
+		{ SpecialType.System_UInt16, typeof(ushort) },
+		{ SpecialType.System_Int32, typeof(int) },
+		{ SpecialType.System_UInt32, typeof(uint) },
+		{ SpecialType.System_Int64, typeof(long) },
+		{ SpecialType.System_UInt64, typeof(ulong) },
+		{ SpecialType.System_Single, typeof(float) },
+		{ SpecialType.System_Double, typeof(double) },
+		{ SpecialType.System_Decimal, typeof(decimal) },
+	};
+
 	public static bool IsConvertible(
 		Compilation compilation,
 		ITypeSymbol source,
 		ITypeSymbol destination,
 		XunitContext xunitContext,
-		object? valueSource = null)
+		object? valueSource = null,
+		bool valueIsConvertedAtRuntime = false)
 	{
 		Guard.ArgumentNotNull(compilation);
 		Guard.ArgumentNotNull(source);
@@ -58,6 +76,9 @@ static class ConversionChecker
 			return source.SpecialType == SpecialType.System_String;
 		}
 
+		if (valueIsConvertedAtRuntime && CanConvertStringValue(source, destination, valueSource))
+			return true;
+
 		// User-defined conversion not supported in AOT
 		if (xunitContext.HasV3AotReferences && conversion.IsUserDefined)
 			return false;
@@ -68,6 +89,32 @@ static class ConversionChecker
 			|| (conversion.IsExplicit && conversion.IsEnumeration)
 			|| (conversion.IsExplicit && conversion.IsUserDefined)
 			|| (conversion.IsExplicit && conversion.IsNullable);
+	}
+
+	static bool CanConvertStringValue(
+		ITypeSymbol source,
+		ITypeSymbol destination,
+		object? valueSource)
+	{
+		if (source.SpecialType != SpecialType.System_String || valueSource is not string stringValue)
+			return false;
+
+		if (!StringConversionTargets.TryGetValue(destination.SpecialType, out var destinationType))
+			return false;
+
+		try
+		{
+			Convert.ChangeType(stringValue, destinationType, CultureInfo.InvariantCulture);
+			return true;
+		}
+		catch (FormatException)
+		{
+			return false;
+		}
+		catch (OverflowException)
+		{
+			return false;
+		}
 	}
 
 	static bool IsConvertibleTypeParameter(

--- a/src/xunit.analyzers/X1000/InlineDataMustMatchTheoryParameters.cs
+++ b/src/xunit.analyzers/X1000/InlineDataMustMatchTheoryParameters.cs
@@ -170,7 +170,8 @@ public class InlineDataMustMatchTheoryParameters : XunitDiagnosticAnalyzer
 							if (value.Type is null)
 								continue;
 
-							var isCompatible = ConversionChecker.IsConvertible(compilation, value.Type, parameter.Type, xunitContext, value.Kind != TypedConstantKind.Array ? value.Value : null);
+							var valueIsConvertedAtRuntime = values.Length == method.Parameters.Length && !parameter.IsParams;
+							var isCompatible = ConversionChecker.IsConvertible(compilation, value.Type, parameter.Type, xunitContext, value.Kind != TypedConstantKind.Array ? value.Value : null, valueIsConvertedAtRuntime);
 							if (!isCompatible && paramsElementType is not null)
 								isCompatible = ConversionChecker.IsConvertible(compilation, value.Type, paramsElementType, xunitContext, value.Kind != TypedConstantKind.Array ? value.Value : null);
 


### PR DESCRIPTION
Fixes xunit/xunit#2354

xUnit.net converts data row values to the test method parameter types via `Convert.ChangeType` (`Reflector.ConvertArgument` in v2, `TypeHelper.ConvertArgument` in v3), so `[InlineData("0.05")]` for a `decimal` parameter works at runtime but was reported as incompatible.

Following the suggestion in the issue, the supported conversion targets are now a lookup table (the from-string column of the `Convert` support table: `bool`, `char`, and the numeric types). Since InlineData values are compile-time constants, the analyzer checks the actual value: a string is only considered compatible when `Convert.ChangeType` to the target type succeeds under the invariant culture. Strings which fail to parse, such as `"Hello world"` for `int`, are still reported, since they fail the test at runtime.

The allowance is deliberately narrow, matching where the runtime actually converts:

- Only when the data row exactly fills the parameter list: `TypeHelper.ConvertArguments` skips conversion entirely on a length mismatch, so rows relying on default parameter values or params expansion keep strict checking.
- Not for params array elements, which are packed with `Array.Copy` without conversion.
- Not for `MemberData` arguments, which bind to the data method via reflection without conversion.
- Nullable and enum parameter types keep strict checking, since `Convert.ChangeType` does not handle them.

One caveat: the runtime converts with `CultureInfo.CurrentCulture`, while the analyzer parses with the invariant culture for deterministic analysis. A value like `"0.05"` could still fail at runtime on a machine whose culture uses a different decimal separator.
