### PR TITLE
Forward CancellationToken to Roslyn APIs in rules

### DIFF
--- a/src/xunit.analyzers.fixes/X1000/InlineDataMustMatchTheoryParameters_TooFewValuesFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/InlineDataMustMatchTheoryParameters_TooFewValuesFixer.cs
@@ -73,7 +73,7 @@ public class InlineDataMustMatchTheoryParameters_TooFewValuesFixer : XunitCodeFi
 		var originalInitializer = arrayInitializer;
 		var i = originalInitializer?.Expressions.Count ?? attribute.ArgumentList?.Arguments.Count ?? 0;
 		for (; i < method.ParameterList.Parameters.Count; i++)
-			if (CreateDefaultValueSyntax(editor, method.ParameterList.Parameters[i].Type) is ExpressionSyntax defaultExpression)
+			if (CreateDefaultValueSyntax(editor, method.ParameterList.Parameters[i].Type, cancellationToken) is ExpressionSyntax defaultExpression)
 			{
 				if (arrayInitializer is not null)
 					arrayInitializer = arrayInitializer.AddExpressions(defaultExpression);
@@ -89,12 +89,13 @@ public class InlineDataMustMatchTheoryParameters_TooFewValuesFixer : XunitCodeFi
 
 	static SyntaxNode CreateDefaultValueSyntax(
 		DocumentEditor editor,
-		TypeSyntax? type)
+		TypeSyntax? type,
+		CancellationToken cancellationToken)
 	{
 		if (type is null)
 			return editor.Generator.NullLiteralExpression();
 
-		var t = editor.SemanticModel.GetTypeInfo(type).Type;
+		var t = editor.SemanticModel.GetTypeInfo(type, cancellationToken).Type;
 		if (t is null)
 			return editor.Generator.NullLiteralExpression();
 

--- a/src/xunit.analyzers.fixes/X1000/MemberDataShouldReferenceValidMember_ExtraValueFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/MemberDataShouldReferenceValidMember_ExtraValueFixer.cs
@@ -89,7 +89,7 @@ public class MemberDataShouldReferenceValidMember_ExtraValueFixer : XunitCodeFix
 		var methodSyntaxes = methodSymbol.DeclaringSyntaxReferences;
 		if (methodSyntaxes.Length != 1)
 			return;
-		if (await methodSyntaxes[0].GetSyntaxAsync().ConfigureAwait(false) is not MethodDeclarationSyntax method)
+		if (await methodSyntaxes[0].GetSyntaxAsync(context.CancellationToken).ConfigureAwait(false) is not MethodDeclarationSyntax method)
 			return;
 
 		var parameterIndexText = diagnostic.Properties[Constants.Properties.ParameterIndex];

--- a/src/xunit.analyzers.fixes/X1000/MemberDataShouldReferenceValidMember_NullShouldNotBeUsedForIncompatibleParameterFixer.cs
+++ b/src/xunit.analyzers.fixes/X1000/MemberDataShouldReferenceValidMember_NullShouldNotBeUsedForIncompatibleParameterFixer.cs
@@ -69,7 +69,7 @@ public class MemberDataShouldReferenceValidMember_NullShouldNotBeUsedForIncompat
 		var methodSyntaxes = methodSymbol.DeclaringSyntaxReferences;
 		if (methodSyntaxes.Length != 1)
 			return;
-		if (await methodSyntaxes[0].GetSyntaxAsync().ConfigureAwait(false) is not MethodDeclarationSyntax method)
+		if (await methodSyntaxes[0].GetSyntaxAsync(context.CancellationToken).ConfigureAwait(false) is not MethodDeclarationSyntax method)
 			return;
 
 		context.RegisterCodeFix(

--- a/src/xunit.analyzers.fixes/X2000/UseGenericOverloadFix.cs
+++ b/src/xunit.analyzers.fixes/X2000/UseGenericOverloadFix.cs
@@ -43,7 +43,7 @@ public class UseGenericOverloadFix : XunitCodeFixProvider
 			return;
 
 		var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
-		var typeInfo = semanticModel.GetTypeInfo(typeOfExpression.Type);
+		var typeInfo = semanticModel.GetTypeInfo(typeOfExpression.Type, context.CancellationToken);
 		if (typeInfo.Type is null)
 			return;
 

--- a/src/xunit.analyzers/Suppressors/ConsiderCallingConfigureAwaitSuppressor.cs
+++ b/src/xunit.analyzers/Suppressors/ConsiderCallingConfigureAwaitSuppressor.cs
@@ -41,7 +41,7 @@ public sealed class ConsiderCallingConfigureAwaitSuppressor : XunitDiagnosticSup
 		}
 
 		var semanticModel = context.GetSemanticModel(diagnostic.Location.SourceTree);
-		var methodSymbol = semanticModel.GetDeclaredSymbol(current);
+		var methodSymbol = semanticModel.GetDeclaredSymbol(current, context.CancellationToken);
 		if (methodSymbol is null)
 			return false;
 

--- a/src/xunit.analyzers/Suppressors/MakeTypesInternalSuppressor.cs
+++ b/src/xunit.analyzers/Suppressors/MakeTypesInternalSuppressor.cs
@@ -25,7 +25,7 @@ public sealed class MakeTypesInternalSuppressor : XunitDiagnosticSuppressor
 			return false;
 
 		var semanticModel = context.GetSemanticModel(diagnostic.Location.SourceTree);
-		var classSymbol = semanticModel.GetDeclaredSymbol(classDeclaration) as ITypeSymbol;
+		var classSymbol = semanticModel.GetDeclaredSymbol(classDeclaration, context.CancellationToken) as ITypeSymbol;
 		return classSymbol.IsTestClass(xunitContext, strict: false);
 	}
 }

