### PR TITLE
Add xUnit1070: Detect unused collection definitions

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/X1070_UnusedCollectionDefinitionsTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/X1070_UnusedCollectionDefinitionsTests.cs
@@ -1,0 +1,146 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+using Verify = CSharpVerifier<Xunit.Analyzers.UnusedCollectionDefinitions>;
+
+public class X1070_UnusedCollectionDefinitionsTests
+{
+	[Fact]
+	public async ValueTask V2_and_V3()
+	{
+		var source = /* lang=c#-test */ """
+			using Xunit;
+
+			[CollectionDefinition("used by test class")]
+			public class UsedByTestClassCollection { }
+
+			[Collection("used by test class")]
+			public class TestClass1 {
+				[Fact]
+				public void TestMethod() { }
+			}
+
+			[CollectionDefinition("used by non-test class")]
+			public class UsedByNonTestClassCollection { }
+
+			[Collection("used by non-test class")]
+			public class NonTestClass { }
+
+			[CollectionDefinition("used via constant")]
+			public class UsedViaConstantCollection {
+				public const string Name = "used via constant";
+			}
+
+			[Collection(UsedViaConstantCollection.Name)]
+			public class TestClass2 {
+				[Fact]
+				public void TestMethod() { }
+			}
+
+			[CollectionDefinition("used on base class")]
+			public class UsedOnBaseClassCollection { }
+
+			[Collection("used on base class")]
+			public abstract class BaseTestClass { }
+
+			public class DerivedTestClass : BaseTestClass {
+				[Fact]
+				public void TestMethod() { }
+			}
+
+			[CollectionDefinition("unused")]
+			public class {|#0:UnusedCollection|} { }
+
+			[CollectionDefinition("misspelled")]
+			public class {|#1:MisspelledCollection|} { }
+
+			[Collection("mispelled")]
+			public class TestClass3 {
+				[Fact]
+				public void TestMethod() { }
+			}
+			""";
+		var expected = new[] {
+			Verify.Diagnostic().WithLocation(0).WithArguments("unused"),
+			Verify.Diagnostic().WithLocation(1).WithArguments("misspelled"),
+		};
+
+		await Verify.VerifyAnalyzer(source, expected);
+	}
+
+	[Fact]
+	public async ValueTask V2_and_V3_CustomCollectionBehavior_DoesNotTrigger()
+	{
+		var source = /* lang=c#-test */ """
+			using Xunit;
+
+			[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]
+
+			[CollectionDefinition("unused")]
+			public class UnusedCollection { }
+			""";
+
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Fact]
+	public async ValueTask V2_and_V3_DisabledParallelization_Triggers()
+	{
+		var source = /* lang=c#-test */ """
+			using Xunit;
+
+			[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
+			[CollectionDefinition("unused")]
+			public class {|#0:UnusedCollection|} { }
+			""";
+		var expected = new[] {
+			Verify.Diagnostic().WithLocation(0).WithArguments("unused"),
+		};
+
+		await Verify.VerifyAnalyzer(source, expected);
+	}
+
+	[Fact]
+	public async ValueTask V3()
+	{
+		var source = /* lang=c#-test */ """
+			using Xunit;
+
+			[CollectionDefinition]
+			public class UsedByTypeCollection { }
+
+			[Collection(typeof(UsedByTypeCollection))]
+			public class TestClass1 {
+				[Fact]
+				public void TestMethod() { }
+			}
+
+			[CollectionDefinition]
+			public class UsedByGenericAttributeCollection { }
+
+			[Collection<UsedByGenericAttributeCollection>]
+			public class TestClass2 {
+				[Fact]
+				public void TestMethod() { }
+			}
+
+			[CollectionDefinition("named, used by type")]
+			public class NamedUsedByTypeCollection { }
+
+			[Collection(typeof(NamedUsedByTypeCollection))]
+			public class TestClass3 {
+				[Fact]
+				public void TestMethod() { }
+			}
+
+			[CollectionDefinition]
+			public class {|#0:UnusedCollection|} { }
+			""";
+		var expected = new[] {
+			Verify.Diagnostic().WithLocation(0).WithArguments("UnusedCollection"),
+		};
+
+		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp11, source, expected);
+	}
+}

--- a/src/xunit.analyzers/Utility/Descriptors.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.cs
@@ -12,12 +12,13 @@ public static partial class Descriptors
 		string title,
 		Category category,
 		DiagnosticSeverity defaultSeverity,
-		string messageFormat)
+		string messageFormat,
+		params string[] customTags)
 	{
 		var helpLink = $"https://xunit.net/xunit.analyzers/rules/{id}";
 		var categoryString = categoryMapping.GetOrAdd(category, c => c.ToString());
 
-		return new DiagnosticDescriptor(id, title, messageFormat, categoryString, defaultSeverity, isEnabledByDefault: true, helpLinkUri: helpLink);
+		return new DiagnosticDescriptor(id, title, messageFormat, categoryString, defaultSeverity, isEnabledByDefault: true, helpLinkUri: helpLink, customTags: customTags);
 	}
 
 	static SuppressionDescriptor Suppression(

--- a/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.xUnit1xxx.cs
@@ -636,5 +636,15 @@ public static partial class Descriptors
 			"Test method '{0}' has a Timeout but does not reference TestContext.Current.CancellationToken. Tests with a Timeout should reference TestContext.Current.CancellationToken so they can terminate promptly when the timeout is exceeded."
 		);
 
