### PR TITLE
Fix xUnit1007 analyzer crash on [ClassData()] with no arguments

### DIFF
--- a/src/xunit.analyzers.tests/Analyzers/X1000/X1007_ClassDataAttributeMustPointAtValidClassTests.cs
+++ b/src/xunit.analyzers.tests/Analyzers/X1000/X1007_ClassDataAttributeMustPointAtValidClassTests.cs
@@ -50,6 +50,22 @@ public class X1007_ClassDataAttributeMustPointAtValidClassTests
 	}
 
 	[Fact]
+	public async ValueTask EmptyArgumentList_DoesNotCrash()
+	{
+		var source = /* lang=c#-test */ """
+			using Xunit;
+
+			public class TestClass {
+				[Theory]
+				[{|CS7036:ClassData()|}]
+				public void TestMethod(int n) { }
+			}
+			""";
+
+		await Verify.VerifyAnalyzer(source);
+	}
+
+	[Fact]
 	public async ValueTask V2_and_V3()
 	{
 		var source = /* lang=c#-test */ """

--- a/src/xunit.analyzers/X1000/ClassDataAttributeMustPointAtValidClass.cs
+++ b/src/xunit.analyzers/X1000/ClassDataAttributeMustPointAtValidClass.cs
@@ -62,7 +62,7 @@ public class ClassDataAttributeMustPointAtValidClass : XunitDiagnosticAnalyzer
 				// [ClassData(typeof(...))]
 				if (SymbolEqualityComparer.Default.Equals(attributeType, xunitContext.Core.ClassDataAttributeType))
 				{
-					if (attributeSyntax.ArgumentList is null)
+					if (attributeSyntax.ArgumentList is null || attributeSyntax.ArgumentList.Arguments.Count == 0)
 						continue;
 					if (attributeSyntax.ArgumentList.Arguments[0].Expression is not TypeOfExpressionSyntax typeOfExpression)
 						continue;


### PR DESCRIPTION
## What

`ClassDataAttributeMustPointAtValidClass` (xUnit1007, 1037–1040, 1050) now skips `[ClassData]` attributes whose argument list is empty.

## Why

The analyzer checked `ArgumentList` for null, then read `ArgumentList.Arguments[0]` without checking the count. For `[ClassData()]` this threw an `ArgumentOutOfRangeException`, reported as AD0001 on top of the compiler error:

```csharp
public class TestClass {
    [Theory]
    [ClassData()]
    public void TestMethod(int n) { }
}
```

The code already fails to compile (CS7036), but the analyzer crash is noisy in the IDE while the attribute is still being typed.
