### PR TITLE
Add xUnit2033: Use the assertion return value instead of re-deriving it

### DIFF
--- a/src/xunit.analyzers.fixes/X2000/AssertReturnValueShouldBeUsedFixer.cs
+++ b/src/xunit.analyzers.fixes/X2000/AssertReturnValueShouldBeUsedFixer.cs
@@ -1,0 +1,133 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Text;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Xunit.Analyzers.Fixes;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public class AssertReturnValueShouldBeUsedFixer : XunitCodeFixProvider
+{
+	const string singleVariableName = "item";
+	const string typedVariableName = "typed";
+
+	public const string Key_UseReturnValue = "xUnit2033_UseReturnValue";
+
+	public AssertReturnValueShouldBeUsedFixer() :
+		base(Descriptors.X2033_AssertReturnValueShouldBeUsed.Id)
+	{ }
+
+	public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+	{
+		var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+		if (root is null)
+			return;
+
+		if (root.FindNode(context.Span).FirstAncestorOrSelf<InvocationExpressionSyntax>() is not { Parent: ExpressionStatementSyntax assertStatement } invocation)
+			return;
+
+		if (context.Diagnostics.FirstOrDefault() is not Diagnostic diagnostic)
+			return;
+		if (!diagnostic.Properties.TryGetValue(Constants.Properties.AssertMethodName, out var assertMethodName) || assertMethodName is null)
+			return;
+
+		var rederivation = GetRederivation(root, diagnostic);
+		if (rederivation is null)
+			return;
+
+		var variableName = assertMethodName == Constants.Asserts.Single ? singleVariableName : typedVariableName;
+
+		context.RegisterCodeFix(
+			XunitCodeAction.Create(
+				ct => UseReturnValue(context.Document, invocation, assertStatement, rederivation, variableName, ct),
+				Key_UseReturnValue,
+				"Use the return value of Assert.{0}", assertMethodName
+			),
+			context.Diagnostics
+		);
+	}
+
+	static ExpressionSyntax? GetRederivation(
+		SyntaxNode root,
+		Diagnostic diagnostic)
+	{
+		if (!TryGetIntProperty(diagnostic, Constants.Properties.RederivationSpanStart, out var start))
+			return null;
+		if (!TryGetIntProperty(diagnostic, Constants.Properties.RederivationSpanLength, out var length))
+			return null;
+
+		return root.FindNode(new TextSpan(start, length), getInnermostNodeForTie: true) as ExpressionSyntax;
+	}
+
+	static string GetSafeVariableName(
+		string baseName,
+		ImmutableHashSet<string> localSymbols)
+	{
+		var idx = 2;
+		var result = baseName;
+
+		while (localSymbols.Contains(result))
+			result = string.Format(CultureInfo.InvariantCulture, "{0}_{1}", baseName, idx++);
+
+		return result;
+	}
+
+	static bool TryGetIntProperty(
+		Diagnostic diagnostic,
+		string key,
+		out int value)
+	{
+		value = 0;
+
+		return
+			diagnostic.Properties.TryGetValue(key, out var text)
+			&& int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+	}
+
+	static async Task<Document> UseReturnValue(
+		Document document,
+		InvocationExpressionSyntax invocation,
+		ExpressionStatementSyntax assertStatement,
+		ExpressionSyntax rederivation,
+		string variableName,
+		CancellationToken cancellationToken)
+	{
+		var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+		var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+		if (semanticModel is null)
+			return document;
+
+		var localSymbols =
+			semanticModel
+				.LookupSymbols(invocation.GetLocation().SourceSpan.Start)
+				.OfType<ILocalSymbol>()
+				.Select(s => s.Name)
+				.ToImmutableHashSet();
+		var safeName = GetSafeVariableName(variableName, localSymbols);
+
+		var declaration =
+			LocalDeclarationStatement(
+				VariableDeclaration(
+					ParseTypeName("var"),
+					SingletonSeparatedList(
+						VariableDeclarator(Identifier(safeName))
+							.WithInitializer(EqualsValueClause(invocation.WithoutTrivia()))
+					)
+				).NormalizeWhitespace()
+			).WithTriviaFrom(assertStatement);
+
+		editor.ReplaceNode(assertStatement, declaration);
+		editor.ReplaceNode(rederivation, IdentifierName(safeName).WithTriviaFrom(rederivation));
+
+		return editor.GetChangedDocument();
+	}
+}