--- a/src/xunit.analyzers/Suppressors/NonNullableFieldInitializationSuppressor.cs
+++ b/src/xunit.analyzers/Suppressors/NonNullableFieldInitializationSuppressor.cs
@@ -65,8 +65,8 @@ public sealed class NonNullableFieldInitializationSuppressor : XunitDiagnosticSu
 		// CS8618 can target field variable declarators or property declarations directly
 		ISymbol? memberSymbol = node switch
 		{
-			VariableDeclaratorSyntax variableDeclarator => semanticModel.GetDeclaredSymbol(variableDeclarator),
-			PropertyDeclarationSyntax propertyDeclaration => semanticModel.GetDeclaredSymbol(propertyDeclaration),
+			VariableDeclaratorSyntax variableDeclarator => semanticModel.GetDeclaredSymbol(variableDeclarator, context.CancellationToken),
+			PropertyDeclarationSyntax propertyDeclaration => semanticModel.GetDeclaredSymbol(propertyDeclaration, context.CancellationToken),
 			_ => null,
 		};
 
@@ -124,7 +124,7 @@ public sealed class NonNullableFieldInitializationSuppressor : XunitDiagnosticSu
 
 			foreach (var assignment in methodDecl.DescendantNodes().OfType<AssignmentExpressionSyntax>())
 			{
-				var assignedSymbol = methodSemanticModel.GetSymbolInfo(assignment.Left).Symbol;
+				var assignedSymbol = methodSemanticModel.GetSymbolInfo(assignment.Left, context.CancellationToken).Symbol;
 				if (assignedSymbol is not null && SymbolEqualityComparer.Default.Equals(assignedSymbol, targetMember))
 					return true;
 			}

--- a/src/xunit.analyzers/Suppressors/UseAsyncSuffixForAsyncMethodsSuppressor.cs
+++ b/src/xunit.analyzers/Suppressors/UseAsyncSuffixForAsyncMethodsSuppressor.cs
@@ -24,11 +24,11 @@ public class UseAsyncSuffixForAsyncMethodsSuppressor : XunitDiagnosticSuppressor
 		if (diagnostic?.Location.SourceTree is null)
 			return false;
 
-		if (diagnostic.Location.SourceTree.GetRoot().FindNode(diagnostic.Location.SourceSpan) is not MethodDeclarationSyntax methodDeclaration)
+		if (diagnostic.Location.SourceTree.GetRoot(context.CancellationToken).FindNode(diagnostic.Location.SourceSpan) is not MethodDeclarationSyntax methodDeclaration)
 			return false;
 
 		var semanticModel = context.GetSemanticModel(diagnostic.Location.SourceTree);
-		var methodSymbol = semanticModel.GetDeclaredSymbol(methodDeclaration) as IMethodSymbol;
+		var methodSymbol = semanticModel.GetDeclaredSymbol(methodDeclaration, context.CancellationToken) as IMethodSymbol;
 		return methodSymbol.IsTestMethod(xunitContext, attributeUsageType, strict: false);
 	}
 }