-	// Placeholder for rule X1070
+	public static DiagnosticDescriptor X1070_CollectionDefinitionIsNeverUsed { get; } =
+		Diagnostic(
+			"xUnit1070",
+			"Collection definition is never used",
+			Usage,
+			Warning,
+			"Collection definition '{0}' is never used. Fix a misspelled collection name in a [Collection] attribute, or remove the unused definition.",
+			WellKnownDiagnosticTags.CompilationEnd
+		);
+
+	// Placeholder for rule X1071
 }

--- a/src/xunit.analyzers/X1000/UnusedCollectionDefinitions.cs
+++ b/src/xunit.analyzers/X1000/UnusedCollectionDefinitions.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Xunit.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class UnusedCollectionDefinitions : XunitDiagnosticAnalyzer
+{
+	public UnusedCollectionDefinitions() :
+		base(Descriptors.X1070_CollectionDefinitionIsNeverUsed)
+	{ }
+
+	public override void AnalyzeCompilation(
+		CompilationStartAnalysisContext context,
+		XunitContext xunitContext)
+	{
+		Guard.ArgumentNotNull(context);
+		Guard.ArgumentNotNull(xunitContext);
+
+		var collectionAttributeType = xunitContext.Core.CollectionAttributeType;
+		var collectionDefinitionAttributeType = xunitContext.Core.CollectionDefinitionAttributeType;
+		if (collectionAttributeType is null || collectionDefinitionAttributeType is null)
+			return;
+
+		var collectionBehaviorAttributeType = xunitContext.Core.CollectionBehaviorAttributeType;
+		if (collectionBehaviorAttributeType is not null
+				&& context.Compilation.Assembly.GetAttributes().Any(a =>
+					collectionBehaviorAttributeType.IsAssignableFrom(a.AttributeClass)
+					&& a.ConstructorArguments.Length != 0))
+			return;
+
+		var collectionAttributeOfTType = xunitContext.V3Core?.CollectionAttributeOfTType?.ConstructUnboundGenericType();
+
+		var definitions = new ConcurrentBag<(INamedTypeSymbol Type, string? Name)>();
+		var referencedNames = new ConcurrentDictionary<string, bool>(StringComparer.Ordinal);
+		var referencedTypes = new ConcurrentDictionary<INamedTypeSymbol, bool>(SymbolEqualityComparer.Default);
+
+		context.RegisterSymbolAction(context =>
+		{
+			if (context.Symbol is not INamedTypeSymbol namedType)
+				return;
+
+			foreach (var attribute in namedType.GetAttributes())
+			{
+				context.CancellationToken.ThrowIfCancellationRequested();
+
+				if (collectionDefinitionAttributeType.IsAssignableFrom(attribute.AttributeClass))
+					definitions.Add((namedType, attribute.ConstructorArguments.FirstOrDefault().Value as string));
+				else if (collectionAttributeType.IsAssignableFrom(attribute.AttributeClass))
+				{
+					var argument = attribute.ConstructorArguments.FirstOrDefault().Value;
+					if (argument is string name)
+						referencedNames.TryAdd(name, true);
+					else if (argument is INamedTypeSymbol type)
+						referencedTypes.TryAdd(type, true);
+				}
+				else if (collectionAttributeOfTType is not null
+					&& attribute.AttributeClass is { IsGenericType: true } attributeClass
+					&& SymbolEqualityComparer.Default.Equals(collectionAttributeOfTType, attributeClass.ConstructUnboundGenericType())
+					&& attributeClass.TypeArguments.FirstOrDefault() is INamedTypeSymbol typeArgument)
+					referencedTypes.TryAdd(typeArgument, true);
+			}
+		}, SymbolKind.NamedType);
+
+		context.RegisterCompilationEndAction(context =>
+		{
+			foreach (var (type, name) in definitions)
+			{
+				context.CancellationToken.ThrowIfCancellationRequested();
+
+				if (name is not null && referencedNames.ContainsKey(name))
+					continue;
+				if (referencedTypes.ContainsKey(type))
+					continue;
+
+				context.ReportDiagnostic(
+					Diagnostic.Create(
+						Descriptors.X1070_CollectionDefinitionIsNeverUsed,
+						type.Locations.First(),
+						type.Locations.Skip(1),
+						name ?? type.Name
+					)
+				);
+			}
+		});
+	}
+}


### PR DESCRIPTION
Fixes xunit/xunit#1277

New rule xUnit1070 (Usage, Warning) flags a class marked with `[CollectionDefinition]` when nothing in the assembly references its collection, which catches misspelled collection names and definitions left behind after their tests were removed.

What counts as a reference:

- `[Collection(name)]` on any class, matched ordinally against the definition name.
- The v3 forms `[Collection(typeof(T))]` and `[Collection<T>]`, matched against the definition class itself. Unnamed v3 definitions participate this way and are reported by class name.
- The referencing attribute can sit on any named type, so definitions referenced only from abstract base classes or non-test classes are not flagged.

Analysis is skipped entirely when an assembly-level `[CollectionBehavior]` has constructor arguments: `CollectionPerAssembly` and custom collection factories attach definitions to collections without any `[Collection]` attribute, and flagging in that situation would be a false positive. `[assembly: CollectionBehavior(DisableTestParallelization = true)]` uses only named arguments and keeps the analysis active.

Since the answer is only known once the whole compilation has been seen, the diagnostic is reported from a compilation end action and the descriptor carries the `CompilationEnd` custom tag (the `Diagnostic` factory helper gained optional custom tags for this). As with other compilation-end diagnostics, it shows up on full builds rather than while typing.

The corollary discussed in the issue thread, a refactoring that generates a definition for a `[Collection]` name that has none, is not part of this PR since it needs to be an info-level analyzer with a fixer. Happy to tackle that as a follow-up.