--- a/src/xunit.analyzers.tests/Analyzers/X2000/X2033_AssertReturnValueShouldBeUsedTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X2000/X2033_AssertReturnValueShouldBeUsedTests.cs
@@ -5,14 +5,63 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertReturnValueShouldBeUsed>;
 public class X2033_AssertReturnValueShouldBeUsedTests
 {
 	[Fact]
-	public async ValueTask SingleFollowedByRederivation_Triggers()
+	public async ValueTask V2_and_V3()
 	{
 		var source = /* lang=c#-test */ """
+			using System;
 			using System.Collections.Generic;
 			using System.Linq;
 			using Xunit;
 
-			class TestClass {
+			class SingleSamples {
+				// Success cases
+
+				void GuardWithoutRederivation() {
+					var xs = new List<int> { 42 };
+					Assert.Single(xs);
+					var count = xs.Count;
+				}
+
+				void ReturnValueAlreadyUsed() {
+					var xs = new List<int> { 42 };
+					var item = Assert.Single(xs);
+					var text = item.ToString();
+				}
+
+				void ExpectedValueOverloadReturnsNothing() {
+					var xs = new List<int> { 42 };
+					Assert.Single(xs, 42);
+					var item = xs.First();
+				}
+
+				void PredicateOverloadIsDifferentComputation() {
+					var xs = new List<int> { 42 };
+					Assert.Single(xs);
+					var filtered = xs.Single(x => x > 21);
+				}
+
+				void DifferentCollection() {
+					var xs = new List<int> { 42 };
+					var ys = new List<int> { 21 };
+					Assert.Single(xs);
+					var other = ys.First();
+				}
+
+				void ReassignmentBetweenAssertAndRederivation() {
+					var xs = new List<int> { 42 };
+					Assert.Single(xs);
+					xs = new List<int> { 1, 2 };
+					var first = xs.First();
+				}
+
+				void RederivationBeforeAssert() {
+					var xs = new List<int> { 42 };
+					var first = xs.First();
+					Assert.Single(xs);
+				}
+
+				// Failure cases
+
 				void ViaSingle() {
 					var xs = new List<int> { 42 };
 					{|#0:Assert.Single(xs)|};
@@ -36,125 +85,20 @@ public class X2033_AssertReturnValueShouldBeUsedTests
 					{|#3:Assert.Single(xs)|};
 					var item = xs[0];
 				}
-			}
-			""";
-		var expected = new[] {
-			Verify.Diagnostic().WithLocation(0).WithArguments("Single", "xs.Single()"),
-			Verify.Diagnostic().WithLocation(1).WithArguments("Single", "xs.First()"),
-			Verify.Diagnostic().WithLocation(2).WithArguments("Single", "xs.ElementAt(0)"),
-			Verify.Diagnostic().WithLocation(3).WithArguments("Single", "xs[0]"),
-		};
 
-		await Verify.VerifyAnalyzer(source, expected);
-	}
-
-	[Fact]
-	public async ValueTask TypeAssertFollowedByRederivation_Triggers()
-	{
-		var source = /* lang=c#-test */ """
-			using Xunit;
-
-			class TestClass {
-				void ViaCast() {
-					object value = "Hello world";
-					{|#0:Assert.IsType<string>(value)|};
-					var text = (string)value;
-				}
-
-				void ViaAsExpression() {
-					object value = "Hello world";
-					{|#1:Assert.IsAssignableFrom<string>(value)|};
-					var text = value as string;
-				}
-			}
-			""";
-		var expected = new[] {
-			Verify.Diagnostic().WithLocation(0).WithArguments("IsType", "(string)value"),
-			Verify.Diagnostic().WithLocation(1).WithArguments("IsAssignableFrom", "value as string"),
-		};
-
-		await Verify.VerifyAnalyzer(source, expected);
-	}
-
-	[Fact]
-	public async ValueTask RederivationOnlyInLaterStatementsOfSameBlock_Triggers()
-	{
-		var source = /* lang=c#-test */ """
-			using System.Collections.Generic;
-			using System.Linq;
-			using Xunit;
-
-			class TestClass {
 				void RederivationInsideDeclarationInitializer() {
 					var xs = new List<string> { "Hello world" };
-					{|#0:Assert.Single(xs)|};
+					{|#4:Assert.Single(xs)|};
 					var length = xs.Single().Length;
 				}
 			}
-			""";
-		var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Single", "xs.Single()");
 
-		await Verify.VerifyAnalyzer(source, expected);
-	}
-
-	[Fact]
-	public async ValueTask NoRederivation_DoesNotTrigger()
-	{
-		var source = /* lang=c#-test */ """
-			using System.Collections.Generic;
-			using System.Linq;
-			using Xunit;
-
-			class TestClass {
-				void GuardWithoutRederivation() {
-					var xs = new List<int> { 42 };
-					Assert.Single(xs);
-					var count = xs.Count;
-				}
-
-				void ReturnValueAlreadyUsed() {
-					var xs = new List<int> { 42 };
-					var item = Assert.Single(xs);
-					var text = item.ToString();
-				}
+			class IsTypeSamples {
+				// Success cases
 
 				void TypeGuardWithoutRederivation() {
 					object value = "Hello world";
 					Assert.IsType<string>(value);
-				}
-
-				void ExpectedValueOverloadReturnsNothing() {
-					var xs = new List<int> { 42 };
-					Assert.Single(xs, 42);
-					var item = xs.First();
-				}
-			}
-			""";
-
-		await Verify.VerifyAnalyzer(source);
-	}
-
-	[Fact]
-	public async ValueTask DifferentComputation_DoesNotTrigger()
-	{
-		var source = /* lang=c#-test */ """
-			using System;
-			using System.Collections.Generic;
-			using System.Linq;
-			using Xunit;
-
-			class TestClass {
-				void PredicateOverloadIsDifferentComputation() {
-					var xs = new List<int> { 42 };
-					Assert.Single(xs);
-					var filtered = xs.Single(x => x > 21);
-				}
-
-				void DifferentCollection() {
-					var xs = new List<int> { 42 };
-					var ys = new List<int> { 21 };
-					Assert.Single(xs);
-					var other = ys.First();
 				}
 
 				void DifferentTypeArgument() {
@@ -169,36 +113,72 @@ public class X2033_AssertReturnValueShouldBeUsedTests
 					Assert.IsType<string>(value);
 					var text = (string)other;
 				}
-			}
-			""";
 
-		await Verify.VerifyAnalyzer(source);
-	}
+				// Failure cases
 
-	[Fact]
-	public async ValueTask RederivationOutsideWindow_DoesNotTrigger()
-	{
-		var source = /* lang=c#-test */ """
-			using System.Collections.Generic;
-			using System.Linq;
-			using Xunit;
-
-			class TestClass {
-				void ReassignmentBetweenAssertAndRederivation() {
-					var xs = new List<int> { 42 };
-					Assert.Single(xs);
-					xs = new List<int> { 1, 2 };
-					var first = xs.First();
+				void ViaCast() {
+					object value = "Hello world";
+					{|#10:Assert.IsType<string>(value)|};
+					var text = (string)value;
 				}
 
-				void RederivationBeforeAssert() {
-					var xs = new List<int> { 42 };
-					var first = xs.First();
-					Assert.Single(xs);
+				void ViaAsExpression() {
+					object value = "Hello world";
+					{|#11:Assert.IsType<string>(value)|};
+					var text = value as string;
+				}
+			}
+
+			class IsAssignableFromSamples {
+				// Success cases
+
+				void TypeGuardWithoutRederivation() {
+					object value = "Hello world";
+					Assert.IsAssignableFrom<string>(value);
+				}
+
+				void DifferentTypeArgument() {
+					object value = "Hello world";
+					Assert.IsAssignableFrom<string>(value);
+					var comparable = (IComparable)value;
+				}
+
+				void CastOfDifferentExpression() {
+					object value = "Hello world";
+					object other = "Other value";
+					Assert.IsAssignableFrom<string>(value);
+					var text = (string)other;
+				}
+
+				// Failure cases
+
+				void ViaCast() {
+					object value = "Hello world";
+					{|#20:Assert.IsAssignableFrom<string>(value)|};
+					var text = (string)value;
+				}
+
+				void ViaAsExpression() {
+					object value = "Hello world";
+					{|#21:Assert.IsAssignableFrom<string>(value)|};
+					var text = value as string;
 				}
 			}
 			""";
+		var expected = new[] {
+			Verify.Diagnostic().WithLocation(0).WithArguments("Single", "xs.Single()"),
+			Verify.Diagnostic().WithLocation(1).WithArguments("Single", "xs.First()"),
+			Verify.Diagnostic().WithLocation(2).WithArguments("Single", "xs.ElementAt(0)"),
+			Verify.Diagnostic().WithLocation(3).WithArguments("Single", "xs[0]"),
+			Verify.Diagnostic().WithLocation(4).WithArguments("Single", "xs.Single()"),
 
-		await Verify.VerifyAnalyzer(source);
+			Verify.Diagnostic().WithLocation(10).WithArguments("IsType", "(string)value"),
+			Verify.Diagnostic().WithLocation(11).WithArguments("IsType", "value as string"),
+
+			Verify.Diagnostic().WithLocation(20).WithArguments("IsAssignableFrom", "(string)value"),
+			Verify.Diagnostic().WithLocation(21).WithArguments("IsAssignableFrom", "value as string"),
+		};
+
+		await Verify.VerifyAnalyzer(source, expected);
 	}
 }