--- a/src/xunit.analyzers/Utility/CodeAnalysisExtensions.cs
+++ b/src/xunit.analyzers/Utility/CodeAnalysisExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Operations;
@@ -173,7 +174,8 @@ static class CodeAnalysisExtensions
 
 	public static (bool isInTestMethod, IOperation? lambdaOwner) IsInTestMethod(
 		this IOperation operation,
-		XunitContext xunitContext)
+		XunitContext xunitContext,
+		CancellationToken cancellationToken)
 	{
 		Guard.ArgumentNotNull(operation);
 		Guard.ArgumentNotNull(xunitContext);
@@ -219,7 +221,7 @@ static class CodeAnalysisExtensions
 
 			var insideTestMethod = methodSyntax.AttributeLists.SelectMany(list => list.Attributes).Any(attr =>
 			{
-				var typeInfo = semanticModel.GetTypeInfo(attr);
+				var typeInfo = semanticModel.GetTypeInfo(attr, cancellationToken);
 				if (typeInfo.Type is null)
 					return false;
 
@@ -237,8 +239,9 @@ static class CodeAnalysisExtensions
 
 	public static bool IsPointer(
 		this ExpressionSyntax expression,
-		SemanticModel? semanticModel) =>
-			semanticModel?.GetTypeInfo(expression).Type?.TypeKind == TypeKind.Pointer;
+		SemanticModel? semanticModel,
+		CancellationToken cancellationToken) =>
+			semanticModel?.GetTypeInfo(expression, cancellationToken).Type?.TypeKind == TypeKind.Pointer;
 
 	public static bool IsTestClass(
 		this ITypeSymbol? type,

--- a/src/xunit.analyzers/Utility/SyntaxExtensions.cs
+++ b/src/xunit.analyzers/Utility/SyntaxExtensions.cs
@@ -11,6 +11,7 @@ public static class SyntaxExtensions
 		this SyntaxList<AttributeListSyntax> attributeLists,
 		SemanticModel semanticModel,
 		INamedTypeSymbol attributeType,
+		CancellationToken cancellationToken,
 		bool exactMatch = false)
 	{
 		Guard.ArgumentNotNull(semanticModel);
@@ -20,7 +21,7 @@ public static class SyntaxExtensions
 		{
 			foreach (var attribute in attributeList.Attributes)
 			{
-				var type = semanticModel.GetTypeInfo(attribute).Type;
+				var type = semanticModel.GetTypeInfo(attribute, cancellationToken).Type;
 				if (attributeType.IsAssignableFrom(type, exactMatch))
 					return true;
 			}

--- a/src/xunit.analyzers/X1000/ClassDataAttributeMustPointAtValidClass.cs
+++ b/src/xunit.analyzers/X1000/ClassDataAttributeMustPointAtValidClass.cs
@@ -53,7 +53,7 @@ public class ClassDataAttributeMustPointAtValidClass : XunitDiagnosticAnalyzer
 			{
 				context.CancellationToken.ThrowIfCancellationRequested();
 
-				var attributeType = semanticModel.GetTypeInfo(attributeSyntax).Type as INamedTypeSymbol;
+				var attributeType = semanticModel.GetTypeInfo(attributeSyntax, context.CancellationToken).Type as INamedTypeSymbol;
 				if (attributeType is null)
 					continue;
 
@@ -67,7 +67,7 @@ public class ClassDataAttributeMustPointAtValidClass : XunitDiagnosticAnalyzer
 					if (attributeSyntax.ArgumentList.Arguments[0].Expression is not TypeOfExpressionSyntax typeOfExpression)
 						continue;
 
-					classType = semanticModel.GetTypeInfo(typeOfExpression.Type).Type as INamedTypeSymbol;
+					classType = semanticModel.GetTypeInfo(typeOfExpression.Type, context.CancellationToken).Type as INamedTypeSymbol;
 				}
 				// [ClassData<...>]
 				else if (attributeType.IsGenericType)

--- a/src/xunit.analyzers/X1000/ConditionalSkipPropertyValidation.cs
+++ b/src/xunit.analyzers/X1000/ConditionalSkipPropertyValidation.cs
@@ -96,7 +96,7 @@ public class ConditionalSkipPropertyValidation() :
 				if (expression is not TypeOfExpressionSyntax typeOf)
 					return null;
 
-				return context.SemanticModel.GetTypeInfo(typeOf.Type).Type as INamedTypeSymbol;
+				return context.SemanticModel.GetTypeInfo(typeOf.Type, context.CancellationToken).Type as INamedTypeSymbol;
 			}
 
 			void verifySkipProperty(

--- a/src/xunit.analyzers/X1000/DoNotUseBlockingTaskOperations.cs
+++ b/src/xunit.analyzers/X1000/DoNotUseBlockingTaskOperations.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Sources;
 using Microsoft.CodeAnalysis;
@@ -71,10 +72,10 @@ public class DoNotUseBlockingTaskOperations : XunitDiagnosticAnalyzer
 				return;
 
 			var foundSymbol =
-				FindSymbol(invocation.TargetMethod, invocation, taskType, blockingTaskMethods, xunitContext, out var foundSymbolName) ||
-				FindSymbol(invocation.TargetMethod, invocation, iCriticalNotifyCompletionType, blockingAwaiterMethods, xunitContext, out foundSymbolName) ||
-				FindSymbol(invocation.TargetMethod, invocation, iValueTaskSourceType, blockingAwaiterMethods, xunitContext, out foundSymbolName) ||
-				FindSymbol(invocation.TargetMethod, invocation, iValueTaskSourceOfTType, blockingAwaiterMethods, xunitContext, out foundSymbolName);
+				FindSymbol(invocation.TargetMethod, invocation, taskType, blockingTaskMethods, xunitContext, context.CancellationToken, out var foundSymbolName) ||
+				FindSymbol(invocation.TargetMethod, invocation, iCriticalNotifyCompletionType, blockingAwaiterMethods, xunitContext, context.CancellationToken, out foundSymbolName) ||
+				FindSymbol(invocation.TargetMethod, invocation, iValueTaskSourceType, blockingAwaiterMethods, xunitContext, context.CancellationToken, out foundSymbolName) ||
+				FindSymbol(invocation.TargetMethod, invocation, iValueTaskSourceOfTType, blockingAwaiterMethods, xunitContext, context.CancellationToken, out foundSymbolName);
 
 			if (!foundSymbol)
 				return;
@@ -123,7 +124,7 @@ public class DoNotUseBlockingTaskOperations : XunitDiagnosticAnalyzer
 			}
 
 			if (symbolsForSearch is not null)
-				if (TaskIsKnownToBeCompleted(invocation, symbolsForSearch, taskType, xunitContext))
+				if (TaskIsKnownToBeCompleted(invocation, symbolsForSearch, taskType, xunitContext, context.CancellationToken))
 					return;
 
 			// Should have two child nodes: "(some other code).(target method)" and the arguments
@@ -149,15 +150,15 @@ public class DoNotUseBlockingTaskOperations : XunitDiagnosticAnalyzer
 				return;
 
 			var foundSymbol =
-				FindSymbol(reference.Property, reference, taskOfTType, blockingTaskProperties, xunitContext, out var foundSymbolName) ||
-				FindSymbol(reference.Property, reference, valueTaskOfTType, blockingTaskProperties, xunitContext, out foundSymbolName);
+				FindSymbol(reference.Property, reference, taskOfTType, blockingTaskProperties, xunitContext, context.CancellationToken, out var foundSymbolName) ||
+				FindSymbol(reference.Property, reference, valueTaskOfTType, blockingTaskProperties, xunitContext, context.CancellationToken, out foundSymbolName);
 
 			if (!foundSymbol)
 				return;
 
 			if (foundSymbolName == nameof(Task<int>.Result) &&
 					reference.Instance is ILocalReferenceOperation localReferenceOperation &&
-					TaskIsKnownToBeCompleted(reference, [localReferenceOperation.Local], taskType, xunitContext))
+					TaskIsKnownToBeCompleted(reference, [localReferenceOperation.Local], taskType, xunitContext, context.CancellationToken))
 				return;
 
 			// Should have two child nodes: "(some other code)" and "(property name)"
@@ -176,6 +177,7 @@ public class DoNotUseBlockingTaskOperations : XunitDiagnosticAnalyzer
 		INamedTypeSymbol? targetType,
 		string[] targetNames,
 		XunitContext xunitContext,
+		CancellationToken cancellationToken,
 		[NotNullWhen(true)]
 		out string? foundSymbolName)
 	{
@@ -198,7 +200,7 @@ public class DoNotUseBlockingTaskOperations : XunitDiagnosticAnalyzer
 			return false;
 
 		// Only trigger when you're inside a test method
-		var (foundSymbol, lambdaOwner) = operation.IsInTestMethod(xunitContext);
+		var (foundSymbol, lambdaOwner) = operation.IsInTestMethod(xunitContext, cancellationToken);
 		if (!foundSymbol || lambdaOwner is not null)
 			return false;
 
@@ -210,7 +212,8 @@ public class DoNotUseBlockingTaskOperations : XunitDiagnosticAnalyzer
 		IOperation? operation,
 		IEnumerable<ILocalSymbol> symbols,
 		INamedTypeSymbol taskType,
-		XunitContext xunitContext)
+		XunitContext xunitContext,
+		CancellationToken cancellationToken)
 	{
 		var ourOperations = new List<IOperation>();
 		var unfoundSymbols = new HashSet<ILocalSymbol>(symbols, SymbolEqualityComparer.Default);
@@ -226,11 +229,11 @@ public class DoNotUseBlockingTaskOperations : XunitDiagnosticAnalyzer
 
 				// Could be marked as safe because of "Task.WhenAll(..., symbol, ...)"
 				if (childOperation is IInvocationOperation childInvocationOperation)
-					ValidateTasksInWhenAll(childInvocationOperation, unfoundSymbols, taskType, xunitContext);
+					ValidateTasksInWhenAll(childInvocationOperation, unfoundSymbols, taskType, xunitContext, cancellationToken);
 
 				// Could be marked as safe because of "var symbol = await WhenAny(...)"
 				if (childOperation is IVariableDeclaratorOperation variableDeclaratorOperation)
-					ValidateTaskFromWhenAny(variableDeclaratorOperation, unfoundSymbols, taskType, xunitContext);
+					ValidateTaskFromWhenAny(variableDeclaratorOperation, unfoundSymbols, taskType, xunitContext, cancellationToken);
 
 				// If we've run out of symbols to validate, we're done
 				if (unfoundSymbols.Count == 0)
@@ -259,7 +262,8 @@ public class DoNotUseBlockingTaskOperations : XunitDiagnosticAnalyzer
 		IVariableDeclaratorOperation operation,
 		HashSet<ILocalSymbol> unfoundSymbols,
 		INamedTypeSymbol taskType,
-		XunitContext xunitContext)
+		XunitContext xunitContext,
+		CancellationToken cancellationToken)
 	{
 		if (!unfoundSymbols.Contains(operation.Symbol))
 			return;
@@ -270,7 +274,7 @@ public class DoNotUseBlockingTaskOperations : XunitDiagnosticAnalyzer
 		if (variableInitializerOperation.Value.ChildOperations.FirstOrDefault() is not IInvocationOperation variableInitializerInvocationOperation)
 			return;
 
-		if (!FindSymbol(variableInitializerInvocationOperation.TargetMethod, variableInitializerInvocationOperation, taskType, whenAny, xunitContext, out var _))
+		if (!FindSymbol(variableInitializerInvocationOperation.TargetMethod, variableInitializerInvocationOperation, taskType, whenAny, xunitContext, cancellationToken, out var _))
 			return;
 
 		unfoundSymbols.Remove(operation.Symbol);
@@ -280,9 +284,10 @@ public class DoNotUseBlockingTaskOperations : XunitDiagnosticAnalyzer
 		IInvocationOperation operation,
 		HashSet<ILocalSymbol> unfoundSymbols,
 		INamedTypeSymbol taskType,
-		XunitContext xunitContext)
+		XunitContext xunitContext,
+		CancellationToken cancellationToken)
 	{
-		if (!FindSymbol(operation.TargetMethod, operation, taskType, whenAll, xunitContext, out var _))
+		if (!FindSymbol(operation.TargetMethod, operation, taskType, whenAll, xunitContext, cancellationToken, out var _))
 			return;
 
 		var argument = operation.Arguments.FirstOrDefault();

--- a/src/xunit.analyzers/X1000/DoNotUseConfigureAwait.cs
+++ b/src/xunit.analyzers/X1000/DoNotUseConfigureAwait.cs
@@ -60,7 +60,7 @@ public class DoNotUseConfigureAwait : XunitDiagnosticAnalyzer
 			if (!match)
 				return;
 
-			var (foundSymbol, lambdaOwner) = invocation.IsInTestMethod(xunitContext);
+			var (foundSymbol, lambdaOwner) = invocation.IsInTestMethod(xunitContext, context.CancellationToken);
 			if (!foundSymbol || lambdaOwner is not null)
 				return;
 

--- a/src/xunit.analyzers/X1000/LocalFunctionsCannotBeTestFunctions.cs
+++ b/src/xunit.analyzers/X1000/LocalFunctionsCannotBeTestFunctions.cs
@@ -36,7 +36,7 @@ public class LocalFunctionsCannotBeTestFunctions : XunitDiagnosticAnalyzer
 			foreach (var attributeList in syntax.AttributeLists)
 				foreach (var attribute in attributeList.Attributes)
 				{
-					var symbol = context.SemanticModel.GetSymbolInfo(attribute).Symbol;
+					var symbol = context.SemanticModel.GetSymbolInfo(attribute, context.CancellationToken).Symbol;
 					if (symbol is null)
 						continue;
 

--- a/src/xunit.analyzers/X1000/MemberDataShouldReferenceValidMember.cs
+++ b/src/xunit.analyzers/X1000/MemberDataShouldReferenceValidMember.cs
@@ -299,7 +299,7 @@ public class MemberDataShouldReferenceValidMember() :
 	}
 
 	static IList<ExpressionSyntax> GetParameterExpressionsFromArrayArgument(
-		List<AttributeArgumentSyntax> arguments, SemanticModel semanticModel)
+		List<AttributeArgumentSyntax> arguments, SemanticModel semanticModel, CancellationToken cancellationToken)
 	{
 		if (arguments.Count > 1)
 			return [.. arguments.Select(a => a.Expression)];
@@ -321,7 +321,7 @@ public class MemberDataShouldReferenceValidMember() :
 			return [argumentExpression];
 
 		// In the special case where the argument is an object[], treat like params
-		var type = semanticModel.GetTypeInfo(argumentExpression).Type;
+		var type = semanticModel.GetTypeInfo(argumentExpression, cancellationToken).Type;
 		if (argumentExpression is CollectionExpressionSyntax || (type is IArrayTypeSymbol arrayType && arrayType.ElementType.SpecialType == SpecialType.System_Object))
 			return [.. expressions];
 
@@ -375,7 +375,7 @@ public class MemberDataShouldReferenceValidMember() :
 
 		var semantics = context.SemanticModel;
 		var declarationReference = memberSymbol.DeclaringSyntaxReferences.First();
-		var declarationSyntax = declarationReference.GetSyntax();
+		var declarationSyntax = declarationReference.GetSyntax(context.CancellationToken);
 		if (declarationSyntax is PropertyDeclarationSyntax prop
 			&& (prop.Initializer != null
 				|| prop.AccessorList?.Accessors.FirstOrDefault(decl => decl.Kind() == SyntaxKind.GetAccessorDeclaration)?.Body != null
@@ -401,7 +401,7 @@ public class MemberDataShouldReferenceValidMember() :
 					.OfType<AssignmentExpressionSyntax>()
 					.Where(assignment =>
 					{
-						var assignedSymbol = semantics.GetSymbolInfo(assignment.Left).Symbol;
+						var assignedSymbol = semantics.GetSymbolInfo(assignment.Left, context.CancellationToken).Symbol;
 						return SymbolEqualityComparer.Default.Equals(assignedSymbol?.OriginalDefinition, memberSymbol);
 					});
 
@@ -879,7 +879,7 @@ public class MemberDataShouldReferenceValidMember() :
 			return;
 		}
 
-		var argumentSyntaxList = GetParameterExpressionsFromArrayArgument(extraArguments, semanticModel);
+		var argumentSyntaxList = GetParameterExpressionsFromArrayArgument(extraArguments, semanticModel, context.CancellationToken);
 		int valueIdx = 0, paramIdx = 0;
 		for (; valueIdx < argumentSyntaxList.Count && paramIdx < dataMethodParameterSymbols.Length; valueIdx++)
 		{

--- a/src/xunit.analyzers/X1000/TestMethodShouldNotBeSkipped.cs
+++ b/src/xunit.analyzers/X1000/TestMethodShouldNotBeSkipped.cs
@@ -46,7 +46,7 @@ public class TestMethodShouldNotBeSkipped : XunitDiagnosticAnalyzer
 			if (skipArgument is null)
 				return;
 
-			var attributeType = context.SemanticModel.GetTypeInfo(attribute).Type;
+			var attributeType = context.SemanticModel.GetTypeInfo(attribute, context.CancellationToken).Type;
 			if (!factAndTheoryAttributeTypes.Any(f => f.IsAssignableFrom(attributeType)))
 				return;
 

--- a/src/xunit.analyzers/X1000/TestMethodWithTimeoutShouldUseCancellationToken.cs
+++ b/src/xunit.analyzers/X1000/TestMethodWithTimeoutShouldUseCancellationToken.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -52,7 +53,7 @@ public class TestMethodWithTimeoutShouldUseCancellationToken() :
 							&& SymbolEqualityComparer.Default.Equals(propertyReference.Property, cancellationTokenProperty))
 						return;
 
-			var location = GetTimeoutLocation(timeoutAttribute) ?? method.Locations.FirstOrDefault();
+			var location = GetTimeoutLocation(timeoutAttribute, ctx.CancellationToken) ?? method.Locations.FirstOrDefault();
 			if (location is null)
 				return;
 
@@ -80,9 +81,11 @@ public class TestMethodWithTimeoutShouldUseCancellationToken() :
 		return null;
 	}
 
-	static Location? GetTimeoutLocation(AttributeData attribute)
+	static Location? GetTimeoutLocation(
+		AttributeData attribute,
+		CancellationToken cancellationToken)
 	{
-		if (attribute.ApplicationSyntaxReference?.GetSyntax() is not AttributeSyntax attributeSyntax)
+		if (attribute.ApplicationSyntaxReference?.GetSyntax(cancellationToken) is not AttributeSyntax attributeSyntax)
 			return null;
 
 		if (attributeSyntax.ArgumentList is { } argumentList)

--- a/src/xunit.analyzers/X1000/TheoryDataShouldNotUseTheoryDataRow.cs
+++ b/src/xunit.analyzers/X1000/TheoryDataShouldNotUseTheoryDataRow.cs
@@ -29,7 +29,7 @@ public class TheoryDataShouldNotUseTheoryDataRow() :
 		{
 			var genericName = (GenericNameSyntax)context.Node;
 
-			if (context.SemanticModel.GetSymbolInfo(genericName).Symbol is not INamedTypeSymbol typeSymbol)
+			if (context.SemanticModel.GetSymbolInfo(genericName, context.CancellationToken).Symbol is not INamedTypeSymbol typeSymbol)
 				return;
 
 			// Only care about TheoryData<ITheoryDataRow>

--- a/src/xunit.analyzers/X1000/TheoryMethodShouldUseAllParameters.cs
+++ b/src/xunit.analyzers/X1000/TheoryMethodShouldUseAllParameters.cs
@@ -35,7 +35,7 @@ public class TheoryMethodShouldUseAllParameters : XunitDiagnosticAnalyzer
 			if (methodSyntax.ParameterList.Parameters.Count == 0)
 				return;
 
-			var methodSymbol = context.SemanticModel.GetDeclaredSymbol(methodSyntax);
+			var methodSymbol = context.SemanticModel.GetDeclaredSymbol(methodSyntax, context.CancellationToken);
 			if (methodSymbol is null)
 				return;
 

--- a/src/xunit.analyzers/X1000/TypeMustBePublicOrInternal.cs
+++ b/src/xunit.analyzers/X1000/TypeMustBePublicOrInternal.cs
@@ -43,18 +43,18 @@ public class TypeMustBePublicOrInternal() :
 
 				if (skipExceptions.Expression is ArrayCreationExpressionSyntax arraySyntax && arraySyntax.Initializer is not null)
 					foreach (var typeOfExpression in arraySyntax.Initializer.Expressions.OfType<TypeOfExpressionSyntax>())
-						if (context.SemanticModel.GetTypeInfo(typeOfExpression.Type).Type is INamedTypeSymbol exceptionType)
+						if (context.SemanticModel.GetTypeInfo(typeOfExpression.Type, context.CancellationToken).Type is INamedTypeSymbol exceptionType)
 							verifyTypeAccessibility(exceptionType, typeOfExpression.GetLocation(), "Exception");
 
 				if (skipExceptions.Expression is ImplicitArrayCreationExpressionSyntax implicitArraySyntax)
 					foreach (var typeOfExpression in implicitArraySyntax.Initializer.Expressions.OfType<TypeOfExpressionSyntax>())
-						if (context.SemanticModel.GetTypeInfo(typeOfExpression.Type).Type is INamedTypeSymbol exceptionType)
+						if (context.SemanticModel.GetTypeInfo(typeOfExpression.Type, context.CancellationToken).Type is INamedTypeSymbol exceptionType)
 							verifyTypeAccessibility(exceptionType, typeOfExpression.GetLocation(), "Exception");
 
 				if (skipExceptions.Expression is CollectionExpressionSyntax collectionSyntax)
 					foreach (var expressionElement in collectionSyntax.Elements.OfType<ExpressionElementSyntax>())
 						if (expressionElement.Expression is TypeOfExpressionSyntax typeOfExpression)
-							if (context.SemanticModel.GetTypeInfo(typeOfExpression.Type).Type is INamedTypeSymbol exceptionType)
+							if (context.SemanticModel.GetTypeInfo(typeOfExpression.Type, context.CancellationToken).Type is INamedTypeSymbol exceptionType)
 								verifyTypeAccessibility(exceptionType, typeOfExpression.GetLocation(), "Exception");
 
 				return;

--- a/src/xunit.analyzers/X1000/UseCancellationToken.cs
+++ b/src/xunit.analyzers/X1000/UseCancellationToken.cs
@@ -41,7 +41,7 @@ public class UseCancellationToken : XunitDiagnosticAnalyzer
 			if (context.Operation is not IInvocationOperation invocationOperation)
 				return;
 
-			var (foundSymbol, lambdaOwner) = invocationOperation.IsInTestMethod(xunitContext);
+			var (foundSymbol, lambdaOwner) = invocationOperation.IsInTestMethod(xunitContext, context.CancellationToken);
 			if (!foundSymbol || lambdaOwner is ILocalFunctionOperation or IAnonymousFunctionOperation)
 				return;
 

--- a/src/xunit.analyzers/X2000/AssertReturnValueShouldBeUsed.cs
+++ b/src/xunit.analyzers/X2000/AssertReturnValueShouldBeUsed.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -50,7 +51,7 @@ public class AssertReturnValueShouldBeUsed : AssertUsageAnalyzerBase
 
 		foreach (var statement in block.Statements.Skip(block.Statements.IndexOf(assertStatement) + 1))
 		{
-			var rederivation = FindRederivation(statement, method, valueExpression, typeArgument, invocationOperation.SemanticModel);
+			var rederivation = FindRederivation(statement, method, valueExpression, typeArgument, invocationOperation.SemanticModel, context.CancellationToken);
 			if (rederivation is not null)
 			{
 				var properties = ImmutableDictionary.CreateBuilder<string, string?>();
@@ -115,7 +116,8 @@ public class AssertReturnValueShouldBeUsed : AssertUsageAnalyzerBase
 		IMethodSymbol method,
 		ExpressionSyntax valueExpression,
 		ITypeSymbol? typeArgument,
-		SemanticModel? semanticModel)
+		SemanticModel? semanticModel,
+		CancellationToken cancellationToken)
 	{
 		// Lambdas and local functions run at some other time, so they are not re-derivations
 		var candidates =
@@ -127,7 +129,7 @@ public class AssertReturnValueShouldBeUsed : AssertUsageAnalyzerBase
 			.Select(candidate =>
 				method.Name == Constants.Asserts.Single
 					? GetSingleItemRederivation(candidate, valueExpression)
-					: GetTypedRederivation(candidate, valueExpression, typeArgument, semanticModel)
+					: GetTypedRederivation(candidate, valueExpression, typeArgument, semanticModel, cancellationToken)
 			)
 			.FirstOrDefault(match => match is not null);
 	}
@@ -161,7 +163,8 @@ public class AssertReturnValueShouldBeUsed : AssertUsageAnalyzerBase
 		SyntaxNode candidate,
 		ExpressionSyntax valueExpression,
 		ITypeSymbol? typeArgument,
-		SemanticModel? semanticModel)
+		SemanticModel? semanticModel,
+		CancellationToken cancellationToken)
 	{
 		if (typeArgument is null || semanticModel is null)
 			return null;
@@ -179,7 +182,7 @@ public class AssertReturnValueShouldBeUsed : AssertUsageAnalyzerBase
 		if (operand is null || typeSyntax is null || !AreEquivalent(valueExpression, operand))
 			return null;
 
-		return SymbolEqualityComparer.Default.Equals(semanticModel.GetTypeInfo(typeSyntax).Type, typeArgument)
+		return SymbolEqualityComparer.Default.Equals(semanticModel.GetTypeInfo(typeSyntax, cancellationToken).Type, typeArgument)
 			? (ExpressionSyntax)candidate
 			: null;
 	}

--- a/src/xunit.analyzers/X2000/BooleanAssertsShouldNotBeUsedForSimpleEqualityCheck.cs
+++ b/src/xunit.analyzers/X2000/BooleanAssertsShouldNotBeUsedForSimpleEqualityCheck.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -44,8 +45,8 @@ public class BooleanAssertsShouldNotBeUsedForSimpleEqualityCheck : AssertUsageAn
 
 		var semanticModel = context.Operation.SemanticModel;
 		var trueMethod = method.Name == Constants.Asserts.True;
-		var leftKind = LiteralReferenceKind(binaryArgument.Left, semanticModel);
-		var rightKind = LiteralReferenceKind(binaryArgument.Right, semanticModel);
+		var leftKind = LiteralReferenceKind(binaryArgument.Left, semanticModel, context.CancellationToken);
+		var rightKind = LiteralReferenceKind(binaryArgument.Right, semanticModel, context.CancellationToken);
 		var literalKind = leftKind ?? rightKind;
 		if (literalKind is null)
 			return;
@@ -82,7 +83,7 @@ public class BooleanAssertsShouldNotBeUsedForSimpleEqualityCheck : AssertUsageAn
 					return;
 				// Can't rewrite if we're using a pointer and don't support pointers in Null assertions
 				if (!xunitContext.Assert.SupportsAssertNullWithPointers)
-					if (binaryArgument.Left.IsPointer(semanticModel) || binaryArgument.Right.IsPointer(semanticModel))
+					if (binaryArgument.Left.IsPointer(semanticModel, context.CancellationToken) || binaryArgument.Right.IsPointer(semanticModel, context.CancellationToken))
 						return;
 				var nullReplacement = trueMethod == isEqualsOperator ? Constants.Asserts.Null : Constants.Asserts.NotNull;
 				builder[Constants.Properties.Replacement] = nullReplacement;
@@ -105,7 +106,8 @@ public class BooleanAssertsShouldNotBeUsedForSimpleEqualityCheck : AssertUsageAn
 
 	public static SyntaxKind? LiteralReferenceKind(
 		ExpressionSyntax expression,
-		SemanticModel? semanticModel)
+		SemanticModel? semanticModel,
+		CancellationToken cancellationToken)
 	{
 		Guard.ArgumentNotNull(expression);
 
@@ -120,7 +122,7 @@ public class BooleanAssertsShouldNotBeUsedForSimpleEqualityCheck : AssertUsageAn
 		if (left.Kind() != SyntaxKind.IdentifierName)
 			return null;
 
-		var type = semanticModel?.GetTypeInfo(expression).Type;
+		var type = semanticModel?.GetTypeInfo(expression, cancellationToken).Type;
 		if (type is not INamedTypeSymbol namedType)
 			return null;
 

--- a/src/xunit.analyzers/X2000/DoNotUseAssertEmptyWithProblematicTypes.cs
+++ b/src/xunit.analyzers/X2000/DoNotUseAssertEmptyWithProblematicTypes.cs
@@ -38,7 +38,7 @@ public class DoNotUseAssertEmptyWithProblematicTypes : AssertUsageAnalyzerBase
 		if (method.Parameters.Length != 1)
 			return;
 
-		if (semanticModel.GetTypeInfo(arguments[0].Value.Syntax).Type is not INamedTypeSymbol sourceType)
+		if (semanticModel.GetTypeInfo(arguments[0].Value.Syntax, context.CancellationToken).Type is not INamedTypeSymbol sourceType)
 			return;
 
 		var stringValuesType = TypeSymbolFactory.StringValues(context.Compilation);

--- a/src/xunit.analyzers/X2000/SetEqualityAnalyzer.cs
+++ b/src/xunit.analyzers/X2000/SetEqualityAnalyzer.cs
@@ -47,7 +47,7 @@ public class SetEqualityAnalyzer : AssertUsageAnalyzerBase
 		if (arguments.Length < 2)
 			return;
 
-		if (semanticModel.GetTypeInfo(arguments[0].Value.Syntax).Type is not INamedTypeSymbol collection0Type)
+		if (semanticModel.GetTypeInfo(arguments[0].Value.Syntax, context.CancellationToken).Type is not INamedTypeSymbol collection0Type)
 			return;
 		var interface0Type =
 			collection0Type
@@ -56,7 +56,7 @@ public class SetEqualityAnalyzer : AssertUsageAnalyzerBase
 				.Where(i => i.IsGenericType)
 				.FirstOrDefault(i => setInterfaces.Contains(i.ConstructUnboundGenericType()));
 
-		if (semanticModel.GetTypeInfo(arguments[1].Value.Syntax).Type is not INamedTypeSymbol collection1Type)
+		if (semanticModel.GetTypeInfo(arguments[1].Value.Syntax, context.CancellationToken).Type is not INamedTypeSymbol collection1Type)
 			return;
 		var interface1Type =
 			collection1Type

--- a/src/xunit.analyzers/X3000/DoNotTestForConcreteTypeOfJsonSerializableTypes.cs
+++ b/src/xunit.analyzers/X3000/DoNotTestForConcreteTypeOfJsonSerializableTypes.cs
@@ -99,7 +99,7 @@ public class DoNotTestForConcreteTypeOfJsonSerializableTypes : XunitV3Diagnostic
 				return;
 
 			foreach (var identifierNameSyntax in typeArgumentListSyntax.ChildNodes().OfType<IdentifierNameSyntax>())
-				reportIfMessageType(context.ReportDiagnostic, context.SemanticModel, context.SemanticModel.GetTypeInfo(identifierNameSyntax).ConvertedType, context.Node);
+				reportIfMessageType(context.ReportDiagnostic, context.SemanticModel, context.SemanticModel.GetTypeInfo(identifierNameSyntax, context.CancellationToken).ConvertedType, context.Node);
 		}, SyntaxKind.GenericName);
 
 		void reportIfMessageType(


### PR DESCRIPTION
Several analyzers, suppressors, and code fixers called Roslyn APIs such as `GetTypeInfo`, `GetSymbolInfo`, `GetDeclaredSymbol`, `GetSyntax`, `GetSyntaxAsync` and `GetRoot` without passing the available cancellation token. This means analysis couldn't be cancelled promptly, for example while the user is typing in the IDE.

## Changes

- **Direct forwarding (28 call sites):** these calls now pass `context.CancellationToken`.
- **Helpers that had no token (6 call sites):** these methods now take a required `CancellationToken` parameter, and callers forward theirs:
  - `CodeAnalysisExtensions.IsInTestMethod` and `IsPointer`
  - `SyntaxExtensions.ContainsAttributeType` (the `SyntaxList<AttributeListSyntax>` overload)
  - `BooleanAssertsShouldNotBeUsedForSimpleEqualityCheck.LiteralReferenceKind`
  - `DoNotUseBlockingTaskOperations`: `FindSymbol`, `TaskIsKnownToBeCompleted`, `ValidateTasksInWhenAll`, `ValidateTaskFromWhenAny`
  - `AssertReturnValueShouldBeUsed`: `FindRederivation`, `GetTypedRederivation`
  - `MemberDataShouldReferenceValidMember.GetParameterExpressionsFromArrayArgument`
  - `TestMethodWithTimeoutShouldUseCancellationToken.GetTimeoutLocation`
  - `InlineDataMustMatchTheoryParameters_TooFewValuesFixer.CreateDefaultValueSyntax`

## Notes for reviewers

- The token parameters are required rather than optional, so new call sites can't silently drop the token. This changes the signatures of the public utility methods listed above. Nothing outside these projects calls them.
- To find these call sites, I temporarily added [Meziantou.Analyzer](https://github.com/meziantou/Meziantou.Analyzer) with only MA0032 and MA0040 enabled. It isn't part of this PR. With the changes applied, it reports no warnings.
- The net8.0 tests pass for both `xunit.analyzers.tests` and `xunit.analyzers.latest.tests`. I didn't run the net472 tests.