### PR TITLE
Fix xUnit1044/xUnit1045 not analyzing MemberData with MemberType

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/X1044_TheoryDataTypeArgumentsShouldBeSerializableTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/X1044_TheoryDataTypeArgumentsShouldBeSerializableTests.cs
@@ -554,6 +554,43 @@ public class X1044_TheoryDataTypeArgumentsShouldBeSerializableTests
 	}
 
 	[Fact]
+	public async ValueTask V2_and_V3_NonAOT_MemberType()
+	{
+		var source = /* lang=c#-test */ """
+			using Xunit;
+
+			public sealed class NonSerializable { }
+
+			public class DataSource {
+				public static readonly TheoryData<NonSerializable> Field = new TheoryData<NonSerializable>() { };
+				public static TheoryData<NonSerializable> Method(int a, string b) => new TheoryData<NonSerializable>() { };
+				public static TheoryData<NonSerializable> Property => new TheoryData<NonSerializable>() { };
+				public static TheoryData<string> SerializableProperty => new TheoryData<string>() { };
+			}
+
+			public class TestClass {
+				[Theory]
+				[MemberData(nameof(DataSource.Field), MemberType = typeof(DataSource), DisableDiscoveryEnumeration = true)]
+				[MemberData(nameof(DataSource.Method), 1, "2", MemberType = typeof(DataSource), DisableDiscoveryEnumeration = true)]
+				[MemberData(nameof(DataSource.Property), MemberType = typeof(DataSource), DisableDiscoveryEnumeration = true)]
+				public void DoesNotTrigger(NonSerializable parameter) { }
+
+				[Theory]
+				[MemberData(nameof(DataSource.SerializableProperty), MemberType = typeof(DataSource))]
+				public void DoesNotTriggerWithSerializableType(string parameter) { }
+
+				[Theory]
+				[{|xUnit1044:MemberData(nameof(DataSource.Field), MemberType = typeof(DataSource))|}]
+				[{|xUnit1044:MemberData(nameof(DataSource.Method), 1, "2", MemberType = typeof(DataSource))|}]
+				[{|xUnit1044:MemberData(nameof(DataSource.Property), MemberType = typeof(DataSource))|}]
+				public void Triggers(NonSerializable parameter) { }
+			}
+			""";
+
+		await Verify.VerifyAnalyzerNonAot(source);
+	}
+
+	[Fact]
 	public async ValueTask V2_and_V3_NonAOT_PreTupleSupport()
 	{
 		var source = /* lang=c#-test */ """

--- a/src/xunit.analyzers.tests/Analyzers/X1000/X1045_TheoryDataTypeArgumentsShouldBeSerializableTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/X1045_TheoryDataTypeArgumentsShouldBeSerializableTests.cs
@@ -111,6 +111,38 @@ public class X1045_TheoryDataTypeArgumentsShouldBeSerializableTests
 	}
 
 	[Fact]
+	public async ValueTask V2_and_V3_NonAOT_MemberType()
+	{
+		var source = /* lang=c#-test */ """
+			using Xunit;
+
+			public class PossiblySerializableUnsealedClass { }
+
+			public class DataSource {
+				public static readonly TheoryData<PossiblySerializableUnsealedClass> Field = new TheoryData<PossiblySerializableUnsealedClass>() { };
+				public static TheoryData<PossiblySerializableUnsealedClass> Method(int a, string b) => new TheoryData<PossiblySerializableUnsealedClass>() { };
+				public static TheoryData<PossiblySerializableUnsealedClass> Property => new TheoryData<PossiblySerializableUnsealedClass>() { };
+			}
+
+			public class TestClass {
+				[Theory]
+				[MemberData(nameof(DataSource.Field), MemberType = typeof(DataSource), DisableDiscoveryEnumeration = true)]
+				[MemberData(nameof(DataSource.Method), 1, "2", MemberType = typeof(DataSource), DisableDiscoveryEnumeration = true)]
+				[MemberData(nameof(DataSource.Property), MemberType = typeof(DataSource), DisableDiscoveryEnumeration = true)]
+				public void DoesNotTrigger(PossiblySerializableUnsealedClass parameter) { }
+
+				[Theory]
+				[{|xUnit1045:MemberData(nameof(DataSource.Field), MemberType = typeof(DataSource))|}]
+				[{|xUnit1045:MemberData(nameof(DataSource.Method), 1, "2", MemberType = typeof(DataSource))|}]
+				[{|xUnit1045:MemberData(nameof(DataSource.Property), MemberType = typeof(DataSource))|}]
+				public void Triggers(PossiblySerializableUnsealedClass parameter) { }
+			}
+			""";
+
+		await Verify.VerifyAnalyzerNonAot(source);
+	}
+
+	[Fact]
 	public async ValueTask V2_and_V3_NonAOT_PreTupleSupport()
 	{
 		var source = /* lang=c#-test */ """

--- a/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
+++ b/src/xunit.analyzers/X1000/TheoryDataTypeArgumentsShouldBeSerializable.cs
@@ -320,7 +320,7 @@ public class TheoryDataTypeArgumentsShouldBeSerializable : XunitDiagnosticAnalyz
 			memberDataAttribute
 				.NamedArguments
 				.Where(namedArgument => namedArgument.Key == MemberType)
-				.Select(namedArgument => namedArgument.Value.Type)
+				.Select(namedArgument => namedArgument.Value.Value as ITypeSymbol)
 				.WhereNotNull()
 				.FirstOrDefault();
 


### PR DESCRIPTION
## Problem

xUnit1044 and xUnit1045 never analyzed a `MemberData` attribute that points at another class through `MemberType`. This affected both v2 and v3.

`GetMemberContainingType` read `namedArgument.Value.Type`, which is the type of the `typeof(...)` constant (`System.Type`), not the type it names. So the analyzer looked up the member on `System.Type`, didn't find it, and reported nothing.

```csharp
public sealed class NonSerializable { }

public class DataSource {
    public static TheoryData<NonSerializable> Data => new TheoryData<NonSerializable>();
}

public class TestClass {
    [Theory]
    [MemberData(nameof(DataSource.Data), MemberType = typeof(DataSource))] // expected xUnit1044, got nothing
    public void Test(NonSerializable p) { }
}
```

## Fix

The analyzer now uses the constant's value instead: `namedArgument.Value.Value as ITypeSymbol`.