--- a/src/xunit.analyzers.tests/Analyzers/X2000/X2033_AssertReturnValueShouldBeUsedTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X2000/X2033_AssertReturnValueShouldBeUsedTests.cs
@@ -1,0 +1,204 @@
+using System.Threading.Tasks;
+using Xunit;
+using Verify = CSharpVerifier<Xunit.Analyzers.AssertReturnValueShouldBeUsed>;
+
+public class X2033_AssertReturnValueShouldBeUsedTests
+{
+	[Fact]
+	public async ValueTask SingleFollowedByRederivation_Triggers()
+	{
+		var source = /* lang=c#-test */ """
+			using System.Collections.Generic;
+			using System.Linq;
+			using Xunit;
+
+			class TestClass {
+				void ViaSingle() {
+					var xs = new List<int> { 42 };
+					{|#0:Assert.Single(xs)|};
+					var item = xs.Single();
+				}
+
+				void ViaFirst() {
+					var xs = new List<int> { 42 };
+					{|#1:Assert.Single(xs)|};
+					var item = xs.First();
+				}
+
+				void ViaElementAt() {
+					var xs = new List<int> { 42 };
+					{|#2:Assert.Single(xs)|};
+					var item = xs.ElementAt(0);
+				}
+
+				void ViaIndexer() {
+					var xs = new List<int> { 42 };
+					{|#3:Assert.Single(xs)|};
+					var item = xs[0];
+				}
+			}
+			""";
+		var expected = new[] {
+			Verify.Diagnostic().WithLocation(0).WithArguments("Single", "xs.Single()"),
+			Verify.Diagnostic().WithLocation(1).WithArguments("Single", "xs.First()"),
+			Verify.Diagnostic().WithLocation(2).WithArguments("Single", "xs.ElementAt(0)"),
+			Verify.Diagnostic().WithLocation(3).WithArguments("Single", "xs[0]"),
+		};
+
+		await Verify.VerifyAnalyzer(source, expected);
+	}
+
+	[Fact]
+	public async ValueTask TypeAssertFollowedByRederivation_Triggers()
+	{
+		var source = /* lang=c#-test */ """
+			using Xunit;
+
+			class TestClass {
+				void ViaCast() {
+					object value = "Hello world";
+					{|#0:Assert.IsType<string>(value)|};
+					var text = (string)value;
+				}
+
+				void ViaAsExpression() {
+					object value = "Hello world";
+					{|#1:Assert.IsAssignableFrom<string>(value)|};
+					var text = value as string;
+				}
+			}
+			""";
+		var expected = new[] {
+			Verify.Diagnostic().WithLocation(0).WithArguments("IsType", "(string)value"),
+			Verify.Diagnostic().WithLocation(1).WithArguments("IsAssignableFrom", "value as string"),
+		};
+
+		await Verify.VerifyAnalyzer(source, expected);
+	}
+
+	[Fact]
+	public async ValueTask RederivationOnlyInLaterStatementsOfSameBlock_Triggers()
+	{
+		var source = /* lang=c#-test */ """
+			using System.Collections.Generic;
+			using System.Linq;
+			using Xunit;
+
+			class TestClass {
+				void RederivationInsideDeclarationInitializer() {
+					var xs = new List<string> { "Hello world" };
+					{|#0:Assert.Single(xs)|};
+					var length = xs.Single().Length;
+				}
+			}
+			""";
+		var expected = Verify.Diagnostic().WithLocation(0).WithArguments("Single", "xs.Single()");
+
+		await Verify.VerifyAnalyzer(source, expected);
+	}
+
+	[Fact]
+	public async ValueTask NoRederivation_DoesNotTrigger()
+	{
+		var source = /* lang=c#-test */ """
+			using System.Collections.Generic;
+			using System.Linq;
+			using Xunit;
+
+			class TestClass {
+				void GuardWithoutRederivation() {
+					var xs = new List<int> { 42 };
+					Assert.Single(xs);
+					var count = xs.Count;
+				}
+
+				void ReturnValueAlreadyUsed() {
+					var xs = new List<int> { 42 };
+					var item = Assert.Single(xs);
+					var text = item.ToString();
+				}
+
+				void TypeGuardWithoutRederivation() {
+					object value = "Hello world";
+					Assert.IsType<string>(value);
+				}
+
+				void ExpectedValueOverloadReturnsNothing() {
+					var xs = new List<int> { 42 };
+					Assert.Single(xs, 42);
+					var item = xs.First();
+				}
+			}
+			""";
+
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Fact]
+	public async ValueTask DifferentComputation_DoesNotTrigger()
+	{
+		var source = /* lang=c#-test */ """
+			using System;
+			using System.Collections.Generic;
+			using System.Linq;
+			using Xunit;
+
+			class TestClass {
+				void PredicateOverloadIsDifferentComputation() {
+					var xs = new List<int> { 42 };
+					Assert.Single(xs);
+					var filtered = xs.Single(x => x > 21);
+				}
+
+				void DifferentCollection() {
+					var xs = new List<int> { 42 };
+					var ys = new List<int> { 21 };
+					Assert.Single(xs);
+					var other = ys.First();
+				}
+
+				void DifferentTypeArgument() {
+					object value = "Hello world";
+					Assert.IsType<string>(value);
+					var comparable = (IComparable)value;
+				}
+
+				void CastOfDifferentExpression() {
+					object value = "Hello world";
+					object other = "Other value";
+					Assert.IsType<string>(value);
+					var text = (string)other;
+				}
+			}
+			""";
+
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Fact]
+	public async ValueTask RederivationOutsideWindow_DoesNotTrigger()
+	{
+		var source = /* lang=c#-test */ """
+			using System.Collections.Generic;
+			using System.Linq;
+			using Xunit;
+
+			class TestClass {
+				void ReassignmentBetweenAssertAndRederivation() {
+					var xs = new List<int> { 42 };
+					Assert.Single(xs);
+					xs = new List<int> { 1, 2 };
+					var first = xs.First();
+				}
+
+				void RederivationBeforeAssert() {
+					var xs = new List<int> { 42 };
+					var first = xs.First();
+					Assert.Single(xs);
+				}
+			}
+			""";
+
+		await Verify.VerifyAnalyzer(source);
+	}
+}

