### PR TITLE
xUnit1041: Fix crash on [assembly: AssemblyFixture] without an argument

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/X1041_EnsureFixturesHaveASourceTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/X1041_EnsureFixturesHaveASourceTests.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using Verify = CSharpVerifier<Xunit.Analyzers.EnsureFixturesHaveASource>;
 
@@ -250,5 +251,24 @@ public class X1041_EnsureFixturesHaveASourceTests
 			""";
 
 		await Verify.VerifyAnalyzerV3(LanguageVersion.CSharp11, source);
+	}
+
+	[Fact]
+	public async ValueTask V3_AssemblyFixtureWithoutArgument_DoesNotCrash()
+	{
+		var source = /* lang=c#-test */ """
+			using Xunit;
+
+			[assembly: AssemblyFixture]
+
+			public class TestClass {
+				public TestClass(int {|#0:x|}) { }
+
+				[Fact] public void TestMethod() { }
+			}
+			""";
+		var expected = Verify.Diagnostic().WithLocation(0).WithArguments("x");
+
+		await Verify.VerifyAnalyzerV3(CompilerDiagnostics.None, source, expected);
 	}
 }

--- a/src/xunit.analyzers/X1000/EnsureFixturesHaveASource.cs
+++ b/src/xunit.analyzers/X1000/EnsureFixturesHaveASource.cs
@@ -125,7 +125,7 @@ public class EnsureFixturesHaveASource : XunitDiagnosticAnalyzer
 					namedType
 						.ContainingAssembly
 						.GetAttributes()
-						.Where(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, assemblyFixtureAttributeType))
+						.Where(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, assemblyFixtureAttributeType) && !a.ConstructorArguments.IsDefaultOrEmpty)
 						.Select(a => a.ConstructorArguments[0].Value as ITypeSymbol)
 				);
 


### PR DESCRIPTION
## Summary

`EnsureFixturesHaveASource` (xUnit1041) read `ConstructorArguments[0]` for every `AssemblyFixture` attribute without checking that an argument exists. When the attribute has no argument (which happens all the time while typing), the analyzer threw `IndexOutOfRangeException` (AD0001).

Assembly attributes are checked for every test class, so one incomplete `[assembly: AssemblyFixture]` crashed the analyzer for every test class and turned off xUnit1041 across the whole project.

## Repro

```csharp
using Xunit;

[assembly: AssemblyFixture]

public class TestClass {
    public TestClass(int x) { }

    [Fact]
    public void TestMethod() { }
}
```

- **Expected:** xUnit1041 on `x`
- **Actual:** `AD0001: Analyzer 'Xunit.Analyzers.EnsureFixturesHaveASource' threw an exception of type 'System.IndexOutOfRangeException'`

## Changes

- Skip `AssemblyFixture` attributes that have no constructor arguments. This uses the same `IsDefaultOrEmpty` check the analyzer already uses for `CollectionDefinition`.
- Add the regression test `V3_AssemblyFixtureWithoutArgument_DoesNotCrash`, which uses the repro above with `CompilerDiagnostics.None`.