--- a/src/xunit.analyzers.tests/Fixes/X2000/X2033_AssertReturnValueShouldBeUsedFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/X2033_AssertReturnValueShouldBeUsedFixerTests.cs
@@ -6,7 +6,7 @@ using Verify = CSharpVerifier<Xunit.Analyzers.AssertReturnValueShouldBeUsed>;
 public class X2033_AssertReturnValueShouldBeUsedFixerTests
 {
 	[Fact]
-	public async ValueTask UsesSingleReturnValue()
+	public async ValueTask V2_and_V3()
 	{
 		var before = /* lang=c#-test */ """
 			using System.Collections.Generic;
@@ -15,71 +15,21 @@ public class X2033_AssertReturnValueShouldBeUsedFixerTests
 
 			public class TestClass {
 				[Fact]
-				public void TestMethod() {
+				public void UsesSingleReturnValue() {
 					var xs = new List<int> { 42 };
 					[|Assert.Single(xs)|];
 					var value = xs.Single();
 				}
-			}
-			""";
-		var after = /* lang=c#-test */ """
-			using System.Collections.Generic;
-			using System.Linq;
-			using Xunit;
 
-			public class TestClass {
 				[Fact]
-				public void TestMethod() {
-					var xs = new List<int> { 42 };
-					var item = Assert.Single(xs);
-					var value = item;
-				}
-			}
-			""";
-		await Verify.VerifyCodeFix(before, after, AssertReturnValueShouldBeUsedFixer.Key_UseReturnValue);
-	}
-
-	[Fact]
-	public async ValueTask UsesTypeAssertReturnValue()
-	{
-		var before = /* lang=c#-test */ """
-			using Xunit;
-
-			public class TestClass {
-				[Fact]
-				public void TestMethod() {
+				public void UsesTypeAssertReturnValue() {
 					object value = "Hello world";
 					[|Assert.IsType<string>(value)|];
 					var text = (string)value;
 				}
-			}
-			""";
-		var after = /* lang=c#-test */ """
-			using Xunit;
 
-			public class TestClass {
 				[Fact]
-				public void TestMethod() {
-					object value = "Hello world";
-					var typed = Assert.IsType<string>(value);
-					var text = typed;
-				}
-			}
-			""";
-		await Verify.VerifyCodeFix(before, after, AssertReturnValueShouldBeUsedFixer.Key_UseReturnValue);
-	}
-
-	[Fact]
-	public async ValueTask PicksSafeVariableNameOnCollision()
-	{
-		var before = /* lang=c#-test */ """
-			using System.Collections.Generic;
-			using System.Linq;
-			using Xunit;
-
-			public class TestClass {
-				[Fact]
-				public void TestMethod() {
+				public void PicksSafeVariableNameOnCollision() {
 					var item = 42;
 					var xs = new List<int> { 42 };
 					[|Assert.Single(xs)|];
@@ -94,7 +44,21 @@ public class X2033_AssertReturnValueShouldBeUsedFixerTests
 
 			public class TestClass {
 				[Fact]
-				public void TestMethod() {
+				public void UsesSingleReturnValue() {
+					var xs = new List<int> { 42 };
+					var item = Assert.Single(xs);
+					var value = item;
+				}
+
+				[Fact]
+				public void UsesTypeAssertReturnValue() {
+					object value = "Hello world";
+					var typed = Assert.IsType<string>(value);
+					var text = typed;
+				}
+
+				[Fact]
+				public void PicksSafeVariableNameOnCollision() {
 					var item = 42;
 					var xs = new List<int> { 42 };
 					var item_2 = Assert.Single(xs);
@@ -102,6 +66,7 @@ public class X2033_AssertReturnValueShouldBeUsedFixerTests
 				}
 			}
 			""";
+
 		await Verify.VerifyCodeFix(before, after, AssertReturnValueShouldBeUsedFixer.Key_UseReturnValue);
 	}
 }

--- a/src/xunit.analyzers.tests/Fixes/X2000/X2033_AssertReturnValueShouldBeUsedFixerTests.cs
+++ b/src/xunit.analyzers.tests/Fixes/X2000/X2033_AssertReturnValueShouldBeUsedFixerTests.cs
@@ -1,0 +1,107 @@
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Analyzers.Fixes;
+using Verify = CSharpVerifier<Xunit.Analyzers.AssertReturnValueShouldBeUsed>;
+
+public class X2033_AssertReturnValueShouldBeUsedFixerTests
+{
+	[Fact]
+	public async ValueTask UsesSingleReturnValue()
+	{
+		var before = /* lang=c#-test */ """
+			using System.Collections.Generic;
+			using System.Linq;
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var xs = new List<int> { 42 };
+					[|Assert.Single(xs)|];
+					var value = xs.Single();
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using System.Collections.Generic;
+			using System.Linq;
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var xs = new List<int> { 42 };
+					var item = Assert.Single(xs);
+					var value = item;
+				}
+			}
+			""";
+		await Verify.VerifyCodeFix(before, after, AssertReturnValueShouldBeUsedFixer.Key_UseReturnValue);
+	}
+
+	[Fact]
+	public async ValueTask UsesTypeAssertReturnValue()
+	{
+		var before = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					object value = "Hello world";
+					[|Assert.IsType<string>(value)|];
+					var text = (string)value;
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					object value = "Hello world";
+					var typed = Assert.IsType<string>(value);
+					var text = typed;
+				}
+			}
+			""";
+		await Verify.VerifyCodeFix(before, after, AssertReturnValueShouldBeUsedFixer.Key_UseReturnValue);
+	}
+
+	[Fact]
+	public async ValueTask PicksSafeVariableNameOnCollision()
+	{
+		var before = /* lang=c#-test */ """
+			using System.Collections.Generic;
+			using System.Linq;
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var item = 42;
+					var xs = new List<int> { 42 };
+					[|Assert.Single(xs)|];
+					var value = xs.Single();
+				}
+			}
+			""";
+		var after = /* lang=c#-test */ """
+			using System.Collections.Generic;
+			using System.Linq;
+			using Xunit;
+
+			public class TestClass {
+				[Fact]
+				public void TestMethod() {
+					var item = 42;
+					var xs = new List<int> { 42 };
+					var item_2 = Assert.Single(xs);
+					var value = item_2;
+				}
+			}
+			""";
+		await Verify.VerifyCodeFix(before, after, AssertReturnValueShouldBeUsedFixer.Key_UseReturnValue);
+	}
+}

--- a/src/xunit.analyzers/Utility/Constants.cs
+++ b/src/xunit.analyzers/Utility/Constants.cs
@@ -110,6 +110,8 @@ public static class Constants
 		public const string ParameterIndex = nameof(ParameterIndex);
 		public const string ParameterName = nameof(ParameterName);
 		public const string ParameterSpecialType = nameof(ParameterSpecialType);
+		public const string RederivationSpanLength = nameof(RederivationSpanLength);
+		public const string RederivationSpanStart = nameof(RederivationSpanStart);
 		public const string Replacement = nameof(Replacement);
 		public const string SizeValue = nameof(SizeValue);
 		public const string SubstringMethodName = nameof(SubstringMethodName);

--- a/src/xunit.analyzers/Utility/Descriptors.xUnit2xxx.cs
+++ b/src/xunit.analyzers/Utility/Descriptors.xUnit2xxx.cs
@@ -296,7 +296,14 @@ public static partial class Descriptors
 			"The naming of Assert.{0} can be confusing. An overload of Assert.{1} is available with an exact match flag which can be set to false to perform the same operation."
 		);
 
-	// Placeholder for rule X2033
+	public static DiagnosticDescriptor X2033_AssertReturnValueShouldBeUsed { get; } =
+		Diagnostic(
+			"xUnit2033",
+			"Use the assertion return value instead of re-deriving it",
+			Assertions,
+			Info,
+			"The return value of Assert.{0} should be used instead of re-deriving it with '{1}'."
+		);
 
 	// Placeholder for rule X2034
 

--- a/src/xunit.analyzers/X2000/AssertReturnValueShouldBeUsed.cs
+++ b/src/xunit.analyzers/X2000/AssertReturnValueShouldBeUsed.cs
@@ -1,0 +1,247 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Xunit.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class AssertReturnValueShouldBeUsed : AssertUsageAnalyzerBase
+{
+	const string elementAtMethod = "ElementAt";
+	const string firstMethod = "First";
+
+	static readonly string[] targetMethods =
+	[
+		Constants.Asserts.IsAssignableFrom,
+		Constants.Asserts.IsType,
+		Constants.Asserts.Single,
+	];
+
+	public AssertReturnValueShouldBeUsed() :
+		base(Descriptors.X2033_AssertReturnValueShouldBeUsed, targetMethods)
+	{ }
+
+	protected override void AnalyzeInvocation(
+		OperationAnalysisContext context,
+		XunitContext xunitContext,
+		IInvocationOperation invocationOperation,
+		IMethodSymbol method)
+	{
+		Guard.ArgumentNotNull(xunitContext);
+		Guard.ArgumentNotNull(invocationOperation);
+		Guard.ArgumentNotNull(method);
+
+		// Only interested in assertions whose return value is thrown away
+		if (method.ReturnsVoid || invocationOperation.Parent is not IExpressionStatementOperation)
+			return;
+
+		if (!TryGetValueExpression(invocationOperation, method, out var valueExpression, out var typeArgument) || valueExpression is null)
+			return;
+
+		if (invocationOperation.Syntax.FirstAncestorOrSelf<ExpressionStatementSyntax>() is not { Parent: BlockSyntax block } assertStatement)
+			return;
+
+		var rootIdentifier = GetRootIdentifier(valueExpression);
+
+		foreach (var statement in block.Statements.Skip(block.Statements.IndexOf(assertStatement) + 1))
+		{
+			var rederivation = FindRederivation(statement, method, valueExpression, typeArgument, invocationOperation.SemanticModel);
+			if (rederivation is not null)
+			{
+				var properties = ImmutableDictionary.CreateBuilder<string, string?>();
+				properties[Constants.Properties.AssertMethodName] = method.Name;
+				properties[Constants.Properties.RederivationSpanStart] = rederivation.SpanStart.ToString(CultureInfo.InvariantCulture);
+				properties[Constants.Properties.RederivationSpanLength] = rederivation.Span.Length.ToString(CultureInfo.InvariantCulture);
+
+				context.ReportDiagnostic(
+					Diagnostic.Create(
+						Descriptors.X2033_AssertReturnValueShouldBeUsed,
+						invocationOperation.Syntax.GetLocation(),
+						properties.ToImmutable(),
+						method.Name,
+						rederivation.ToString()
+					)
+				);
+				return;
+			}
+
+			// Once the value may have changed, later matches are no longer re-derivations
+			if (rootIdentifier is not null && ReassignsIdentifier(statement, rootIdentifier))
+				return;
+		}
+	}
+
+	static bool TryGetValueExpression(
+		IInvocationOperation invocation,
+		IMethodSymbol method,
+		out ExpressionSyntax? valueExpression,
+		out ITypeSymbol? typeArgument)
+	{
+		valueExpression = null;
+		typeArgument = null;
+
+		// For Single, only the single-argument overload applies; the expected-value and
+		// predicate overloads assert something else than "the one and only item". For the
+		// type assertions, only the generic overloads carry the type being asserted.
+		if (method.Name == Constants.Asserts.Single)
+		{
+			if (method.Parameters.Length != 1)
+				return false;
+		}
+		else if (method is { IsGenericMethod: true, TypeArguments.Length: 1 })
+			typeArgument = method.TypeArguments[0];
+		else
+			return false;
+
+		var argument = invocation.Arguments.FirstOrDefault(a => a.Parameter?.Ordinal == 0);
+		if (argument is null)
+			return false;
+
+		var value = argument.Value;
+		while (value is IConversionOperation { IsImplicit: true } conversion)
+			value = conversion.Operand;
+
+		valueExpression = value.Syntax as ExpressionSyntax;
+		return valueExpression is not null;
+	}
+
+	static ExpressionSyntax? FindRederivation(
+		StatementSyntax statement,
+		IMethodSymbol method,
+		ExpressionSyntax valueExpression,
+		ITypeSymbol? typeArgument,
+		SemanticModel? semanticModel)
+	{
+		// Lambdas and local functions run at some other time, so they are not re-derivations
+		var candidates =
+			statement.DescendantNodesAndSelf(node =>
+				node is not AnonymousFunctionExpressionSyntax && node is not LocalFunctionStatementSyntax
+			);
+
+		return candidates
+			.Select(candidate =>
+				method.Name == Constants.Asserts.Single
+					? GetSingleItemRederivation(candidate, valueExpression)
+					: GetTypedRederivation(candidate, valueExpression, typeArgument, semanticModel)
+			)
+			.FirstOrDefault(match => match is not null);
+	}
+
+	static ExpressionSyntax? GetSingleItemRederivation(
+		SyntaxNode candidate,
+		ExpressionSyntax valueExpression) =>
+			candidate switch
+			{
+				InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax memberAccess } invocation
+					when RederivesSingleItem(memberAccess.Name.Identifier.ValueText, invocation.ArgumentList.Arguments)
+						&& AreEquivalent(valueExpression, memberAccess.Expression) =>
+							invocation,
+				ElementAccessExpressionSyntax elementAccess
+					when IsZeroIndexer(elementAccess.ArgumentList.Arguments) && AreEquivalent(valueExpression, elementAccess.Expression) =>
+						elementAccess,
+				_ => null,
+			};
+
+	static bool RederivesSingleItem(
+		string methodName,
+		SeparatedSyntaxList<ArgumentSyntax> arguments) =>
+			methodName switch
+			{
+				Constants.Asserts.Single or firstMethod => arguments.Count == 0,
+				elementAtMethod => IsZeroIndexer(arguments),
+				_ => false,
+			};
+
+	static ExpressionSyntax? GetTypedRederivation(
+		SyntaxNode candidate,
+		ExpressionSyntax valueExpression,
+		ITypeSymbol? typeArgument,
+		SemanticModel? semanticModel)
+	{
+		if (typeArgument is null || semanticModel is null)
+			return null;
+
+		var (operand, typeSyntax) = candidate switch
+		{
+			CastExpressionSyntax cast =>
+				(cast.Expression, cast.Type),
+			BinaryExpressionSyntax { RawKind: (int)SyntaxKind.AsExpression, Right: TypeSyntax asType } binary =>
+				(binary.Left, asType),
+			_ =>
+				(default(ExpressionSyntax), default(TypeSyntax)),
+		};
+
+		if (operand is null || typeSyntax is null || !AreEquivalent(valueExpression, operand))
+			return null;
+
+		return SymbolEqualityComparer.Default.Equals(semanticModel.GetTypeInfo(typeSyntax).Type, typeArgument)
+			? (ExpressionSyntax)candidate
+			: null;
+	}
+
+	static IdentifierNameSyntax? GetRootIdentifier(ExpressionSyntax expression)
+	{
+		while (true)
+			switch (expression)
+			{
+				case IdentifierNameSyntax identifier:
+					return identifier;
+				case MemberAccessExpressionSyntax memberAccess:
+					expression = memberAccess.Expression;
+					break;
+				case ElementAccessExpressionSyntax elementAccess:
+					expression = elementAccess.Expression;
+					break;
+				case InvocationExpressionSyntax invocation:
+					expression = invocation.Expression;
+					break;
+				case ParenthesizedExpressionSyntax parenthesized:
+					expression = parenthesized.Expression;
+					break;
+				default:
+					return null;
+			}
+	}
+
+	static bool ReassignsIdentifier(
+		StatementSyntax statement,
+		IdentifierNameSyntax rootIdentifier)
+	{
+		var identifier = rootIdentifier.Identifier.ValueText;
+
+		return statement.DescendantNodesAndSelf().Any(node => node switch
+		{
+			AssignmentExpressionSyntax assignment =>
+				IsIdentifier(assignment.Left, identifier),
+			PrefixUnaryExpressionSyntax prefix when prefix.IsKind(SyntaxKind.PreIncrementExpression) || prefix.IsKind(SyntaxKind.PreDecrementExpression) =>
+				IsIdentifier(prefix.Operand, identifier),
+			PostfixUnaryExpressionSyntax postfix when postfix.IsKind(SyntaxKind.PostIncrementExpression) || postfix.IsKind(SyntaxKind.PostDecrementExpression) =>
+				IsIdentifier(postfix.Operand, identifier),
+			ArgumentSyntax argument =>
+				!argument.RefKindKeyword.IsKind(SyntaxKind.None) && IsIdentifier(argument.Expression, identifier),
+			_ =>
+				false,
+		});
+	}
+
+	static bool AreEquivalent(
+		ExpressionSyntax valueExpression,
+		ExpressionSyntax candidate) =>
+			SyntaxFactory.AreEquivalent(valueExpression, candidate, topLevel: false);
+
+	static bool IsIdentifier(
+		ExpressionSyntax expression,
+		string identifier) =>
+			expression is IdentifierNameSyntax identifierName && identifierName.Identifier.ValueText == identifier;
+
+	static bool IsZeroIndexer(SeparatedSyntaxList<ArgumentSyntax> arguments) =>
+		arguments.Count == 1 && IsZeroLiteral(arguments[0].Expression);
+
+	static bool IsZeroLiteral(ExpressionSyntax expression) =>
+		expression is LiteralExpressionSyntax literal && literal.IsKind(SyntaxKind.NumericLiteralExpression) && literal.Token.ValueText == "0";
+}

--- a/src/xunit.analyzers/X2000/AssertReturnValueShouldBeUsed.cs
+++ b/src/xunit.analyzers/X2000/AssertReturnValueShouldBeUsed.cs
@@ -173,7 +173,7 @@ public class AssertReturnValueShouldBeUsed : AssertUsageAnalyzerBase
 			BinaryExpressionSyntax { RawKind: (int)SyntaxKind.AsExpression, Right: TypeSyntax asType } binary =>
 				(binary.Left, asType),
 			_ =>
-				(default(ExpressionSyntax), default(TypeSyntax)),
+				(default, default),
 		};
 
 		if (operand is null || typeSyntax is null || !AreEquivalent(valueExpression, operand))


### PR DESCRIPTION
Fixes xunit/xunit#1506

## Summary

`Assert.Single`, `Assert.IsType<T>`, and `Assert.IsAssignableFrom<T>` return useful values (the single item / the typed value), but tests often throw the value away and then re-derive it:

```csharp
Assert.Single(filters);
Filter filter = filters.Single();

Assert.IsType<MyType>(value);
var typed = (MyType)value;
```

This PR adds **xUnit2033: Use the assertion return value instead of re-deriving it** (Info severity, Assertions category), plus a code fixer that turns the assertion into `var item = Assert.Single(filters);` and replaces the later re-derivation with the new variable.

## Design: only provable re-derivations are flagged

To keep the rule noise-free, the diagnostic is reported only when both hold:

- the assertion's return value is discarded (the call is a standalone expression statement), and
- a later statement in the same block re-derives the same value:
  - after `Assert.Single(xs)`: a parameterless `xs.Single()` / `xs.First()` / `xs.ElementAt(0)` / `xs[0]`
  - after `Assert.IsType<T>(x)` / `Assert.IsAssignableFrom<T>(x)`: `(T)x` or `x as T` (same `T` by symbol comparison)
  - where `xs` / `x` are compared as syntactically equivalent expressions

Deliberately not flagged:

- the guard idiom (`Assert.Single(xs);` with no later re-derivation): discarding the return value on purpose is legitimate and common, so the plain "return value unused" case stays silent
- the `Single(collection, expected)` and `Single(collection, predicate)` overloads (they assert something different), and predicate-based `xs.Single(...)` / `xs.First(...)` re-derivation candidates
- anything after the root identifier may have changed (`xs = ...`, `ref` / `out` argument, increment / decrement)
- matches inside lambdas or local functions (they run at another time)

The fixer picks a collision-safe variable name (`item` / `typed`, suffixed with `_2` etc. when taken), mirroring the xUnit2023 fixer.

## Tests

TDD: analyzer tests were written first against a no-op skeleton (RED 3/6) and driven to GREEN; fixer tests likewise (RED 3/3, then GREEN). Full suite: net8.0 304/304, net472 291/291.
